### PR TITLE
Support to read gzip compressed metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+.vscode
 .idea
 cmake-build-debug
 duckdb_unittest_tempdir/

--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -165,7 +165,6 @@ IcebergSnapshot IcebergSnapshot::GetSnapshotByTimestamp(const string &path, File
 
 string IcebergSnapshot::ReadMetaData(const string &path, FileSystem &fs, string metadata_compression_codec) {
 	string metadata_file_path;
-	printf("got metadata_compression_codec=%s\n", metadata_compression_codec.c_str());
 	if (StringUtil::EndsWith(path, ".json")) {
 		metadata_file_path = path;
 		// check if metadata is gz compressed file?

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,5 +1,7 @@
 #include "duckdb.hpp"
 #include "iceberg_utils.hpp"
+#include "zlib.h"
+#include "fstream"
 
 namespace duckdb {
 
@@ -10,6 +12,41 @@ string IcebergUtils::FileToString(const string &path, FileSystem &fs) {
 	string ret_val(file_size, ' ');
 	handle->Read((char *)ret_val.c_str(), file_size);
 	return ret_val;
+}
+
+// Function to decompress a gz file content string
+string IcebergUtils::GzFileToString(const string &path, FileSystem &fs) {
+  // Initialize zlib variables
+  string gzipped_string = FileToString(path, fs);
+  std::stringstream decompressed;
+    int CHUNK_SIZE = 16384;
+    z_stream zs;
+    zs.zalloc = Z_NULL;
+    zs.zfree = Z_NULL;
+    zs.opaque = Z_NULL;
+    zs.avail_in = gzipped_string.size();
+    zs.next_in = (Bytef *)gzipped_string.data();
+    int ret = inflateInit2(&zs, 16 + MAX_WBITS); // MAX_WBITS + 16 to enable gzip decoding
+    if (ret != Z_OK)
+    {
+        throw std::runtime_error("inflateInit failed");
+    }
+    do
+    {
+        char out[CHUNK_SIZE];
+        zs.avail_out = CHUNK_SIZE;
+        zs.next_out = (Bytef *)out;
+        ret = inflate(&zs, Z_NO_FLUSH);
+        if (ret < 0)
+        {
+            inflateEnd(&zs);
+            throw std::runtime_error("inflate failed with error code " + to_string(ret));
+        }
+        decompressed.write(out, CHUNK_SIZE - zs.avail_out);
+    } while (zs.avail_out == 0);
+    inflateEnd(&zs);
+    string ds = decompressed.str();
+    return ds;
 }
 
 string IcebergUtils::GetFullPath(const string &iceberg_path, const string &relative_file_path, FileSystem &fs) {

--- a/src/iceberg_functions/iceberg_snapshots.cpp
+++ b/src/iceberg_functions/iceberg_snapshots.cpp
@@ -12,6 +12,7 @@ namespace duckdb {
 struct IcebergSnaphotsBindData : public TableFunctionData {
 	IcebergSnaphotsBindData() {};
 	string filename;
+	string metadata_compression_codec;
 };
 
 struct IcebergSnapshotGlobalTableFunctionState : public GlobalTableFunctionState {
@@ -22,11 +23,12 @@ public:
 		}
 	}
 	static unique_ptr<GlobalTableFunctionState> Init(ClientContext &context, TableFunctionInitInput &input) {
+		
 		auto bind_data = input.bind_data->Cast<IcebergSnaphotsBindData>();
 		auto global_state = make_uniq<IcebergSnapshotGlobalTableFunctionState>();
-
+		
 		FileSystem &fs = FileSystem::GetFileSystem(context);
-		global_state->metadata_file = IcebergSnapshot::ReadMetaData(bind_data.filename, fs);
+		global_state->metadata_file = IcebergSnapshot::ReadMetaData(bind_data.filename, fs,  bind_data.metadata_compression_codec);
 		global_state->metadata_doc =
 		    yyjson_read(global_state->metadata_file.c_str(), global_state->metadata_file.size(), 0);
 		auto root = yyjson_doc_get_root(global_state->metadata_doc);
@@ -45,8 +47,18 @@ public:
 static unique_ptr<FunctionData> IcebergSnapshotsBind(ClientContext &context, TableFunctionBindInput &input,
                                                      vector<LogicalType> &return_types, vector<string> &names) {
 	auto bind_data = make_uniq<IcebergSnaphotsBindData>();
+	
+	string metadata_compression_codec = "none";
+	
+	for (auto &kv : input.named_parameters) {
+		auto loption = StringUtil::Lower(kv.first);
+		if (loption == "metadata_compression_codec") {
+			metadata_compression_codec = StringValue::Get(kv.second);
+		}
+	}
 
 	bind_data->filename = input.inputs[0].ToString();
+	bind_data->metadata_compression_codec = metadata_compression_codec;
 
 	names.emplace_back("sequence_number");
 	return_types.emplace_back(LogicalType::UBIGINT);
@@ -66,7 +78,7 @@ static unique_ptr<FunctionData> IcebergSnapshotsBind(ClientContext &context, Tab
 // Snapshots function
 static void IcebergSnapshotsFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
 	auto &global_state = data.global_state->Cast<IcebergSnapshotGlobalTableFunctionState>();
-
+	auto &bind_data = data.bind_data->Cast<IcebergSnaphotsBindData>();
 	idx_t i = 0;
 	while (auto next_snapshot = yyjson_arr_iter_next(&global_state.snapshot_it)) {
 		if (i >= STANDARD_VECTOR_SIZE) {
@@ -75,7 +87,7 @@ static void IcebergSnapshotsFunction(ClientContext &context, TableFunctionInput 
 
 		auto parse_info = IcebergSnapshot::GetParseInfo(*global_state.metadata_doc);
 		auto snapshot = IcebergSnapshot::ParseSnapShot(next_snapshot, global_state.iceberg_format_version,
-		                                               parse_info->schema_id, parse_info->schemas);
+		                                               parse_info->schema_id, parse_info->schemas, bind_data.metadata_compression_codec);
 
 		FlatVector::GetData<int64_t>(output.data[0])[i] = snapshot.sequence_number;
 		FlatVector::GetData<int64_t>(output.data[1])[i] = snapshot.snapshot_id;

--- a/src/include/iceberg_metadata.hpp
+++ b/src/include/iceberg_metadata.hpp
@@ -57,15 +57,16 @@ public:
 	idx_t iceberg_format_version;
 	uint64_t schema_id;
 	vector<IcebergColumnDefinition> schema;
+	string metadata_compression_codec = "none";
 
-	static IcebergSnapshot GetLatestSnapshot(const string &path, FileSystem &fs);
-	static IcebergSnapshot GetSnapshotById(const string &path, FileSystem &fs, idx_t snapshot_id);
-	static IcebergSnapshot GetSnapshotByTimestamp(const string &path, FileSystem &fs, timestamp_t timestamp);
+	static IcebergSnapshot GetLatestSnapshot(const string &path, FileSystem &fs, string GetSnapshotByTimestamp);
+	static IcebergSnapshot GetSnapshotById(const string &path, FileSystem &fs, idx_t snapshot_id, string GetSnapshotByTimestamp);
+	static IcebergSnapshot GetSnapshotByTimestamp(const string &path, FileSystem &fs, timestamp_t timestamp, string GetSnapshotByTimestamp);
 
 	static IcebergSnapshot ParseSnapShot(yyjson_val *snapshot, idx_t iceberg_format_version, idx_t schema_id,
-	                                     vector<yyjson_val *> &schemas);
-	static string ReadMetaData(const string &path, FileSystem &fs);
-	static yyjson_val *GetSnapshots(const string &path, FileSystem &fs);
+	                                     vector<yyjson_val *> &schemas, string metadata_compression_codec);
+	static string ReadMetaData(const string &path, FileSystem &fs, string GetSnapshotByTimestamp);
+	static yyjson_val *GetSnapshots(const string &path, FileSystem &fs, string GetSnapshotByTimestamp);
 	static unique_ptr<SnapshotParseInfo> GetParseInfo(yyjson_doc &metadata_json);
 
 protected:
@@ -75,7 +76,7 @@ protected:
 	static yyjson_val *FindSnapshotByIdInternal(yyjson_val *snapshots, idx_t target_id);
 	static yyjson_val *FindSnapshotByIdTimestampInternal(yyjson_val *snapshots, timestamp_t timestamp);
 	static vector<IcebergColumnDefinition> ParseSchema(vector<yyjson_val *> &schemas, idx_t schema_id);
-	static unique_ptr<SnapshotParseInfo> GetParseInfo(const string &path, FileSystem &fs);
+	static unique_ptr<SnapshotParseInfo> GetParseInfo(const string &path, FileSystem &fs, string metadata_compression_codec);
 };
 
 //! Represents the iceberg table at a specific IcebergSnapshot. Corresponds to a single Manifest List.
@@ -83,7 +84,7 @@ struct IcebergTable {
 public:
 	//! Loads all(!) metadata of into IcebergTable object
 	static IcebergTable Load(const string &iceberg_path, IcebergSnapshot &snapshot, FileSystem &fs,
-	                         bool allow_moved_paths = false);
+	                         bool allow_moved_paths = false, string metadata_compression_codec = "none");
 
 	//! Returns all paths to be scanned for the IcebergManifestContentType
 	template <IcebergManifestContentType TYPE>

--- a/src/include/iceberg_utils.hpp
+++ b/src/include/iceberg_utils.hpp
@@ -18,7 +18,8 @@ class IcebergUtils {
 public:
 	//! Downloads a file fully into a string
 	static string FileToString(const string &path, FileSystem &fs);
-
+	//! Downloads a gz file fully into a string
+	static string GzFileToString(const string &path, FileSystem &fs);
 	//! Somewhat hacky function that allows relative paths in iceberg tables to be resolved,
 	//! used for the allow_moved_paths debug option which allows us to test with iceberg tables that
 	//! were moved without their paths updated


### PR DESCRIPTION
The current version of iceberg extension does not support reading iceberg tables that were written with gzip compressed metadata files. Adding one more flag in the commands to consider the metadata files as gz while loading metadata.

```
SELECT * FROM iceberg_scan("s3://my-bucket/icebergwh/someschema/t01", metadata_compression_codec="gzip") limit 10;
``` 
As of now  *metadata_compression_codec* can be none or gzip; default is none.