### PR TITLE
feat: AWS glue catalog support for iceberg_scan()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ set_target_properties(
   PROPERTIES IMPORTED_LOCATION ${AVROCPP_LIBRARY_DEBUG}
              INTERFACE_INCLUDE_DIRECTORIES ${AVROCPP_INCLUDE_DIR})
 
+# For the Glue catalog support.
+find_package(AWSSDK REQUIRED COMPONENTS core;glue)
+
 # Note: for some reason avro-cpp port does properly handle static deps, so we
 # need to manually ensure avro's deps are linked too
 set(SNAPPY_HOME "${AVROCPP_ROOT_FIND_DIR}")
@@ -55,6 +58,9 @@ find_package(Boost REQUIRED COMPONENTS iostreams program_options system
                                        filesystem)
 find_package(Snappy CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
+
+target_include_directories(${EXTENSION_NAME}
+                           PUBLIC $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
 target_link_libraries(
   avro_static_release
   INTERFACE Boost::boost
@@ -76,9 +82,9 @@ target_link_libraries(
 
 # Link dependencies into extension
 target_link_libraries(${EXTENSION_NAME} PUBLIC optimized avro_static_release
-                                               debug avro_static_debug)
+                                               debug avro_static_debug ${AWSSDK_LINK_LIBRARIES})
 target_link_libraries(${TARGET_NAME}_loadable_extension optimized
-                      avro_static_release debug avro_static_debug)
+                      avro_static_release debug avro_static_debug ${AWSSDK_LINK_LIBRARIES})
 
 install(
   TARGETS ${EXTENSION_NAME} ${TARGET_NAME}_loadable_extension

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > **Disclaimer:** This extension is currently in an experimental state. Feel free to try it out, but be aware that things may not work as expected
 
-# DuckDB extension for Apache Iceberg 
+# DuckDB extension for Apache Iceberg
 
 This repository contains a DuckDB extension that adds support for [Apache Iceberg](https://iceberg.apache.org/). In its current state, the extension offers some basics features that allow listing snapshots and reading specific snapshots
 of an iceberg tables.
@@ -9,19 +9,38 @@ of an iceberg tables.
 
 See the [Iceberg page in the DuckDB documentation](https://duckdb.org/docs/extensions/iceberg).
 
+### External Data Catalog Support
+
+#### AWS Glue
+
+You can now access Iceberg Tables stored in a AWS Glue Catalog by passing a JSON formatted string to the `iceberg_scan()`
+function.
+
+This JSON object should be of this format:
+
+```json
+{
+  "catalog_type": "glue",
+  "catalog": "1234567890",          // optional - the catalog to use
+  "region": "us-east-1",            // required - change to the right region
+  "database_name": "test_iceberg",  // required - change to your database
+  "table_name": "table_name"        // required - change for each table.
+}
+```
+
 ## Developer guide
 
 ### Dependencies
 
-This extension has several dependencies. Currently, the main way to install them is through vcpkg. To install vcpkg, 
+This extension has several dependencies. Currently, the main way to install them is through vcpkg. To install vcpkg,
 check out the docs [here](https://vcpkg.io/en/getting-started.html). Note that this extension contains a custom vcpkg port
 that overrides the existing 'avro-cpp' port of vcpkg. The reason for this is that the other versions of avro-cpp have
 some issue that seems to cause issues with the avro files produced by the spark iceberg extension.
 
 ### Test data generation
 
-To generate test data, the script in 'scripts/test_data_generator' is used to have spark generate some test data. This is 
-based on pyspark 3.5, which you can install through pip. 
+To generate test data, the script in 'scripts/test_data_generator' is used to have spark generate some test data. This is
+based on pyspark 3.5, which you can install through pip.
 
 ### Building the extension
 
@@ -53,7 +72,7 @@ running `python3 -m pip install duckdb pyspark[sql]==3.5.0` should do the trick.
 #### Running unit tests
 
 ```shell
-make test 
+make test
 ```
 
 #### Running the local S3 test server

--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -127,7 +127,7 @@ unique_ptr<SnapshotParseInfo> IcebergSnapshot::GetParseInfo(const string &path, 
 	parse_info->doc = doc;
 	parse_info->document = std::move(metadata_json);
 
-	return std::move(parse_info);
+	return parse_info;
 }
 
 IcebergSnapshot IcebergSnapshot::GetLatestSnapshot(const string &path, FileSystem &fs,
@@ -195,7 +195,7 @@ IcebergSnapshot IcebergSnapshot::ParseSnapShot(yyjson_val *snapshot, idx_t icebe
                                                vector<yyjson_val *> &schemas, string metadata_compression_codec,
 											   bool skip_schema_inference) {
 	IcebergSnapshot ret;
-	auto snapshot_tag = yyjson_get_tag(snapshot);
+	auto snapshot_tag = yyjson_get_type(snapshot);
 	if (snapshot_tag != YYJSON_TYPE_OBJ) {
 		throw IOException("Invalid snapshot field found parsing iceberg metadata.json");
 	}

--- a/src/common/schema.cpp
+++ b/src/common/schema.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 static LogicalType ParseType(yyjson_val *type);
 
 static LogicalType ParseStruct(yyjson_val *struct_type) {
-	D_ASSERT(yyjson_get_tag(struct_type) == YYJSON_TYPE_OBJ);
+	D_ASSERT(yyjson_get_type(struct_type) == YYJSON_TYPE_OBJ);
 	D_ASSERT(IcebergUtils::TryGetStrFromObject(struct_type, "type") == "struct");
 
 	child_list_t<LogicalType> children;
@@ -28,7 +28,7 @@ static LogicalType ParseStruct(yyjson_val *struct_type) {
 }
 
 static LogicalType ParseList(yyjson_val *list_type) {
-	D_ASSERT(yyjson_get_tag(list_type) == YYJSON_TYPE_OBJ);
+	D_ASSERT(yyjson_get_type(list_type) == YYJSON_TYPE_OBJ);
 	D_ASSERT(IcebergUtils::TryGetStrFromObject(list_type, "type") == "list");
 
 	// NOTE: 'element-id', 'element-required' are ignored for now
@@ -38,7 +38,7 @@ static LogicalType ParseList(yyjson_val *list_type) {
 }
 
 static LogicalType ParseMap(yyjson_val *map_type) {
-	D_ASSERT(yyjson_get_tag(map_type) == YYJSON_TYPE_OBJ);
+	D_ASSERT(yyjson_get_type(map_type) == YYJSON_TYPE_OBJ);
 	D_ASSERT(IcebergUtils::TryGetStrFromObject(map_type, "type") == "map");
 
 	// NOTE: 'key-id', 'value-id', 'value-required' are ignored for now
@@ -51,7 +51,7 @@ static LogicalType ParseMap(yyjson_val *map_type) {
 }
 
 static LogicalType ParseComplexType(yyjson_val *type) {
-	D_ASSERT(yyjson_get_tag(type) == YYJSON_TYPE_OBJ);
+	D_ASSERT(yyjson_get_type(type) == YYJSON_TYPE_OBJ);
 	auto type_str = IcebergUtils::TryGetStrFromObject(type, "type");
 
 	if (type_str == "struct") {
@@ -73,10 +73,10 @@ static LogicalType ParseType(yyjson_val *type) {
 	if (!val) {
 		throw IOException("Invalid field found while parsing field: type");
 	}
-	if (yyjson_get_tag(val) == YYJSON_TYPE_OBJ) {
+	if (yyjson_get_type(val) == YYJSON_TYPE_OBJ) {
 		return ParseComplexType(val);
 	}
-	if (yyjson_get_tag(val) != YYJSON_TYPE_STR) {
+	if (yyjson_get_type(val) != YYJSON_TYPE_STR) {
 		throw IOException("Invalid field found while parsing field: type");
 	}
 
@@ -154,7 +154,7 @@ static vector<IcebergColumnDefinition> ParseSchemaFromJson(yyjson_val *schema_js
 	if (type_str != "struct") {
 		throw IOException("Schema in JSON Metadata is invalid");
 	}
-	D_ASSERT(yyjson_get_tag(schema_json) == YYJSON_TYPE_OBJ);
+	D_ASSERT(yyjson_get_type(schema_json) == YYJSON_TYPE_OBJ);
 	D_ASSERT(IcebergUtils::TryGetStrFromObject(schema_json, "type") == "struct");
 	yyjson_val *field;
 	size_t max, idx;

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 
 string IcebergUtils::FileToString(const string &path, FileSystem &fs) {
 	auto handle =
-	    fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK, FileSystem::DEFAULT_COMPRESSION);
+	    fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
 	auto file_size = handle->GetFileSize();
 	string ret_val(file_size, ' ');
 	handle->Read((char *)ret_val.c_str(), file_size);
@@ -38,7 +38,7 @@ string IcebergUtils::GetFullPath(const string &iceberg_path, const string &relat
 
 uint64_t IcebergUtils::TryGetNumFromObject(yyjson_val *obj, const string &field) {
 	auto val = yyjson_obj_getn(obj, field.c_str(), field.size());
-	if (!val || yyjson_get_tag(val) != YYJSON_TYPE_NUM) {
+	if (!val || yyjson_get_type(val) != YYJSON_TYPE_NUM) {
 		throw IOException("Invalid field found while parsing field: " + field);
 	}
 	return yyjson_get_uint(val);
@@ -46,7 +46,7 @@ uint64_t IcebergUtils::TryGetNumFromObject(yyjson_val *obj, const string &field)
 
 bool IcebergUtils::TryGetBoolFromObject(yyjson_val *obj, const string &field) {
 	auto val = yyjson_obj_getn(obj, field.c_str(), field.size());
-	if (!val || yyjson_get_tag(val) != YYJSON_TYPE_BOOL) {
+	if (!val || yyjson_get_type(val) != YYJSON_TYPE_BOOL) {
 		throw IOException("Invalid field found while parsing field: " + field);
 	}
 	return yyjson_get_bool(val);
@@ -54,7 +54,7 @@ bool IcebergUtils::TryGetBoolFromObject(yyjson_val *obj, const string &field) {
 
 string IcebergUtils::TryGetStrFromObject(yyjson_val *obj, const string &field) {
 	auto val = yyjson_obj_getn(obj, field.c_str(), field.size());
-	if (!val || yyjson_get_tag(val) != YYJSON_TYPE_STR) {
+	if (!val || yyjson_get_type(val) != YYJSON_TYPE_STR) {
 		throw IOException("Invalid field found while parsing field: " + field);
 	}
 	return yyjson_get_str(val);

--- a/src/iceberg_functions/iceberg_snapshots.cpp
+++ b/src/iceberg_functions/iceberg_snapshots.cpp
@@ -117,7 +117,7 @@ TableFunctionSet IcebergFunctions::GetIcebergSnapshotsFunction() {
 	table_function.named_parameters["metadata_compression_codec"] = LogicalType::VARCHAR;
 	table_function.named_parameters["skip_schema_inference"] = LogicalType::BOOLEAN;
 	function_set.AddFunction(table_function);
-	return std::move(function_set);
+	return function_set;
 }
 
 } // namespace duckdb

--- a/src/include/yyjson.hpp
+++ b/src/include/yyjson.hpp
@@ -1,50 +1,71 @@
 /*==============================================================================
- * Created by Yaoyuan on 2019/3/9.
- * Copyright (C) 2019 Yaoyuan <ibireme@gmail.com>.
- *
- * Released under the MIT License:
- * https://github.com/ibireme/yyjson/blob/master/LICENSE
+ Copyright (c) 2020 YaoYuan <ibireme@gmail.com>
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
  *============================================================================*/
 
-/** @file yyjson.h */
+/** 
+ @file yyjson.h
+ @date 2019-03-09
+ @author YaoYuan
+ */
 
 #ifndef YYJSON_H
 #define YYJSON_H
+
+
 
 /*==============================================================================
  * Header Files
  *============================================================================*/
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
 #include <limits.h>
 #include <string.h>
 #include <float.h>
 
-#include "duckdb/common/fast_mem.hpp"
+
 
 /*==============================================================================
  * Compile-time Options
  *============================================================================*/
 
 /*
- Define as 1 to disable JSON reader if you don't need to parse JSON.
-
+ Define as 1 to disable JSON reader if JSON parsing is not required.
+ 
  This will disable these functions at compile-time:
+    - yyjson_read()
     - yyjson_read_opts()
     - yyjson_read_file()
-    - yyjson_read()
     - yyjson_read_number()
     - yyjson_mut_read_number()
-
+ 
  This will reduce the binary size by about 60%.
  */
 #ifndef YYJSON_DISABLE_READER
 #endif
 
 /*
- Define as 1 to disable JSON writer if you don't need to serialize JSON.
-
+ Define as 1 to disable JSON writer if JSON serialization is not required.
+ 
  This will disable these functions at compile-time:
     - yyjson_write()
     - yyjson_write_file()
@@ -58,16 +79,32 @@
     - yyjson_mut_val_write()
     - yyjson_mut_val_write_file()
     - yyjson_mut_val_write_opts()
-
+ 
  This will reduce the binary size by about 30%.
  */
 #ifndef YYJSON_DISABLE_WRITER
 #endif
 
 /*
+ Define as 1 to disable JSON Pointer, JSON Patch and JSON Merge Patch supports.
+ 
+ This will disable these functions at compile-time:
+    - yyjson_ptr_xxx()
+    - yyjson_mut_ptr_xxx()
+    - yyjson_doc_ptr_xxx()
+    - yyjson_mut_doc_ptr_xxx()
+    - yyjson_patch()
+    - yyjson_mut_patch()
+    - yyjson_merge_patch()
+    - yyjson_mut_merge_patch()
+ */
+#ifndef YYJSON_DISABLE_UTILS
+#endif
+
+/*
  Define as 1 to disable the fast floating-point number conversion in yyjson,
  and use libc's `strtod/snprintf` instead.
-
+ 
  This will reduce the binary size by about 30%, but significantly slow down the
  floating-point read/write speed.
  */
@@ -80,7 +117,7 @@
     - Single line and multiple line comments.
     - Single trailing comma at the end of an object or array.
     - Invalid unicode in string value.
-
+ 
  This will also invalidate these run-time options:
     - YYJSON_READ_ALLOW_INF_AND_NAN
     - YYJSON_READ_ALLOW_COMMENTS
@@ -88,20 +125,37 @@
     - YYJSON_READ_ALLOW_INVALID_UNICODE
     - YYJSON_WRITE_ALLOW_INF_AND_NAN
     - YYJSON_WRITE_ALLOW_INVALID_UNICODE
-
- This will reduce the binary size by about 10%, and slightly improve the JSON
- read/write speed.
+ 
+ This will reduce the binary size by about 10%, and speed up the reading and
+ writing speed by about 2% to 6%.
  */
 #ifndef YYJSON_DISABLE_NON_STANDARD
 #endif
 
 /*
- Define as 1 to disable unaligned memory access if target architecture does not
- support unaligned memory access (such as some embedded processors).
+ Define as 1 to disable UTF-8 validation at compile time.
+ 
+ If all input strings are guaranteed to be valid UTF-8 encoding (for example,
+ some language's String object has already validated the encoding), using this
+ flag can avoid redundant UTF-8 validation in yyjson.
+ 
+ This flag can speed up the reading and writing speed of non-ASCII encoded
+ strings by about 3% to 7%.
+ 
+ Note: If this flag is used while passing in illegal UTF-8 strings, the
+ following errors may occur:
+ - Escaped characters may be ignored when parsing JSON strings.
+ - Ending quotes may be ignored when parsing JSON strings, causing the string
+   to be concatenated to the next value.
+ - When accessing `yyjson_mut_val` for serialization, the string ending may be
+   accessed out of bounds, causing a segmentation fault.
+ */
+#ifndef YYJSON_DISABLE_UTF8_VALIDATION
+#endif
 
- If this value is not defined, yyjson will perform some automatic detection.
- The wrong definition of this option may cause some performance degradation,
- but will not cause any run-time errors.
+/*
+ Define as 1 to indicate that the target architecture does not support unaligned
+ memory access. Please refer to the comments in the C file for details.
  */
 #ifndef YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
 #endif
@@ -122,248 +176,321 @@
 #ifndef YYJSON_HAS_STDBOOL_H
 #endif
 
+
+
 /*==============================================================================
  * Compiler Macros
  *============================================================================*/
 
 /** compiler version (MSVC) */
 #ifdef _MSC_VER
-#define YYJSON_MSC_VER _MSC_VER
+#   define YYJSON_MSC_VER _MSC_VER
 #else
-#define YYJSON_MSC_VER 0
+#   define YYJSON_MSC_VER 0
 #endif
 
 /** compiler version (GCC) */
 #ifdef __GNUC__
-#define YYJSON_GCC_VER __GNUC__
+#   define YYJSON_GCC_VER __GNUC__
+#   if defined(__GNUC_PATCHLEVEL__)
+#       define yyjson_gcc_available(major, minor, patch) \
+            ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) \
+            >= (major * 10000 + minor * 100 + patch))
+#   else
+#       define yyjson_gcc_available(major, minor, patch) \
+            ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) \
+            >= (major * 10000 + minor * 100 + patch))
+#   endif
 #else
-#define YYJSON_GCC_VER 0
+#   define YYJSON_GCC_VER 0
+#   define yyjson_gcc_available(major, minor, patch) 0
+#endif
+
+/** real gcc check */
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__ICC) && \
+    defined(__GNUC__)
+#   define YYJSON_IS_REAL_GCC 1
+#else
+#   define YYJSON_IS_REAL_GCC 0
 #endif
 
 /** C version (STDC) */
 #if defined(__STDC__) && (__STDC__ >= 1) && defined(__STDC_VERSION__)
-#define YYJSON_STDC_VER __STDC_VERSION__
+#   define YYJSON_STDC_VER __STDC_VERSION__
 #else
-#define YYJSON_STDC_VER 0
+#   define YYJSON_STDC_VER 0
 #endif
 
 /** C++ version */
 #if defined(__cplusplus)
-#define YYJSON_CPP_VER __cplusplus
+#   define YYJSON_CPP_VER __cplusplus
 #else
-#define YYJSON_CPP_VER 0
+#   define YYJSON_CPP_VER 0
 #endif
 
 /** compiler builtin check (since gcc 10.0, clang 2.6, icc 2021) */
 #ifndef yyjson_has_builtin
-#ifdef __has_builtin
-#define yyjson_has_builtin(x) __has_builtin(x)
-#else
-#define yyjson_has_builtin(x) 0
-#endif
+#   ifdef __has_builtin
+#       define yyjson_has_builtin(x) __has_builtin(x)
+#   else
+#       define yyjson_has_builtin(x) 0
+#   endif
 #endif
 
 /** compiler attribute check (since gcc 5.0, clang 2.9, icc 17) */
 #ifndef yyjson_has_attribute
-#ifdef __has_attribute
-#define yyjson_has_attribute(x) __has_attribute(x)
-#else
-#define yyjson_has_attribute(x) 0
+#   ifdef __has_attribute
+#       define yyjson_has_attribute(x) __has_attribute(x)
+#   else
+#       define yyjson_has_attribute(x) 0
+#   endif
 #endif
+
+/** compiler feature check (since clang 2.6, icc 17) */
+#ifndef yyjson_has_feature
+#   ifdef __has_feature
+#       define yyjson_has_feature(x) __has_feature(x)
+#   else
+#       define yyjson_has_feature(x) 0
+#   endif
 #endif
 
 /** include check (since gcc 5.0, clang 2.7, icc 16, msvc 2017 15.3) */
 #ifndef yyjson_has_include
-#ifdef __has_include
-#define yyjson_has_include(x) __has_include(x)
-#else
-#define yyjson_has_include(x) 0
-#endif
+#   ifdef __has_include
+#       define yyjson_has_include(x) __has_include(x)
+#   else
+#       define yyjson_has_include(x) 0
+#   endif
 #endif
 
 /** inline for compiler */
 #ifndef yyjson_inline
-#if YYJSON_MSC_VER >= 1200
-#define yyjson_inline __forceinline
-#elif defined(_MSC_VER)
-#define yyjson_inline __inline
-#elif yyjson_has_attribute(always_inline) || YYJSON_GCC_VER >= 4
-#define yyjson_inline __inline__ __attribute__((always_inline))
-#elif defined(__clang__) || defined(__GNUC__)
-#define yyjson_inline __inline__
-#elif defined(__cplusplus) || YYJSON_STDC_VER >= 199901L
-#define yyjson_inline inline
-#else
-#define yyjson_inline
-#endif
+#   if YYJSON_MSC_VER >= 1200
+#       define yyjson_inline __forceinline
+#   elif defined(_MSC_VER)
+#       define yyjson_inline __inline
+#   elif yyjson_has_attribute(always_inline) || YYJSON_GCC_VER >= 4
+#       define yyjson_inline __inline__ __attribute__((always_inline))
+#   elif defined(__clang__) || defined(__GNUC__)
+#       define yyjson_inline __inline__
+#   elif defined(__cplusplus) || YYJSON_STDC_VER >= 199901L
+#       define yyjson_inline inline
+#   else
+#       define yyjson_inline
+#   endif
 #endif
 
 /** noinline for compiler */
 #ifndef yyjson_noinline
-#if YYJSON_MSC_VER >= 1400
-#define yyjson_noinline __declspec(noinline)
-#elif yyjson_has_attribute(noinline) || YYJSON_GCC_VER >= 4
-#define yyjson_noinline __attribute__((noinline))
-#else
-#define yyjson_noinline
-#endif
+#   if YYJSON_MSC_VER >= 1400
+#       define yyjson_noinline __declspec(noinline)
+#   elif yyjson_has_attribute(noinline) || YYJSON_GCC_VER >= 4
+#       define yyjson_noinline __attribute__((noinline))
+#   else
+#       define yyjson_noinline
+#   endif
 #endif
 
 /** align for compiler */
 #ifndef yyjson_align
-#if YYJSON_MSC_VER >= 1300
-#define yyjson_align(x) __declspec(align(x))
-#elif yyjson_has_attribute(aligned) || defined(__GNUC__)
-#define yyjson_align(x) __attribute__((aligned(x)))
-#elif YYJSON_CPP_VER >= 201103L
-#define yyjson_align(x) alignas(x)
-#else
-#define yyjson_align(x)
-#endif
+#   if YYJSON_MSC_VER >= 1300
+#       define yyjson_align(x) __declspec(align(x))
+#   elif yyjson_has_attribute(aligned) || defined(__GNUC__)
+#       define yyjson_align(x) __attribute__((aligned(x)))
+#   elif YYJSON_CPP_VER >= 201103L
+#       define yyjson_align(x) alignas(x)
+#   else
+#       define yyjson_align(x)
+#   endif
 #endif
 
 /** likely for compiler */
 #ifndef yyjson_likely
-#if yyjson_has_builtin(__builtin_expect) || (YYJSON_GCC_VER >= 4 && YYJSON_GCC_VER != 5)
-#define yyjson_likely(expr) __builtin_expect(!!(expr), 1)
-#else
-#define yyjson_likely(expr) (expr)
-#endif
+#   if yyjson_has_builtin(__builtin_expect) || \
+    (YYJSON_GCC_VER >= 4 && YYJSON_GCC_VER != 5)
+#       define yyjson_likely(expr) __builtin_expect(!!(expr), 1)
+#   else
+#       define yyjson_likely(expr) (expr)
+#   endif
 #endif
 
 /** unlikely for compiler */
 #ifndef yyjson_unlikely
-#if yyjson_has_builtin(__builtin_expect) || (YYJSON_GCC_VER >= 4 && YYJSON_GCC_VER != 5)
-#define yyjson_unlikely(expr) __builtin_expect(!!(expr), 0)
-#else
-#define yyjson_unlikely(expr) (expr)
+#   if yyjson_has_builtin(__builtin_expect) || \
+    (YYJSON_GCC_VER >= 4 && YYJSON_GCC_VER != 5)
+#       define yyjson_unlikely(expr) __builtin_expect(!!(expr), 0)
+#   else
+#       define yyjson_unlikely(expr) (expr)
+#   endif
 #endif
+
+/** compile-time constant check for compiler */
+#ifndef yyjson_constant_p
+#   if yyjson_has_builtin(__builtin_constant_p) || (YYJSON_GCC_VER >= 3)
+#       define YYJSON_HAS_CONSTANT_P 1
+#       define yyjson_constant_p(value) __builtin_constant_p(value)
+#   else
+#       define YYJSON_HAS_CONSTANT_P 0
+#       define yyjson_constant_p(value) 0
+#   endif
+#endif
+
+/** deprecate warning */
+#ifndef yyjson_deprecated
+#   if YYJSON_MSC_VER >= 1400
+#       define yyjson_deprecated(msg) __declspec(deprecated(msg))
+#   elif yyjson_has_feature(attribute_deprecated_with_message) || \
+        (YYJSON_GCC_VER > 4 || (YYJSON_GCC_VER == 4 && __GNUC_MINOR__ >= 5))
+#       define yyjson_deprecated(msg) __attribute__((deprecated(msg)))
+#   elif YYJSON_GCC_VER >= 3
+#       define yyjson_deprecated(msg) __attribute__((deprecated))
+#   else
+#       define yyjson_deprecated(msg)
+#   endif
 #endif
 
 /** function export */
 #ifndef yyjson_api
-#if defined(_WIN32)
-#if defined(YYJSON_EXPORTS) && YYJSON_EXPORTS
-#define yyjson_api __declspec(dllexport)
-#elif defined(YYJSON_IMPORTS) && YYJSON_IMPORTS
-#define yyjson_api __declspec(dllimport)
-#else
-#define yyjson_api
-#endif
-#elif yyjson_has_attribute(visibility) || YYJSON_GCC_VER >= 4
-#define yyjson_api __attribute__((visibility("default")))
-#else
-#define yyjson_api
-#endif
+#   if defined(_WIN32)
+#       if defined(YYJSON_EXPORTS) && YYJSON_EXPORTS
+#           define yyjson_api __declspec(dllexport)
+#       elif defined(YYJSON_IMPORTS) && YYJSON_IMPORTS
+#           define yyjson_api __declspec(dllimport)
+#       else
+#           define yyjson_api
+#       endif
+#   elif yyjson_has_attribute(visibility) || YYJSON_GCC_VER >= 4
+#       define yyjson_api __attribute__((visibility("default")))
+#   else
+#       define yyjson_api
+#   endif
 #endif
 
 /** inline function export */
 #ifndef yyjson_api_inline
-#define yyjson_api_inline static yyjson_inline
+#   define yyjson_api_inline static yyjson_inline
 #endif
 
 /** stdint (C89 compatible) */
-#if (defined(YYJSON_HAS_STDINT_H) && YYJSON_HAS_STDINT_H) || YYJSON_MSC_VER >= 1600 || YYJSON_STDC_VER >= 199901L ||   \
-    defined(_STDINT_H) || defined(_STDINT_H_) || defined(__CLANG_STDINT_H) || defined(_STDINT_H_INCLUDED) ||           \
+#if (defined(YYJSON_HAS_STDINT_H) && YYJSON_HAS_STDINT_H) || \
+    YYJSON_MSC_VER >= 1600 || YYJSON_STDC_VER >= 199901L || \
+    defined(_STDINT_H) || defined(_STDINT_H_) || \
+    defined(__CLANG_STDINT_H) || defined(_STDINT_H_INCLUDED) || \
     yyjson_has_include(<stdint.h>)
-#include <stdint.h>
+#   include <stdint.h>
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1300
-typedef signed char int8_t;
-typedef signed short int16_t;
-typedef signed int int32_t;
-typedef unsigned char uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int uint32_t;
-typedef signed __int64 int64_t;
-typedef unsigned __int64 uint64_t;
+#   if _MSC_VER < 1300
+        typedef signed char         int8_t;
+        typedef signed short        int16_t;
+        typedef signed int          int32_t;
+        typedef unsigned char       uint8_t;
+        typedef unsigned short      uint16_t;
+        typedef unsigned int        uint32_t;
+        typedef signed __int64      int64_t;
+        typedef unsigned __int64    uint64_t;
+#   else
+        typedef signed __int8       int8_t;
+        typedef signed __int16      int16_t;
+        typedef signed __int32      int32_t;
+        typedef unsigned __int8     uint8_t;
+        typedef unsigned __int16    uint16_t;
+        typedef unsigned __int32    uint32_t;
+        typedef signed __int64      int64_t;
+        typedef unsigned __int64    uint64_t;
+#   endif
 #else
-typedef signed __int8 int8_t;
-typedef signed __int16 int16_t;
-typedef signed __int32 int32_t;
-typedef unsigned __int8 uint8_t;
-typedef unsigned __int16 uint16_t;
-typedef unsigned __int32 uint32_t;
-typedef signed __int64 int64_t;
-typedef unsigned __int64 uint64_t;
-#endif
-#else
-#if UCHAR_MAX == 0xFFU
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-#else
-#error cannot find 8-bit integer type
-#endif
-#if USHRT_MAX == 0xFFFFU
-typedef unsigned short uint16_t;
-typedef signed short int16_t;
-#elif UINT_MAX == 0xFFFFU
-typedef unsigned int uint16_t;
-typedef signed int int16_t;
-#else
-#error cannot find 16-bit integer type
-#endif
-#if UINT_MAX == 0xFFFFFFFFUL
-typedef unsigned int uint32_t;
-typedef signed int int32_t;
-#elif ULONG_MAX == 0xFFFFFFFFUL
-typedef unsigned long uint32_t;
-typedef signed long int32_t;
-#elif USHRT_MAX == 0xFFFFFFFFUL
-typedef unsigned short uint32_t;
-typedef signed short int32_t;
-#else
-#error cannot find 32-bit integer type
-#endif
-#if defined(__INT64_TYPE__) && defined(__UINT64_TYPE__)
-typedef __INT64_TYPE__ int64_t;
-typedef __UINT64_TYPE__ uint64_t;
-#elif defined(__GNUC__) || defined(__clang__)
-#if !defined(_SYS_TYPES_H) && !defined(__int8_t_defined)
-__extension__ typedef long long int64_t;
-#endif
-__extension__ typedef unsigned long long uint64_t;
-#elif defined(_LONG_LONG) || defined(__MWERKS__) || defined(_CRAYC) || defined(__SUNPRO_C) || defined(__SUNPRO_CC)
-typedef long long int64_t;
-typedef unsigned long long uint64_t;
-#elif (defined(__BORLANDC__) && __BORLANDC__ > 0x460) || defined(__WATCOM_INT64__) || defined(__alpha) ||              \
-    defined(__DECC)
-typedef __int64 int64_t;
-typedef unsigned __int64 uint64_t;
-#else
-#error cannot find 64-bit integer type
-#endif
+#   if UCHAR_MAX == 0xFFU
+        typedef signed char     int8_t;
+        typedef unsigned char   uint8_t;
+#   else
+#       error cannot find 8-bit integer type
+#   endif
+#   if USHRT_MAX == 0xFFFFU
+        typedef unsigned short  uint16_t;
+        typedef signed short    int16_t;
+#   elif UINT_MAX == 0xFFFFU
+        typedef unsigned int    uint16_t;
+        typedef signed int      int16_t;
+#   else
+#       error cannot find 16-bit integer type
+#   endif
+#   if UINT_MAX == 0xFFFFFFFFUL
+        typedef unsigned int    uint32_t;
+        typedef signed int      int32_t;
+#   elif ULONG_MAX == 0xFFFFFFFFUL
+        typedef unsigned long   uint32_t;
+        typedef signed long     int32_t;
+#   elif USHRT_MAX == 0xFFFFFFFFUL
+        typedef unsigned short  uint32_t;
+        typedef signed short    int32_t;
+#   else
+#       error cannot find 32-bit integer type
+#   endif
+#   if defined(__INT64_TYPE__) && defined(__UINT64_TYPE__)
+        typedef __INT64_TYPE__  int64_t;
+        typedef __UINT64_TYPE__ uint64_t;
+#   elif defined(__GNUC__) || defined(__clang__)
+#       if !defined(_SYS_TYPES_H) && !defined(__int8_t_defined)
+        __extension__ typedef long long             int64_t;
+#       endif
+        __extension__ typedef unsigned long long    uint64_t;
+#   elif defined(_LONG_LONG) || defined(__MWERKS__) || defined(_CRAYC) || \
+        defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+        typedef long long           int64_t;
+        typedef unsigned long long  uint64_t;
+#   elif (defined(__BORLANDC__) && __BORLANDC__ > 0x460) || \
+        defined(__WATCOM_INT64__) || defined (__alpha) || defined (__DECC)
+        typedef __int64             int64_t;
+        typedef unsigned __int64    uint64_t;
+#   else
+#       error cannot find 64-bit integer type
+#   endif
 #endif
 
 /** stdbool (C89 compatible) */
-#if (defined(YYJSON_HAS_STDBOOL_H) && YYJSON_HAS_STDBOOL_H) ||                                                         \
-    (yyjson_has_include(<stdbool.h>) && !defined(__STRICT_ANSI__)) || YYJSON_MSC_VER >= 1800 ||                        \
-    YYJSON_STDC_VER >= 199901L
-#include <stdbool.h>
+#if (defined(YYJSON_HAS_STDBOOL_H) && YYJSON_HAS_STDBOOL_H) || \
+    (yyjson_has_include(<stdbool.h>) && !defined(__STRICT_ANSI__)) || \
+    YYJSON_MSC_VER >= 1800 || YYJSON_STDC_VER >= 199901L
+#   include <stdbool.h>
 #elif !defined(__bool_true_false_are_defined)
-#define __bool_true_false_are_defined 1
-#if defined(__cplusplus)
-#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
-#define _Bool bool
-#if __cplusplus < 201103L
-#define bool bool
-#define false false
-#define true true
-#endif
-#endif
-#else
-#define bool unsigned char
-#define true 1
-#define false 0
-#endif
+#   define __bool_true_false_are_defined 1
+#   if defined(__cplusplus)
+#       if defined(__GNUC__) && !defined(__STRICT_ANSI__)
+#           define _Bool bool
+#           if __cplusplus < 201103L
+#               define bool bool
+#               define false false
+#               define true true
+#           endif
+#       endif
+#   else
+#       define bool unsigned char
+#       define true 1
+#       define false 0
+#   endif
 #endif
 
 /** char bit check */
 #if defined(CHAR_BIT)
-#if CHAR_BIT != 8
-#error non 8-bit char is not supported
+#   if CHAR_BIT != 8
+#       error non 8-bit char is not supported
+#   endif
 #endif
+
+/**
+ Microsoft Visual C++ 6.0 doesn't support converting number from u64 to f64:
+ error C2520: conversion from unsigned __int64 to double not implemented.
+ */
+#ifndef YYJSON_U64_TO_F64_NO_IMPL
+#   if (0 < YYJSON_MSC_VER) && (YYJSON_MSC_VER <= 1200)
+#       define YYJSON_U64_TO_F64_NO_IMPL 1
+#   else
+#       define YYJSON_U64_TO_F64_NO_IMPL 0
+#   endif
 #endif
+
+
 
 /*==============================================================================
  * Compile Hint Begin
@@ -376,78 +503,107 @@ extern "C" {
 
 /* warning suppress begin */
 #if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-parameter"
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wunused-function"
+#   pragma clang diagnostic ignored "-Wunused-parameter"
 #elif defined(__GNUC__)
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#pragma GCC diagnostic push
-#endif
-#pragma GCC diagnostic ignored "-Wunused-function"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
+#   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#   pragma GCC diagnostic push
+#   endif
+#   pragma GCC diagnostic ignored "-Wunused-function"
+#   pragma GCC diagnostic ignored "-Wunused-parameter"
 #elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4800) /* 'int': forcing value to 'true' or 'false' */
+#   pragma warning(push)
+#   pragma warning(disable:4800) /* 'int': forcing value to 'true' or 'false' */
 #endif
+
+
 
 /*==============================================================================
  * Version
  *============================================================================*/
 
 /** The major version of yyjson. */
-#define YYJSON_VERSION_MAJOR 0
+#define YYJSON_VERSION_MAJOR  0
 
 /** The minor version of yyjson. */
-#define YYJSON_VERSION_MINOR 6
+#define YYJSON_VERSION_MINOR  9
 
 /** The patch version of yyjson. */
-#define YYJSON_VERSION_PATCH 0
+#define YYJSON_VERSION_PATCH  0
 
 /** The version of yyjson in hex: `(major << 16) | (minor << 8) | (patch)`. */
-#define YYJSON_VERSION_HEX 0x000600
+#define YYJSON_VERSION_HEX    0x000900
 
 /** The version string of yyjson. */
-#define YYJSON_VERSION_STRING "0.6.0"
+#define YYJSON_VERSION_STRING "0.9.0"
 
 /** The version of yyjson in hex, same as `YYJSON_VERSION_HEX`. */
 yyjson_api uint32_t yyjson_version(void);
+
+
 
 /*==============================================================================
  * JSON Types
  *============================================================================*/
 
-/** Type of JSON value (3 bit). */
+/** Type of a JSON value (3 bit). */
 typedef uint8_t yyjson_type;
-#define YYJSON_TYPE_NONE ((uint8_t)0) /* _____000 */
-#define YYJSON_TYPE_RAW  ((uint8_t)1) /* _____001 */
-#define YYJSON_TYPE_NULL ((uint8_t)2) /* _____010 */
-#define YYJSON_TYPE_BOOL ((uint8_t)3) /* _____011 */
-#define YYJSON_TYPE_NUM  ((uint8_t)4) /* _____100 */
-#define YYJSON_TYPE_STR  ((uint8_t)5) /* _____101 */
-#define YYJSON_TYPE_ARR  ((uint8_t)6) /* _____110 */
-#define YYJSON_TYPE_OBJ  ((uint8_t)7) /* _____111 */
+/** No type, invalid. */
+#define YYJSON_TYPE_NONE        ((uint8_t)0)        /* _____000 */
+/** Raw string type, no subtype. */
+#define YYJSON_TYPE_RAW         ((uint8_t)1)        /* _____001 */
+/** Null type: `null` literal, no subtype. */
+#define YYJSON_TYPE_NULL        ((uint8_t)2)        /* _____010 */
+/** Boolean type, subtype: TRUE, FALSE. */
+#define YYJSON_TYPE_BOOL        ((uint8_t)3)        /* _____011 */
+/** Number type, subtype: UINT, SINT, REAL. */
+#define YYJSON_TYPE_NUM         ((uint8_t)4)        /* _____100 */
+/** String type, subtype: NONE, NOESC. */
+#define YYJSON_TYPE_STR         ((uint8_t)5)        /* _____101 */
+/** Array type, no subtype. */
+#define YYJSON_TYPE_ARR         ((uint8_t)6)        /* _____110 */
+/** Object type, no subtype. */
+#define YYJSON_TYPE_OBJ         ((uint8_t)7)        /* _____111 */
 
-/** Subtype of JSON value (2 bit). */
+/** Subtype of a JSON value (2 bit). */
 typedef uint8_t yyjson_subtype;
-#define YYJSON_SUBTYPE_NONE  ((uint8_t)(0 << 3)) /* ___00___ */
-#define YYJSON_SUBTYPE_FALSE ((uint8_t)(0 << 3)) /* ___00___ */
-#define YYJSON_SUBTYPE_TRUE  ((uint8_t)(1 << 3)) /* ___01___ */
-#define YYJSON_SUBTYPE_UINT  ((uint8_t)(0 << 3)) /* ___00___ */
-#define YYJSON_SUBTYPE_SINT  ((uint8_t)(1 << 3)) /* ___01___ */
-#define YYJSON_SUBTYPE_REAL  ((uint8_t)(2 << 3)) /* ___10___ */
+/** No subtype. */
+#define YYJSON_SUBTYPE_NONE     ((uint8_t)(0 << 3)) /* ___00___ */
+/** False subtype: `false` literal. */
+#define YYJSON_SUBTYPE_FALSE    ((uint8_t)(0 << 3)) /* ___00___ */
+/** True subtype: `true` literal. */
+#define YYJSON_SUBTYPE_TRUE     ((uint8_t)(1 << 3)) /* ___01___ */
+/** Unsigned integer subtype: `uint64_t`. */
+#define YYJSON_SUBTYPE_UINT     ((uint8_t)(0 << 3)) /* ___00___ */
+/** Signed integer subtype: `int64_t`. */
+#define YYJSON_SUBTYPE_SINT     ((uint8_t)(1 << 3)) /* ___01___ */
+/** Real number subtype: `double`. */
+#define YYJSON_SUBTYPE_REAL     ((uint8_t)(2 << 3)) /* ___10___ */
+/** String that do not need to be escaped for writing (internal use). */
+#define YYJSON_SUBTYPE_NOESC    ((uint8_t)(1 << 3)) /* ___01___ */
 
-/** Mask and bits of JSON value tag. */
-#define YYJSON_TYPE_MASK     ((uint8_t)0x07) /* _____111 */
-#define YYJSON_TYPE_BIT      ((uint8_t)3)
-#define YYJSON_SUBTYPE_MASK  ((uint8_t)0x18) /* ___11___ */
-#define YYJSON_SUBTYPE_BIT   ((uint8_t)2)
-#define YYJSON_RESERVED_MASK ((uint8_t)0xE0) /* 111_____ */
-#define YYJSON_RESERVED_BIT  ((uint8_t)3)
-#define YYJSON_TAG_MASK      ((uint8_t)0xFF) /* 11111111 */
-#define YYJSON_TAG_BIT       ((uint8_t)8)
+/** The mask used to extract the type of a JSON value. */
+#define YYJSON_TYPE_MASK        ((uint8_t)0x07)     /* _____111 */
+/** The number of bits used by the type. */
+#define YYJSON_TYPE_BIT         ((uint8_t)3)
+/** The mask used to extract the subtype of a JSON value. */
+#define YYJSON_SUBTYPE_MASK     ((uint8_t)0x18)     /* ___11___ */
+/** The number of bits used by the subtype. */
+#define YYJSON_SUBTYPE_BIT      ((uint8_t)2)
+/** The mask used to extract the reserved bits of a JSON value. */
+#define YYJSON_RESERVED_MASK    ((uint8_t)0xE0)     /* 111_____ */
+/** The number of reserved bits. */
+#define YYJSON_RESERVED_BIT     ((uint8_t)3)
+/** The mask used to extract the tag of a JSON value. */
+#define YYJSON_TAG_MASK         ((uint8_t)0xFF)     /* 11111111 */
+/** The number of bits used by the tag. */
+#define YYJSON_TAG_BIT          ((uint8_t)8)
 
 /** Padding size for JSON reader. */
-#define YYJSON_PADDING_SIZE 4
+#define YYJSON_PADDING_SIZE     4
+
+
 
 /*==============================================================================
  * Allocator
@@ -455,32 +611,36 @@ typedef uint8_t yyjson_subtype;
 
 /**
  A memory allocator.
-
+ 
  Typically you don't need to use it, unless you want to customize your own
  memory allocator.
  */
 typedef struct yyjson_alc {
-	/** Same as libc's malloc(size), should not be NULL. */
-	void *(*malloc)(void *ctx, size_t size);
-	/** Same as libc's realloc(ptr, size), should not be NULL. */
-	void *(*realloc)(void *ctx, void *ptr, size_t old_size, size_t size);
-	/** Same as libc's free(ptr), should not be NULL. */
-	void (*free)(void *ctx, void *ptr);
-	/** A context for malloc/realloc/free, can be NULL. */
-	void *ctx;
+    /** Same as libc's malloc(size), should not be NULL. */
+    void *(*malloc)(void *ctx, size_t size);
+    /** Same as libc's realloc(ptr, size), should not be NULL. */
+    void *(*realloc)(void *ctx, void *ptr, size_t old_size, size_t size);
+    /** Same as libc's free(ptr), should not be NULL. */
+    void (*free)(void *ctx, void *ptr);
+    /** A context for malloc/realloc/free, can be NULL. */
+    void *ctx;
 } yyjson_alc;
 
 /**
  A pool allocator uses fixed length pre-allocated memory.
-
- This allocator may used to avoid malloc/realloc calls. The pre-allocated memory
- should be held by the caller. The maximum amount of memory required to read a
- JSON can be calculated using the `yyjson_read_max_memory_usage()` function, but
- the amount of memory required to write a JSON cannot be directly calculated.
-
- This is not a general-purpose allocator, and should only be used to read or
- write single JSON document.
-
+ 
+ This allocator may be used to avoid malloc/realloc calls. The pre-allocated 
+ memory should be held by the caller. The maximum amount of memory required to
+ read a JSON can be calculated using the `yyjson_read_max_memory_usage()`
+ function, but the amount of memory required to write a JSON cannot be directly 
+ calculated.
+ 
+ This is not a general-purpose allocator. It is designed to handle a single JSON
+ data at a time. If it is used for overly complex memory tasks, such as parsing
+ multiple JSON documents using the same allocator but releasing only a few of
+ them, it may cause memory fragmentation, resulting in performance degradation
+ and memory waste.
+ 
  @param alc The allocator to be initialized.
     If this parameter is NULL, the function will fail and return false.
     If `buf` or `size` is invalid, this will be set to an empty allocator.
@@ -490,20 +650,44 @@ typedef struct yyjson_alc {
     If this parameter is less than 8 words (32/64 bytes on 32/64-bit OS), the
     function will fail and return false.
  @return true if the `alc` has been successfully initialized.
-
+ 
  @par Example
  @code
     // parse JSON with stack memory
     char buf[1024];
     yyjson_alc alc;
     yyjson_alc_pool_init(&alc, buf, 1024);
-
+    
     const char *json = "{\"name\":\"Helvetica\",\"size\":16}"
     yyjson_doc *doc = yyjson_read_opts(json, strlen(json), 0, &alc, NULL);
     // the memory of `doc` is on the stack
  @endcode
+ 
+ @warning This Allocator is not thread-safe.
  */
 yyjson_api bool yyjson_alc_pool_init(yyjson_alc *alc, void *buf, size_t size);
+
+/**
+ A dynamic allocator.
+ 
+ This allocator has a similar usage to the pool allocator above. However, when
+ there is not enough memory, this allocator will dynamically request more memory
+ using libc's `malloc` function, and frees it all at once when it is destroyed.
+ 
+ @return A new dynamic allocator, or NULL if memory allocation failed.
+ @note The returned value should be freed with `yyjson_alc_dyn_free()`.
+ 
+ @warning This Allocator is not thread-safe.
+ */
+yyjson_api yyjson_alc *yyjson_alc_dyn_new(void);
+
+/**
+ Free a dynamic allocator which is created by `yyjson_alc_dyn_new()`.
+ @param alc The dynamic allocator to be destroyed.
+ */
+yyjson_api void yyjson_alc_dyn_free(yyjson_alc *alc);
+
+
 
 /*==============================================================================
  * JSON Structure
@@ -537,6 +721,8 @@ typedef struct yyjson_mut_doc yyjson_mut_doc;
  */
 typedef struct yyjson_mut_val yyjson_mut_val;
 
+
+
 /*==============================================================================
  * JSON Reader API
  *============================================================================*/
@@ -549,10 +735,10 @@ typedef uint32_t yyjson_read_flag;
     - Read negative integer as int64_t.
     - Read floating-point number as double with round-to-nearest mode.
     - Read integer which cannot fit in uint64_t or int64_t as double.
-    - Report error if real number is infinity.
+    - Report error if double number is infinity.
     - Report error if string contains invalid UTF-8 character or BOM.
     - Report error on trailing commas, comments, inf and nan literals. */
-static const yyjson_read_flag YYJSON_READ_NOFLAG = 0 << 0;
+static const yyjson_read_flag YYJSON_READ_NOFLAG                = 0;
 
 /** Read the input data in-situ.
     This option allows the reader to modify and use input data to store string
@@ -560,100 +746,110 @@ static const yyjson_read_flag YYJSON_READ_NOFLAG = 0 << 0;
     The caller should hold the input data before free the document.
     The input data must be padded by at least `YYJSON_PADDING_SIZE` bytes.
     For example: `[1,2]` should be `[1,2]\0\0\0\0`, input length should be 5. */
-static const yyjson_read_flag YYJSON_READ_INSITU = 1 << 0;
+static const yyjson_read_flag YYJSON_READ_INSITU                = 1 << 0;
 
 /** Stop when done instead of issuing an error if there's additional content
     after a JSON document. This option may be used to parse small pieces of JSON
     in larger data, such as `NDJSON`. */
-static const yyjson_read_flag YYJSON_READ_STOP_WHEN_DONE = 1 << 1;
+static const yyjson_read_flag YYJSON_READ_STOP_WHEN_DONE        = 1 << 1;
 
 /** Allow single trailing comma at the end of an object or array,
     such as `[1,2,3,]`, `{"a":1,"b":2,}` (non-standard). */
 static const yyjson_read_flag YYJSON_READ_ALLOW_TRAILING_COMMAS = 1 << 2;
 
 /** Allow C-style single line and multiple line comments (non-standard). */
-static const yyjson_read_flag YYJSON_READ_ALLOW_COMMENTS = 1 << 3;
+static const yyjson_read_flag YYJSON_READ_ALLOW_COMMENTS        = 1 << 3;
 
 /** Allow inf/nan number and literal, case-insensitive,
     such as 1e999, NaN, inf, -Infinity (non-standard). */
-static const yyjson_read_flag YYJSON_READ_ALLOW_INF_AND_NAN = 1 << 4;
+static const yyjson_read_flag YYJSON_READ_ALLOW_INF_AND_NAN     = 1 << 4;
 
-/** Read number as raw string (value with `YYJSON_TYPE_RAW` type),
+/** Read all numbers as raw strings (value with `YYJSON_TYPE_RAW` type),
     inf/nan literal is also read as raw with `ALLOW_INF_AND_NAN` flag. */
-static const yyjson_read_flag YYJSON_READ_NUMBER_AS_RAW = 1 << 5;
+static const yyjson_read_flag YYJSON_READ_NUMBER_AS_RAW         = 1 << 5;
 
 /** Allow reading invalid unicode when parsing string values (non-standard).
     Invalid characters will be allowed to appear in the string values, but
     invalid escape sequences will still be reported as errors.
     This flag does not affect the performance of correctly encoded strings.
-
+    
     @warning Strings in JSON values may contain incorrect encoding when this
     option is used, you need to handle these strings carefully to avoid security
     risks. */
 static const yyjson_read_flag YYJSON_READ_ALLOW_INVALID_UNICODE = 1 << 6;
 
+/** Read big numbers as raw strings. These big numbers include integers that
+    cannot be represented by `int64_t` and `uint64_t`, and floating-point
+    numbers that cannot be represented by finite `double`.
+    The flag will be overridden by `YYJSON_READ_NUMBER_AS_RAW` flag. */
+static const yyjson_read_flag YYJSON_READ_BIGNUM_AS_RAW         = 1 << 7;
+
+
+
 /** Result code for JSON reader. */
 typedef uint32_t yyjson_read_code;
 
 /** Success, no error. */
-static const yyjson_read_code YYJSON_READ_SUCCESS = 0;
+static const yyjson_read_code YYJSON_READ_SUCCESS                       = 0;
 
 /** Invalid parameter, such as NULL input string or 0 input length. */
-static const yyjson_read_code YYJSON_READ_ERROR_INVALID_PARAMETER = 1;
+static const yyjson_read_code YYJSON_READ_ERROR_INVALID_PARAMETER       = 1;
 
 /** Memory allocation failure occurs. */
-static const yyjson_read_code YYJSON_READ_ERROR_MEMORY_ALLOCATION = 2;
+static const yyjson_read_code YYJSON_READ_ERROR_MEMORY_ALLOCATION       = 2;
 
 /** Input JSON string is empty. */
-static const yyjson_read_code YYJSON_READ_ERROR_EMPTY_CONTENT = 3;
+static const yyjson_read_code YYJSON_READ_ERROR_EMPTY_CONTENT           = 3;
 
-/** Unexpected content after document, such as `[1]abc`. */
-static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_CONTENT = 4;
+/** Unexpected content after document, such as `[123]abc`. */
+static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_CONTENT      = 4;
 
 /** Unexpected ending, such as `[123`. */
-static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_END = 5;
+static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_END          = 5;
 
 /** Unexpected character inside the document, such as `[abc]`. */
-static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_CHARACTER = 6;
+static const yyjson_read_code YYJSON_READ_ERROR_UNEXPECTED_CHARACTER    = 6;
 
 /** Invalid JSON structure, such as `[1,]`. */
-static const yyjson_read_code YYJSON_READ_ERROR_JSON_STRUCTURE = 7;
+static const yyjson_read_code YYJSON_READ_ERROR_JSON_STRUCTURE          = 7;
 
 /** Invalid comment, such as unclosed multi-line comment. */
-static const yyjson_read_code YYJSON_READ_ERROR_INVALID_COMMENT = 8;
+static const yyjson_read_code YYJSON_READ_ERROR_INVALID_COMMENT         = 8;
 
 /** Invalid number, such as `123.e12`, `000`. */
-static const yyjson_read_code YYJSON_READ_ERROR_INVALID_NUMBER = 9;
+static const yyjson_read_code YYJSON_READ_ERROR_INVALID_NUMBER          = 9;
 
 /** Invalid string, such as invalid escaped character inside a string. */
-static const yyjson_read_code YYJSON_READ_ERROR_INVALID_STRING = 10;
+static const yyjson_read_code YYJSON_READ_ERROR_INVALID_STRING          = 10;
 
 /** Invalid JSON literal, such as `truu`. */
-static const yyjson_read_code YYJSON_READ_ERROR_LITERAL = 11;
+static const yyjson_read_code YYJSON_READ_ERROR_LITERAL                 = 11;
 
 /** Failed to open a file. */
-static const yyjson_read_code YYJSON_READ_ERROR_FILE_OPEN = 12;
+static const yyjson_read_code YYJSON_READ_ERROR_FILE_OPEN               = 12;
 
 /** Failed to read a file. */
-static const yyjson_read_code YYJSON_READ_ERROR_FILE_READ = 13;
+static const yyjson_read_code YYJSON_READ_ERROR_FILE_READ               = 13;
 
 /** Error information for JSON reader. */
 typedef struct yyjson_read_err {
-	/** Error code, see `yyjson_read_code` for all possible values. */
-	yyjson_read_code code;
-	/** Error message, constant, no need to free (NULL if success). */
-	const char *msg;
-	/** Error byte position for input data (0 if success). */
-	size_t pos;
+    /** Error code, see `yyjson_read_code` for all possible values. */
+    yyjson_read_code code;
+    /** Error message, constant, no need to free (NULL if success). */
+    const char *msg;
+    /** Error byte position for input data (0 if success). */
+    size_t pos;
 } yyjson_read_err;
+
+
 
 /**
  Read JSON with options.
-
+ 
  This function is thread-safe when:
  1. The `dat` is not modified by other threads.
  2. The `alc` is thread-safe or NULL.
-
+ 
  @param dat The JSON data (UTF-8 without BOM), null-terminator is not required.
     If this parameter is NULL, the function will fail and return NULL.
     The `dat` will not be modified without the flag `YYJSON_READ_INSITU`, so you
@@ -670,16 +866,19 @@ typedef struct yyjson_read_err {
  @return A new JSON document, or NULL if an error occurs.
     When it's no longer needed, it should be freed with `yyjson_doc_free()`.
  */
-yyjson_api yyjson_doc *yyjson_read_opts(char *dat, size_t len, yyjson_read_flag flg, const yyjson_alc *alc,
+yyjson_api yyjson_doc *yyjson_read_opts(char *dat,
+                                        size_t len,
+                                        yyjson_read_flag flg,
+                                        const yyjson_alc *alc,
                                         yyjson_read_err *err);
 
 /**
  Read a JSON file.
-
+ 
  This function is thread-safe when:
  1. The file is not modified by other threads.
  2. The `alc` is thread-safe or NULL.
-
+ 
  @param path The JSON file's path.
     If this path is NULL or invalid, the function will fail and return NULL.
  @param flg The JSON read options.
@@ -690,17 +889,41 @@ yyjson_api yyjson_doc *yyjson_read_opts(char *dat, size_t len, yyjson_read_flag 
     Pass NULL if you don't need error information.
  @return A new JSON document, or NULL if an error occurs.
     When it's no longer needed, it should be freed with `yyjson_doc_free()`.
-
+ 
  @warning On 32-bit operating system, files larger than 2GB may fail to read.
  */
-yyjson_api yyjson_doc *yyjson_read_file(const char *path, yyjson_read_flag flg, const yyjson_alc *alc,
+yyjson_api yyjson_doc *yyjson_read_file(const char *path,
+                                        yyjson_read_flag flg,
+                                        const yyjson_alc *alc,
                                         yyjson_read_err *err);
 
 /**
+ Read JSON from a file pointer.
+ 
+ @param fp The file pointer.
+    The data will be read from the current position of the FILE to the end.
+    If this fp is NULL or invalid, the function will fail and return NULL.
+ @param flg The JSON read options.
+    Multiple options can be combined with `|` operator. 0 means no options.
+ @param alc The memory allocator used by JSON reader.
+    Pass NULL to use the libc's default allocator.
+ @param err A pointer to receive error information.
+    Pass NULL if you don't need error information.
+ @return A new JSON document, or NULL if an error occurs.
+    When it's no longer needed, it should be freed with `yyjson_doc_free()`.
+ 
+ @warning On 32-bit operating system, files larger than 2GB may fail to read.
+ */
+yyjson_api yyjson_doc *yyjson_read_fp(FILE *fp,
+                                      yyjson_read_flag flg,
+                                      const yyjson_alc *alc,
+                                      yyjson_read_err *err);
+
+/**
  Read a JSON string.
-
+ 
  This function is thread-safe.
-
+ 
  @param dat The JSON data (UTF-8 without BOM), null-terminator is not required.
     If this parameter is NULL, the function will fail and return NULL.
  @param len The length of JSON data in bytes.
@@ -710,36 +933,39 @@ yyjson_api yyjson_doc *yyjson_read_file(const char *path, yyjson_read_flag flg, 
  @return A new JSON document, or NULL if an error occurs.
     When it's no longer needed, it should be freed with `yyjson_doc_free()`.
  */
-yyjson_api_inline yyjson_doc *yyjson_read(const char *dat, size_t len, yyjson_read_flag flg) {
-	flg &= ~YYJSON_READ_INSITU; /* const string cannot be modified */
-	return yyjson_read_opts((char *)dat, len, flg, NULL, NULL);
+yyjson_api_inline yyjson_doc *yyjson_read(const char *dat,
+                                          size_t len,
+                                          yyjson_read_flag flg) {
+    flg &= ~YYJSON_READ_INSITU; /* const string cannot be modified */
+    return yyjson_read_opts((char *)(void *)(size_t)(const void *)dat,
+                            len, flg, NULL, NULL);
 }
 
 /**
  Returns the size of maximum memory usage to read a JSON data.
-
+ 
  You may use this value to avoid malloc() or calloc() call inside the reader
  to get better performance, or read multiple JSON with one piece of memory.
-
+ 
  @param len The length of JSON data in bytes.
  @param flg The JSON read options.
  @return The maximum memory size to read this JSON, or 0 if overflow.
-
+ 
  @par Example
  @code
     // read multiple JSON with same pre-allocated memory
-
+    
     char *dat1, *dat2, *dat3; // JSON data
     size_t len1, len2, len3; // JSON length
     size_t max_len = MAX(len1, MAX(len2, len3));
     yyjson_doc *doc;
-
+    
     // use one allocator for multiple JSON
     size_t size = yyjson_read_max_memory_usage(max_len, 0);
     void *buf = malloc(size);
     yyjson_alc alc;
     yyjson_alc_pool_init(&alc, buf, size);
-
+    
     // no more alloc() or realloc() call during reading
     doc = yyjson_read_opts(dat1, len1, 0, &alc, NULL);
     yyjson_doc_free(doc);
@@ -747,30 +973,29 @@ yyjson_api_inline yyjson_doc *yyjson_read(const char *dat, size_t len, yyjson_re
     yyjson_doc_free(doc);
     doc = yyjson_read_opts(dat3, len3, 0, &alc, NULL);
     yyjson_doc_free(doc);
-
+    
     free(buf);
  @endcode
  @see yyjson_alc_pool_init()
  */
-yyjson_api_inline size_t yyjson_read_max_memory_usage(size_t len, yyjson_read_flag flg) {
-	/*
-	 1. The max value count is (json_size / 2 + 1),
-	    for example: "[1,2,3,4]" size is 9, value count is 5.
-	 2. Some broken JSON may cost more memory during reading, but fail at end,
-	    for example: "[[[[[[[[".
-	 3. yyjson use 16 bytes per value, see struct yyjson_val.
-	 4. yyjson use dynamic memory with a growth factor of 1.5.
-
-	 The max memory size is (json_size / 2 * 16 * 1.5 + padding).
-	 */
-	size_t mul = (size_t)12 + !(flg & YYJSON_READ_INSITU);
-	size_t pad = 256;
-	size_t max = (size_t)(~(size_t)0);
-	if (flg & YYJSON_READ_STOP_WHEN_DONE)
-		len = len < 256 ? 256 : len;
-	if (len >= (max - pad - mul) / mul)
-		return 0;
-	return len * mul + pad;
+yyjson_api_inline size_t yyjson_read_max_memory_usage(size_t len,
+                                                      yyjson_read_flag flg) {
+    /*
+     1. The max value count is (json_size / 2 + 1),
+        for example: "[1,2,3,4]" size is 9, value count is 5.
+     2. Some broken JSON may cost more memory during reading, but fail at end,
+        for example: "[[[[[[[[".
+     3. yyjson use 16 bytes per value, see struct yyjson_val.
+     4. yyjson use dynamic memory with a growth factor of 1.5.
+     
+     The max memory size is (json_size / 2 * 16 * 1.5 + padding).
+     */
+    size_t mul = (size_t)12 + !(flg & YYJSON_READ_INSITU);
+    size_t pad = 256;
+    size_t max = (size_t)(~(size_t)0);
+    if (flg & YYJSON_READ_STOP_WHEN_DONE) len = len < 256 ? 256 : len;
+    if (len >= (max - pad - mul) / mul) return 0;
+    return len * mul + pad;
 }
 
 /**
@@ -785,7 +1010,7 @@ yyjson_api_inline size_t yyjson_read_max_memory_usage(size_t len, yyjson_read_fl
     The value will hold either UINT or SINT or REAL number;
  @param flg The JSON read options.
     Multiple options can be combined with `|` operator. 0 means no options.
-    Suppors `YYJSON_READ_NUMBER_AS_RAW` and `YYJSON_READ_ALLOW_INF_AND_NAN`.
+    Supports `YYJSON_READ_NUMBER_AS_RAW` and `YYJSON_READ_ALLOW_INF_AND_NAN`.
  @param alc The memory allocator used for long number.
     It is only used when the built-in floating point reader is disabled.
     Pass NULL to use the libc's default allocator.
@@ -794,7 +1019,10 @@ yyjson_api_inline size_t yyjson_read_max_memory_usage(size_t len, yyjson_read_fl
  @return If successful, a pointer to the character after the last character
     used in the conversion, NULL if an error occurs.
  */
-yyjson_api const char *yyjson_read_number(const char *dat, yyjson_val *val, yyjson_read_flag flg, const yyjson_alc *alc,
+yyjson_api const char *yyjson_read_number(const char *dat,
+                                          yyjson_val *val,
+                                          yyjson_read_flag flg,
+                                          const yyjson_alc *alc,
                                           yyjson_read_err *err);
 
 /**
@@ -809,7 +1037,7 @@ yyjson_api const char *yyjson_read_number(const char *dat, yyjson_val *val, yyjs
     The value will hold either UINT or SINT or REAL number;
  @param flg The JSON read options.
     Multiple options can be combined with `|` operator. 0 means no options.
-    Suppors `YYJSON_READ_NUMBER_AS_RAW` and `YYJSON_READ_ALLOW_INF_AND_NAN`.
+    Supports `YYJSON_READ_NUMBER_AS_RAW` and `YYJSON_READ_ALLOW_INF_AND_NAN`.
  @param alc The memory allocator used for long number.
     It is only used when the built-in floating point reader is disabled.
     Pass NULL to use the libc's default allocator.
@@ -818,10 +1046,14 @@ yyjson_api const char *yyjson_read_number(const char *dat, yyjson_val *val, yyjs
  @return If successful, a pointer to the character after the last character
     used in the conversion, NULL if an error occurs.
  */
-yyjson_api_inline const char *yyjson_mut_read_number(const char *dat, yyjson_mut_val *val, yyjson_read_flag flg,
-                                                     const yyjson_alc *alc, yyjson_read_err *err) {
-	return yyjson_read_number(dat, (yyjson_val *)val, flg, alc, err);
+yyjson_api_inline const char *yyjson_mut_read_number(const char *dat,
+                                                     yyjson_mut_val *val,
+                                                     yyjson_read_flag flg,
+                                                     const yyjson_alc *alc,
+                                                     yyjson_read_err *err) {
+    return yyjson_read_number(dat, (yyjson_val *)val, flg, alc, err);
 }
+
 
 /*==============================================================================
  * JSON Writer API
@@ -835,69 +1067,77 @@ typedef uint32_t yyjson_write_flag;
     - Report error on inf or nan number.
     - Report error on invalid UTF-8 string.
     - Do not escape unicode or slash. */
-static const yyjson_write_flag YYJSON_WRITE_NOFLAG = 0 << 0;
+static const yyjson_write_flag YYJSON_WRITE_NOFLAG                  = 0;
 
 /** Write JSON pretty with 4 space indent. */
-static const yyjson_write_flag YYJSON_WRITE_PRETTY = 1 << 0;
+static const yyjson_write_flag YYJSON_WRITE_PRETTY                  = 1 << 0;
 
 /** Escape unicode as `uXXXX`, make the output ASCII only. */
-static const yyjson_write_flag YYJSON_WRITE_ESCAPE_UNICODE = 1 << 1;
+static const yyjson_write_flag YYJSON_WRITE_ESCAPE_UNICODE          = 1 << 1;
 
 /** Escape '/' as '\/'. */
-static const yyjson_write_flag YYJSON_WRITE_ESCAPE_SLASHES = 1 << 2;
+static const yyjson_write_flag YYJSON_WRITE_ESCAPE_SLASHES          = 1 << 2;
 
 /** Write inf and nan number as 'Infinity' and 'NaN' literal (non-standard). */
-static const yyjson_write_flag YYJSON_WRITE_ALLOW_INF_AND_NAN = 1 << 3;
+static const yyjson_write_flag YYJSON_WRITE_ALLOW_INF_AND_NAN       = 1 << 3;
 
 /** Write inf and nan number as null literal.
     This flag will override `YYJSON_WRITE_ALLOW_INF_AND_NAN` flag. */
-static const yyjson_write_flag YYJSON_WRITE_INF_AND_NAN_AS_NULL = 1 << 4;
+static const yyjson_write_flag YYJSON_WRITE_INF_AND_NAN_AS_NULL     = 1 << 4;
 
 /** Allow invalid unicode when encoding string values (non-standard).
     Invalid characters in string value will be copied byte by byte.
     If `YYJSON_WRITE_ESCAPE_UNICODE` flag is also set, invalid character will be
     escaped as `U+FFFD` (replacement character).
     This flag does not affect the performance of correctly encoded strings. */
-static const yyjson_write_flag YYJSON_WRITE_ALLOW_INVALID_UNICODE = 1 << 5;
+static const yyjson_write_flag YYJSON_WRITE_ALLOW_INVALID_UNICODE   = 1 << 5;
 
 /** Write JSON pretty with 2 space indent.
     This flag will override `YYJSON_WRITE_PRETTY` flag. */
-static const yyjson_write_flag YYJSON_WRITE_PRETTY_TWO_SPACES = 1 << 6;
+static const yyjson_write_flag YYJSON_WRITE_PRETTY_TWO_SPACES       = 1 << 6;
+
+/** Adds a newline character `\n` at the end of the JSON.
+    This can be helpful for text editors or NDJSON. */
+static const yyjson_write_flag YYJSON_WRITE_NEWLINE_AT_END          = 1 << 7;
+
+
 
 /** Result code for JSON writer */
 typedef uint32_t yyjson_write_code;
 
 /** Success, no error. */
-static const yyjson_write_code YYJSON_WRITE_SUCCESS = 0;
+static const yyjson_write_code YYJSON_WRITE_SUCCESS                     = 0;
 
 /** Invalid parameter, such as NULL document. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_PARAMETER = 1;
+static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_PARAMETER     = 1;
 
 /** Memory allocation failure occurs. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_MEMORY_ALLOCATION = 2;
+static const yyjson_write_code YYJSON_WRITE_ERROR_MEMORY_ALLOCATION     = 2;
 
 /** Invalid value type in JSON document. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_VALUE_TYPE = 3;
+static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_VALUE_TYPE    = 3;
 
 /** NaN or Infinity number occurs. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_NAN_OR_INF = 4;
+static const yyjson_write_code YYJSON_WRITE_ERROR_NAN_OR_INF            = 4;
 
 /** Failed to open a file. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_FILE_OPEN = 5;
+static const yyjson_write_code YYJSON_WRITE_ERROR_FILE_OPEN             = 5;
 
 /** Failed to write a file. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_FILE_WRITE = 6;
+static const yyjson_write_code YYJSON_WRITE_ERROR_FILE_WRITE            = 6;
 
 /** Invalid unicode in string. */
-static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_STRING = 7;
+static const yyjson_write_code YYJSON_WRITE_ERROR_INVALID_STRING        = 7;
 
 /** Error information for JSON writer. */
 typedef struct yyjson_write_err {
-	/** Error code, see `yyjson_write_code` for all possible values. */
-	yyjson_write_code code;
-	/** Error message, constant, no need to free (NULL if success). */
-	const char *msg;
+    /** Error code, see `yyjson_write_code` for all possible values. */
+    yyjson_write_code code;
+    /** Error message, constant, no need to free (NULL if success). */
+    const char *msg;
 } yyjson_write_err;
+
+
 
 /*==============================================================================
  * JSON Document Writer API
@@ -905,30 +1145,33 @@ typedef struct yyjson_write_err {
 
 /**
  Write a document to JSON string with options.
-
+ 
  This function is thread-safe when:
  The `alc` is thread-safe or NULL.
-
+ 
  @param doc The JSON document.
     If this doc is NULL or has no root, the function will fail and return false.
  @param flg The JSON write options.
     Multiple options can be combined with `|` operator. 0 means no options.
  @param alc The memory allocator used by JSON writer.
     Pass NULL to use the libc's default allocator.
- @param len A pointer to receive output length in bytes.
-    Pass NULL if you don't need length information.
+ @param len A pointer to receive output length in bytes (not including the
+    null-terminator). Pass NULL if you don't need length information.
  @param err A pointer to receive error information.
     Pass NULL if you don't need error information.
  @return A new JSON string, or NULL if an error occurs.
     This string is encoded as UTF-8 with a null-terminator.
     When it's no longer needed, it should be freed with free() or alc->free().
  */
-yyjson_api char *yyjson_write_opts(const yyjson_doc *doc, yyjson_write_flag flg, const yyjson_alc *alc, size_t *len,
+yyjson_api char *yyjson_write_opts(const yyjson_doc *doc,
+                                   yyjson_write_flag flg,
+                                   const yyjson_alc *alc,
+                                   size_t *len,
                                    yyjson_write_err *err);
 
 /**
  Write a document to JSON file with options.
-
+ 
  This function is thread-safe when:
  1. The file is not accessed by other threads.
  2. The `alc` is thread-safe or NULL.
@@ -945,34 +1188,65 @@ yyjson_api char *yyjson_write_opts(const yyjson_doc *doc, yyjson_write_flag flg,
  @param err A pointer to receive error information.
     Pass NULL if you don't need error information.
  @return true if successful, false if an error occurs.
-
+ 
  @warning On 32-bit operating system, files larger than 2GB may fail to write.
  */
-yyjson_api bool yyjson_write_file(const char *path, const yyjson_doc *doc, yyjson_write_flag flg, const yyjson_alc *alc,
+yyjson_api bool yyjson_write_file(const char *path,
+                                  const yyjson_doc *doc,
+                                  yyjson_write_flag flg,
+                                  const yyjson_alc *alc,
                                   yyjson_write_err *err);
 
 /**
- Write a document to JSON string.
-
- This function is thread-safe.
-
+ Write a document to file pointer with options.
+ 
+ @param fp The file pointer.
+    The data will be written to the current position of the file.
+    If this fp is NULL or invalid, the function will fail and return false.
  @param doc The JSON document.
     If this doc is NULL or has no root, the function will fail and return false.
  @param flg The JSON write options.
     Multiple options can be combined with `|` operator. 0 means no options.
- @param len A pointer to receive output length in bytes.
-    Pass NULL if you don't need length information.
+ @param alc The memory allocator used by JSON writer.
+    Pass NULL to use the libc's default allocator.
+ @param err A pointer to receive error information.
+    Pass NULL if you don't need error information.
+ @return true if successful, false if an error occurs.
+ 
+ @warning On 32-bit operating system, files larger than 2GB may fail to write.
+ */
+yyjson_api bool yyjson_write_fp(FILE *fp,
+                                const yyjson_doc *doc,
+                                yyjson_write_flag flg,
+                                const yyjson_alc *alc,
+                                yyjson_write_err *err);
+
+/**
+ Write a document to JSON string.
+ 
+ This function is thread-safe.
+ 
+ @param doc The JSON document.
+    If this doc is NULL or has no root, the function will fail and return false.
+ @param flg The JSON write options.
+    Multiple options can be combined with `|` operator. 0 means no options.
+ @param len A pointer to receive output length in bytes (not including the
+    null-terminator). Pass NULL if you don't need length information.
  @return A new JSON string, or NULL if an error occurs.
     This string is encoded as UTF-8 with a null-terminator.
     When it's no longer needed, it should be freed with free().
  */
-yyjson_api_inline char *yyjson_write(const yyjson_doc *doc, yyjson_write_flag flg, size_t *len) {
-	return yyjson_write_opts(doc, flg, NULL, len, NULL);
+yyjson_api_inline char *yyjson_write(const yyjson_doc *doc,
+                                     yyjson_write_flag flg,
+                                     size_t *len) {
+    return yyjson_write_opts(doc, flg, NULL, len, NULL);
 }
+
+
 
 /**
  Write a document to JSON string with options.
-
+ 
  This function is thread-safe when:
  1. The `doc` is not modified by other threads.
  2. The `alc` is thread-safe or NULL.
@@ -983,25 +1257,28 @@ yyjson_api_inline char *yyjson_write(const yyjson_doc *doc, yyjson_write_flag fl
     Multiple options can be combined with `|` operator. 0 means no options.
  @param alc The memory allocator used by JSON writer.
     Pass NULL to use the libc's default allocator.
- @param len A pointer to receive output length in bytes.
-    Pass NULL if you don't need length information.
+ @param len A pointer to receive output length in bytes (not including the
+    null-terminator). Pass NULL if you don't need length information.
  @param err A pointer to receive error information.
     Pass NULL if you don't need error information.
  @return A new JSON string, or NULL if an error occurs.
     This string is encoded as UTF-8 with a null-terminator.
     When it's no longer needed, it should be freed with free() or alc->free().
  */
-yyjson_api char *yyjson_mut_write_opts(const yyjson_mut_doc *doc, yyjson_write_flag flg, const yyjson_alc *alc,
-                                       size_t *len, yyjson_write_err *err);
+yyjson_api char *yyjson_mut_write_opts(const yyjson_mut_doc *doc,
+                                       yyjson_write_flag flg,
+                                       const yyjson_alc *alc,
+                                       size_t *len,
+                                       yyjson_write_err *err);
 
 /**
  Write a document to JSON file with options.
-
+ 
  This function is thread-safe when:
  1. The file is not accessed by other threads.
  2. The `doc` is not modified by other threads.
  3. The `alc` is thread-safe or NULL.
-
+ 
  @param path The JSON file's path.
     If this path is NULL or invalid, the function will fail and return false.
     If this file is not empty, the content will be discarded.
@@ -1014,31 +1291,62 @@ yyjson_api char *yyjson_mut_write_opts(const yyjson_mut_doc *doc, yyjson_write_f
  @param err A pointer to receive error information.
     Pass NULL if you don't need error information.
  @return true if successful, false if an error occurs.
-
+ 
  @warning On 32-bit operating system, files larger than 2GB may fail to write.
  */
-yyjson_api bool yyjson_mut_write_file(const char *path, const yyjson_mut_doc *doc, yyjson_write_flag flg,
-                                      const yyjson_alc *alc, yyjson_write_err *err);
+yyjson_api bool yyjson_mut_write_file(const char *path,
+                                      const yyjson_mut_doc *doc,
+                                      yyjson_write_flag flg,
+                                      const yyjson_alc *alc,
+                                      yyjson_write_err *err);
+
+/**
+ Write a document to file pointer with options.
+ 
+ @param fp The file pointer.
+    The data will be written to the current position of the file.
+    If this fp is NULL or invalid, the function will fail and return false.
+ @param doc The mutable JSON document.
+    If this doc is NULL or has no root, the function will fail and return false.
+ @param flg The JSON write options.
+    Multiple options can be combined with `|` operator. 0 means no options.
+ @param alc The memory allocator used by JSON writer.
+    Pass NULL to use the libc's default allocator.
+ @param err A pointer to receive error information.
+    Pass NULL if you don't need error information.
+ @return true if successful, false if an error occurs.
+ 
+ @warning On 32-bit operating system, files larger than 2GB may fail to write.
+ */
+yyjson_api bool yyjson_mut_write_fp(FILE *fp,
+                                    const yyjson_mut_doc *doc,
+                                    yyjson_write_flag flg,
+                                    const yyjson_alc *alc,
+                                    yyjson_write_err *err);
 
 /**
  Write a document to JSON string.
-
+ 
  This function is thread-safe when:
  The `doc` is not modified by other threads.
-
+ 
  @param doc The JSON document.
     If this doc is NULL or has no root, the function will fail and return false.
  @param flg The JSON write options.
     Multiple options can be combined with `|` operator. 0 means no options.
- @param len A pointer to receive output length in bytes.
-    Pass NULL if you don't need length information.
+ @param len A pointer to receive output length in bytes (not including the
+    null-terminator). Pass NULL if you don't need length information.
  @return A new JSON string, or NULL if an error occurs.
     This string is encoded as UTF-8 with a null-terminator.
     When it's no longer needed, it should be freed with free().
  */
-yyjson_api_inline char *yyjson_mut_write(const yyjson_mut_doc *doc, yyjson_write_flag flg, size_t *len) {
-	return yyjson_mut_write_opts(doc, flg, NULL, len, NULL);
+yyjson_api_inline char *yyjson_mut_write(const yyjson_mut_doc *doc,
+                                         yyjson_write_flag flg,
+                                         size_t *len) {
+    return yyjson_mut_write_opts(doc, flg, NULL, len, NULL);
 }
+
+
 
 /*==============================================================================
  * JSON Value Writer API
@@ -1046,34 +1354,37 @@ yyjson_api_inline char *yyjson_mut_write(const yyjson_mut_doc *doc, yyjson_write
 
 /**
  Write a value to JSON string with options.
-
+ 
  This function is thread-safe when:
  The `alc` is thread-safe or NULL.
-
+ 
  @param val The JSON root value.
     If this parameter is NULL, the function will fail and return NULL.
  @param flg The JSON write options.
     Multiple options can be combined with `|` operator. 0 means no options.
  @param alc The memory allocator used by JSON writer.
     Pass NULL to use the libc's default allocator.
- @param len A pointer to receive output length in bytes.
-    Pass NULL if you don't need length information.
+ @param len A pointer to receive output length in bytes (not including the
+    null-terminator). Pass NULL if you don't need length information.
  @param err A pointer to receive error information.
     Pass NULL if you don't need error information.
  @return A new JSON string, or NULL if an error occurs.
     This string is encoded as UTF-8 with a null-terminator.
     When it's no longer needed, it should be freed with free() or alc->free().
  */
-yyjson_api char *yyjson_val_write_opts(const yyjson_val *val, yyjson_write_flag flg, const yyjson_alc *alc, size_t *len,
+yyjson_api char *yyjson_val_write_opts(const yyjson_val *val,
+                                       yyjson_write_flag flg,
+                                       const yyjson_alc *alc,
+                                       size_t *len,
                                        yyjson_write_err *err);
 
 /**
  Write a value to JSON file with options.
-
+ 
  This function is thread-safe when:
  1. The file is not accessed by other threads.
  2. The `alc` is thread-safe or NULL.
-
+ 
  @param path The JSON file's path.
     If this path is NULL or invalid, the function will fail and return false.
     If this file is not empty, the content will be discarded.
@@ -1086,63 +1397,95 @@ yyjson_api char *yyjson_val_write_opts(const yyjson_val *val, yyjson_write_flag 
  @param err A pointer to receive error information.
     Pass NULL if you don't need error information.
  @return true if successful, false if an error occurs.
-
+ 
  @warning On 32-bit operating system, files larger than 2GB may fail to write.
  */
-yyjson_api bool yyjson_val_write_file(const char *path, const yyjson_val *val, yyjson_write_flag flg,
-                                      const yyjson_alc *alc, yyjson_write_err *err);
+yyjson_api bool yyjson_val_write_file(const char *path,
+                                      const yyjson_val *val,
+                                      yyjson_write_flag flg,
+                                      const yyjson_alc *alc,
+                                      yyjson_write_err *err);
 
 /**
- Write a value to JSON string.
-
- This function is thread-safe.
-
+ Write a value to file pointer with options.
+ 
+ @param fp The file pointer.
+    The data will be written to the current position of the file.
+    If this path is NULL or invalid, the function will fail and return false.
  @param val The JSON root value.
     If this parameter is NULL, the function will fail and return NULL.
  @param flg The JSON write options.
     Multiple options can be combined with `|` operator. 0 means no options.
- @param len A pointer to receive output length in bytes.
-    Pass NULL if you don't need length information.
+ @param alc The memory allocator used by JSON writer.
+    Pass NULL to use the libc's default allocator.
+ @param err A pointer to receive error information.
+    Pass NULL if you don't need error information.
+ @return true if successful, false if an error occurs.
+ 
+ @warning On 32-bit operating system, files larger than 2GB may fail to write.
+ */
+yyjson_api bool yyjson_val_write_fp(FILE *fp,
+                                    const yyjson_val *val,
+                                    yyjson_write_flag flg,
+                                    const yyjson_alc *alc,
+                                    yyjson_write_err *err);
+
+/**
+ Write a value to JSON string.
+ 
+ This function is thread-safe.
+ 
+ @param val The JSON root value.
+    If this parameter is NULL, the function will fail and return NULL.
+ @param flg The JSON write options.
+    Multiple options can be combined with `|` operator. 0 means no options.
+ @param len A pointer to receive output length in bytes (not including the
+    null-terminator). Pass NULL if you don't need length information.
  @return A new JSON string, or NULL if an error occurs.
     This string is encoded as UTF-8 with a null-terminator.
     When it's no longer needed, it should be freed with free().
  */
-yyjson_api_inline char *yyjson_val_write(const yyjson_val *val, yyjson_write_flag flg, size_t *len) {
-	return yyjson_val_write_opts(val, flg, NULL, len, NULL);
+yyjson_api_inline char *yyjson_val_write(const yyjson_val *val,
+                                         yyjson_write_flag flg,
+                                         size_t *len) {
+    return yyjson_val_write_opts(val, flg, NULL, len, NULL);
 }
 
 /**
  Write a value to JSON string with options.
-
+ 
  This function is thread-safe when:
  1. The `val` is not modified by other threads.
  2. The `alc` is thread-safe or NULL.
-
+ 
  @param val The mutable JSON root value.
     If this parameter is NULL, the function will fail and return NULL.
  @param flg The JSON write options.
     Multiple options can be combined with `|` operator. 0 means no options.
  @param alc The memory allocator used by JSON writer.
     Pass NULL to use the libc's default allocator.
- @param len A pointer to receive output length in bytes.
-    Pass NULL if you don't need length information.
+ @param len A pointer to receive output length in bytes (not including the
+    null-terminator). Pass NULL if you don't need length information.
  @param err A pointer to receive error information.
     Pass NULL if you don't need error information.
  @return  A new JSON string, or NULL if an error occurs.
     This string is encoded as UTF-8 with a null-terminator.
     When it's no longer needed, it should be freed with free() or alc->free().
  */
-yyjson_api char *yyjson_mut_val_write_opts(const yyjson_mut_val *val, yyjson_write_flag flg, const yyjson_alc *alc,
-                                           size_t *len, yyjson_write_err *err);
+yyjson_api char *yyjson_mut_val_write_opts(const yyjson_mut_val *val,
+                                           yyjson_write_flag flg,
+                                           const yyjson_alc *alc,
+                                           size_t *len,
+                                           yyjson_write_err *err);
 
 /**
  Write a value to JSON file with options.
-
+ 
  This function is thread-safe when:
  1. The file is not accessed by other threads.
  2. The `val` is not modified by other threads.
  3. The `alc` is thread-safe or NULL.
-
+ 
  @param path The JSON file's path.
     If this path is NULL or invalid, the function will fail and return false.
     If this file is not empty, the content will be discarded.
@@ -1155,31 +1498,62 @@ yyjson_api char *yyjson_mut_val_write_opts(const yyjson_mut_val *val, yyjson_wri
  @param err A pointer to receive error information.
     Pass NULL if you don't need error information.
  @return true if successful, false if an error occurs.
-
+ 
  @warning On 32-bit operating system, files larger than 2GB may fail to write.
  */
-yyjson_api bool yyjson_mut_val_write_file(const char *path, const yyjson_mut_val *val, yyjson_write_flag flg,
-                                          const yyjson_alc *alc, yyjson_write_err *err);
+yyjson_api bool yyjson_mut_val_write_file(const char *path,
+                                          const yyjson_mut_val *val,
+                                          yyjson_write_flag flg,
+                                          const yyjson_alc *alc,
+                                          yyjson_write_err *err);
+
+/**
+ Write a value to JSON file with options.
+ 
+ @param fp The file pointer.
+    The data will be written to the current position of the file.
+    If this path is NULL or invalid, the function will fail and return false.
+ @param val The mutable JSON root value.
+    If this parameter is NULL, the function will fail and return NULL.
+ @param flg The JSON write options.
+    Multiple options can be combined with `|` operator. 0 means no options.
+ @param alc The memory allocator used by JSON writer.
+    Pass NULL to use the libc's default allocator.
+ @param err A pointer to receive error information.
+    Pass NULL if you don't need error information.
+ @return true if successful, false if an error occurs.
+ 
+ @warning On 32-bit operating system, files larger than 2GB may fail to write.
+ */
+yyjson_api bool yyjson_mut_val_write_fp(FILE *fp,
+                                        const yyjson_mut_val *val,
+                                        yyjson_write_flag flg,
+                                        const yyjson_alc *alc,
+                                        yyjson_write_err *err);
 
 /**
  Write a value to JSON string.
-
+ 
  This function is thread-safe when:
  The `val` is not modified by other threads.
-
+ 
  @param val The JSON root value.
     If this parameter is NULL, the function will fail and return NULL.
  @param flg The JSON write options.
     Multiple options can be combined with `|` operator. 0 means no options.
- @param len A pointer to receive output length in bytes.
-    Pass NULL if you don't need length information.
+ @param len A pointer to receive output length in bytes (not including the
+    null-terminator). Pass NULL if you don't need length information.
  @return A new JSON string, or NULL if an error occurs.
     This string is encoded as UTF-8 with a null-terminator.
     When it's no longer needed, it should be freed with free().
  */
-yyjson_api_inline char *yyjson_mut_val_write(const yyjson_mut_val *val, yyjson_write_flag flg, size_t *len) {
-	return yyjson_mut_val_write_opts(val, flg, NULL, len, NULL);
+yyjson_api_inline char *yyjson_mut_val_write(const yyjson_mut_val *val,
+                                             yyjson_write_flag flg,
+                                             size_t *len) {
+    return yyjson_mut_val_write_opts(val, flg, NULL, len, NULL);
 }
+
+
 
 /*==============================================================================
  * JSON Document API
@@ -1203,6 +1577,8 @@ yyjson_api_inline size_t yyjson_doc_get_val_count(yyjson_doc *doc);
     After calling this function, the `doc` and all values from the `doc` are no
     longer available. This function will do nothing if the `doc` is NULL. */
 yyjson_api_inline void yyjson_doc_free(yyjson_doc *doc);
+
+
 
 /*==============================================================================
  * JSON Value Type API
@@ -1264,6 +1640,8 @@ yyjson_api_inline bool yyjson_is_obj(yyjson_val *val);
     Returns false if `val` is NULL. */
 yyjson_api_inline bool yyjson_is_ctn(yyjson_val *val);
 
+
+
 /*==============================================================================
  * JSON Value Content API
  *============================================================================*/
@@ -1309,6 +1687,10 @@ yyjson_api_inline int yyjson_get_int(yyjson_val *val);
     Returns 0.0 if `val` is NULL or type is not real(double). */
 yyjson_api_inline double yyjson_get_real(yyjson_val *val);
 
+/** Returns the content and typecast to `double` if the value is number.
+    Returns 0.0 if `val` is NULL or type is not number(uint/sint/real). */
+yyjson_api_inline double yyjson_get_num(yyjson_val *val);
+
 /** Returns the content if the value is string.
     Returns NULL if `val` is NULL or type is not string. */
 yyjson_api_inline const char *yyjson_get_str(yyjson_val *val);
@@ -1324,16 +1706,21 @@ yyjson_api_inline bool yyjson_equals_str(yyjson_val *val, const char *str);
 /** Returns whether the JSON value is equals to a string.
     The `str` should be a UTF-8 string, null-terminator is not required.
     Returns false if input is NULL or type is not string. */
-yyjson_api_inline bool yyjson_equals_strn(yyjson_val *val, const char *str, size_t len);
+yyjson_api_inline bool yyjson_equals_strn(yyjson_val *val, const char *str,
+                                          size_t len);
 
 /** Returns whether two JSON values are equal (deep compare).
-    Returns false if input is NULL. */
+    Returns false if input is NULL.
+    @note the result may be inaccurate if object has duplicate keys.
+    @warning This function is recursive and may cause a stack overflow
+        if the object level is too deep. */
 yyjson_api_inline bool yyjson_equals(yyjson_val *lhs, yyjson_val *rhs);
 
 /** Set the value to raw.
     Returns false if input is NULL or `val` is object or array.
     @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_raw(yyjson_val *val, const char *raw, size_t len);
+yyjson_api_inline bool yyjson_set_raw(yyjson_val *val,
+                                      const char *raw, size_t len);
 
 /** Set the value to null.
     Returns false if input is NULL or `val` is object or array.
@@ -1373,7 +1760,10 @@ yyjson_api_inline bool yyjson_set_str(yyjson_val *val, const char *str);
 /** Set the value to string (with length).
     Returns false if input is NULL or `val` is object or array.
     @warning This will modify the `immutable` value, use with caution. */
-yyjson_api_inline bool yyjson_set_strn(yyjson_val *val, const char *str, size_t len);
+yyjson_api_inline bool yyjson_set_strn(yyjson_val *val,
+                                       const char *str, size_t len);
+
+
 
 /*==============================================================================
  * JSON Array API
@@ -1399,37 +1789,54 @@ yyjson_api_inline yyjson_val *yyjson_arr_get_first(yyjson_val *arr);
         For example: `[1,{},3]` is flat, `[1,[2],3]` is not flat.*/
 yyjson_api_inline yyjson_val *yyjson_arr_get_last(yyjson_val *arr);
 
+
+
 /*==============================================================================
  * JSON Array Iterator API
  *============================================================================*/
 
 /**
  A JSON array iterator.
-
+ 
  @par Example
  @code
     yyjson_val *val;
-    yyjson_arr_iter iter;
-    yyjson_arr_iter_init(arr, &iter);
+    yyjson_arr_iter iter = yyjson_arr_iter_with(arr);
     while ((val = yyjson_arr_iter_next(&iter))) {
         your_func(val);
     }
  @endcode
  */
-typedef struct yyjson_arr_iter yyjson_arr_iter;
+typedef struct yyjson_arr_iter {
+    size_t idx; /**< next value's index */
+    size_t max; /**< maximum index (arr.size) */
+    yyjson_val *cur; /**< next value */
+} yyjson_arr_iter;
 
 /**
  Initialize an iterator for this array.
-
+ 
  @param arr The array to be iterated over.
     If this parameter is NULL or not an array, `iter` will be set to empty.
  @param iter The iterator to be initialized.
     If this parameter is NULL, the function will fail and return false.
  @return true if the `iter` has been successfully initialized.
-
+ 
  @note The iterator does not need to be destroyed.
  */
-yyjson_api_inline bool yyjson_arr_iter_init(yyjson_val *arr, yyjson_arr_iter *iter);
+yyjson_api_inline bool yyjson_arr_iter_init(yyjson_val *arr,
+                                            yyjson_arr_iter *iter);
+
+/**
+ Create an iterator with an array , same as `yyjson_arr_iter_init()`.
+ 
+ @param arr The array to be iterated over.
+    If this parameter is NULL or not an array, an empty iterator will returned.
+ @return A new iterator for the array.
+ 
+ @note The iterator does not need to be destroyed.
+ */
+yyjson_api_inline yyjson_arr_iter yyjson_arr_iter_with(yyjson_val *arr);
 
 /**
  Returns whether the iteration has more elements.
@@ -1446,7 +1853,7 @@ yyjson_api_inline yyjson_val *yyjson_arr_iter_next(yyjson_arr_iter *iter);
 /**
  Macro for iterating over an array.
  It works like iterator, but with a more intuitive API.
-
+ 
  @par Example
  @code
     size_t idx, max;
@@ -1456,9 +1863,15 @@ yyjson_api_inline yyjson_val *yyjson_arr_iter_next(yyjson_arr_iter *iter);
     }
  @endcode
  */
-#define yyjson_arr_foreach(arr, idx, max, val)                                                                         \
-	for ((idx) = 0, (max) = yyjson_arr_size(arr), (val) = yyjson_arr_get_first(arr); (idx) < (max);                    \
-	     (idx)++, (val) = unsafe_yyjson_get_next(val))
+#define yyjson_arr_foreach(arr, idx, max, val) \
+    for ((idx) = 0, \
+        (max) = yyjson_arr_size(arr), \
+        (val) = yyjson_arr_get_first(arr); \
+        (idx) < (max); \
+        (idx)++, \
+        (val) = unsafe_yyjson_get_next(val))
+
+
 
 /*==============================================================================
  * JSON Object API
@@ -1471,21 +1884,24 @@ yyjson_api_inline size_t yyjson_obj_size(yyjson_val *obj);
 /** Returns the value to which the specified key is mapped.
     Returns NULL if this object contains no mapping for the key.
     Returns NULL if `obj/key` is NULL, or type is not object.
-
+    
     The `key` should be a null-terminated UTF-8 string.
-
+    
     @warning This function takes a linear search time. */
 yyjson_api_inline yyjson_val *yyjson_obj_get(yyjson_val *obj, const char *key);
 
 /** Returns the value to which the specified key is mapped.
     Returns NULL if this object contains no mapping for the key.
     Returns NULL if `obj/key` is NULL, or type is not object.
-
+    
     The `key` should be a UTF-8 string, null-terminator is not required.
     The `key_len` should be the length of the key, in bytes.
-
+    
     @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_val *yyjson_obj_getn(yyjson_val *obj, const char *key, size_t key_len);
+yyjson_api_inline yyjson_val *yyjson_obj_getn(yyjson_val *obj, const char *key,
+                                              size_t key_len);
+
+
 
 /*==============================================================================
  * JSON Object Iterator API
@@ -1493,44 +1909,59 @@ yyjson_api_inline yyjson_val *yyjson_obj_getn(yyjson_val *obj, const char *key, 
 
 /**
  A JSON object iterator.
-
+ 
  @par Example
  @code
     yyjson_val *key, *val;
-    yyjson_obj_iter iter;
-    yyjson_obj_iter_init(obj, &iter);
+    yyjson_obj_iter iter = yyjson_obj_iter_with(obj);
     while ((key = yyjson_obj_iter_next(&iter))) {
         val = yyjson_obj_iter_get_val(key);
         your_func(key, val);
     }
  @endcode
-
+ 
  If the ordering of the keys is known at compile-time, you can use this method
  to speed up value lookups:
  @code
     // {"k1":1, "k2": 3, "k3": 3}
     yyjson_val *key, *val;
-    yyjson_obj_iter iter;
-    yyjson_obj_iter_init(obj, &iter);
+    yyjson_obj_iter iter = yyjson_obj_iter_with(obj);
     yyjson_val *v1 = yyjson_obj_iter_get(&iter, "k1");
     yyjson_val *v3 = yyjson_obj_iter_get(&iter, "k3");
  @endcode
  @see yyjson_obj_iter_get() and yyjson_obj_iter_getn()
  */
-typedef struct yyjson_obj_iter yyjson_obj_iter;
+typedef struct yyjson_obj_iter {
+    size_t idx; /**< next key's index */
+    size_t max; /**< maximum key index (obj.size) */
+    yyjson_val *cur; /**< next key */
+    yyjson_val *obj; /**< the object being iterated */
+} yyjson_obj_iter;
 
 /**
  Initialize an iterator for this object.
-
+ 
  @param obj The object to be iterated over.
     If this parameter is NULL or not an object, `iter` will be set to empty.
  @param iter The iterator to be initialized.
     If this parameter is NULL, the function will fail and return false.
  @return true if the `iter` has been successfully initialized.
-
+ 
  @note The iterator does not need to be destroyed.
  */
-yyjson_api_inline bool yyjson_obj_iter_init(yyjson_val *obj, yyjson_obj_iter *iter);
+yyjson_api_inline bool yyjson_obj_iter_init(yyjson_val *obj,
+                                            yyjson_obj_iter *iter);
+
+/**
+ Create an iterator with an object, same as `yyjson_obj_iter_init()`.
+ 
+ @param obj The object to be iterated over.
+    If this parameter is NULL or not an object, an empty iterator will returned.
+ @return A new iterator for the object.
+ 
+ @note The iterator does not need to be destroyed.
+ */
+yyjson_api_inline yyjson_obj_iter yyjson_obj_iter_with(yyjson_val *obj);
 
 /**
  Returns whether the iteration has more elements.
@@ -1552,21 +1983,22 @@ yyjson_api_inline yyjson_val *yyjson_obj_iter_get_val(yyjson_val *key);
 
 /**
  Iterates to a specified key and returns the value.
-
+ 
  This function does the same thing as `yyjson_obj_get()`, but is much faster
  if the ordering of the keys is known at compile-time and you are using the same
  order to look up the values. If the key exists in this object, then the
  iterator will stop at the next key, otherwise the iterator will not change and
  NULL is returned.
-
+ 
  @param iter The object iterator, should not be NULL.
  @param key The key, should be a UTF-8 string with null-terminator.
  @return The value to which the specified key is mapped.
     NULL if this object contains no mapping for the key or input is invalid.
-
+ 
  @warning This function takes a linear search time if the key is not nearby.
  */
-yyjson_api_inline yyjson_val *yyjson_obj_iter_get(yyjson_obj_iter *iter, const char *key);
+yyjson_api_inline yyjson_val *yyjson_obj_iter_get(yyjson_obj_iter *iter,
+                                                  const char *key);
 
 /**
  Iterates to a specified key and returns the value.
@@ -1576,21 +2008,23 @@ yyjson_api_inline yyjson_val *yyjson_obj_iter_get(yyjson_obj_iter *iter, const c
  order to look up the values. If the key exists in this object, then the
  iterator will stop at the next key, otherwise the iterator will not change and
  NULL is returned.
-
+ 
  @param iter The object iterator, should not be NULL.
  @param key The key, should be a UTF-8 string, null-terminator is not required.
  @param key_len The the length of `key`, in bytes.
  @return The value to which the specified key is mapped.
     NULL if this object contains no mapping for the key or input is invalid.
-
+ 
  @warning This function takes a linear search time if the key is not nearby.
  */
-yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter, const char *key, size_t key_len);
+yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter,
+                                                   const char *key,
+                                                   size_t key_len);
 
 /**
  Macro for iterating over an object.
  It works like iterator, but with a more intuitive API.
-
+ 
  @par Example
  @code
     size_t idx, max;
@@ -1600,10 +2034,17 @@ yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter, const 
     }
  @endcode
  */
-#define yyjson_obj_foreach(obj, idx, max, key, val)                                                                    \
-	for ((idx) = 0, (max) = yyjson_obj_size(obj), (key) = (obj) ? unsafe_yyjson_get_first(obj) : NULL,                 \
-	    (val) = (key) + 1;                                                                                             \
-	     (idx) < (max); (idx)++, (key) = unsafe_yyjson_get_next(val), (val) = (key) + 1)
+#define yyjson_obj_foreach(obj, idx, max, key, val) \
+    for ((idx) = 0, \
+        (max) = yyjson_obj_size(obj), \
+        (key) = (obj) ? unsafe_yyjson_get_first(obj) : NULL, \
+        (val) = (key) + 1; \
+        (idx) < (max); \
+        (idx)++, \
+        (key) = unsafe_yyjson_get_next(val), \
+        (val) = (key) + 1)
+
+
 
 /*==============================================================================
  * Mutable JSON Document API
@@ -1615,7 +2056,40 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_root(yyjson_mut_doc *doc);
 
 /** Sets the root value of this JSON document.
     Pass NULL to clear root value of the document. */
-yyjson_api_inline void yyjson_mut_doc_set_root(yyjson_mut_doc *doc, yyjson_mut_val *root);
+yyjson_api_inline void yyjson_mut_doc_set_root(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *root);
+
+/**
+ Set the string pool size for a mutable document.
+ This function does not allocate memory immediately, but uses the size when
+ the next memory allocation is needed.
+ 
+ If the caller knows the approximate bytes of strings that the document needs to
+ store (e.g. copy string with `yyjson_mut_strcpy` function), setting a larger
+ size can avoid multiple memory allocations and improve performance.
+ 
+ @param doc The mutable document.
+ @param len The desired string pool size in bytes (total string length).
+ @return true if successful, false if size is 0 or overflow.
+ */
+yyjson_api bool yyjson_mut_doc_set_str_pool_size(yyjson_mut_doc *doc,
+                                                 size_t len);
+
+/**
+ Set the value pool size for a mutable document.
+ This function does not allocate memory immediately, but uses the size when
+ the next memory allocation is needed.
+ 
+ If the caller knows the approximate number of values that the document needs to
+ store (e.g. create new value with `yyjson_mut_xxx` functions), setting a larger
+ size can avoid multiple memory allocations and improve performance.
+ 
+ @param doc The mutable document.
+ @param count The desired value pool size (number of `yyjson_mut_val`).
+ @return true if successful, false if size is 0 or overflow.
+ */
+yyjson_api bool yyjson_mut_doc_set_val_pool_size(yyjson_mut_doc *doc,
+                                                 size_t count);
 
 /** Release the JSON document and free the memory.
     After calling this function, the `doc` and all values from the `doc` are no
@@ -1630,19 +2104,22 @@ yyjson_api yyjson_mut_doc *yyjson_mut_doc_new(const yyjson_alc *alc);
     This makes a `deep-copy` on the immutable document.
     If allocator is NULL, the default allocator will be used.
     @note `imut_doc` -> `mut_doc`. */
-yyjson_api yyjson_mut_doc *yyjson_doc_mut_copy(yyjson_doc *doc, const yyjson_alc *alc);
+yyjson_api yyjson_mut_doc *yyjson_doc_mut_copy(yyjson_doc *doc,
+                                               const yyjson_alc *alc);
 
 /** Copies and returns a new mutable document from input, returns NULL on error.
     This makes a `deep-copy` on the mutable document.
     If allocator is NULL, the default allocator will be used.
     @note `mut_doc` -> `mut_doc`. */
-yyjson_api yyjson_mut_doc *yyjson_mut_doc_mut_copy(yyjson_mut_doc *doc, const yyjson_alc *alc);
+yyjson_api yyjson_mut_doc *yyjson_mut_doc_mut_copy(yyjson_mut_doc *doc,
+                                                   const yyjson_alc *alc);
 
 /** Copies and returns a new mutable value from input, returns NULL on error.
     This makes a `deep-copy` on the immutable value.
     The memory was managed by mutable document.
     @note `imut_val` -> `mut_val`. */
-yyjson_api yyjson_mut_val *yyjson_val_mut_copy(yyjson_mut_doc *doc, yyjson_val *val);
+yyjson_api yyjson_mut_val *yyjson_val_mut_copy(yyjson_mut_doc *doc,
+                                               yyjson_val *val);
 
 /** Copies and returns a new mutable value from input, returns NULL on error.
     This makes a `deep-copy` on the mutable value.
@@ -1650,7 +2127,8 @@ yyjson_api yyjson_mut_val *yyjson_val_mut_copy(yyjson_mut_doc *doc, yyjson_val *
     @note `mut_val` -> `mut_val`.
     @warning This function is recursive and may cause a stack overflow
         if the object level is too deep. */
-yyjson_api yyjson_mut_val *yyjson_mut_val_mut_copy(yyjson_mut_doc *doc, yyjson_mut_val *val);
+yyjson_api yyjson_mut_val *yyjson_mut_val_mut_copy(yyjson_mut_doc *doc,
+                                                   yyjson_mut_val *val);
 
 /** Copies and returns a new immutable document from input,
     returns NULL on error. This makes a `deep-copy` on the mutable document.
@@ -1658,7 +2136,8 @@ yyjson_api yyjson_mut_val *yyjson_mut_val_mut_copy(yyjson_mut_doc *doc, yyjson_m
     @note `mut_doc` -> `imut_doc`.
     @warning This function is recursive and may cause a stack overflow
         if the object level is too deep. */
-yyjson_api yyjson_doc *yyjson_mut_doc_imut_copy(yyjson_mut_doc *doc, const yyjson_alc *alc);
+yyjson_api yyjson_doc *yyjson_mut_doc_imut_copy(yyjson_mut_doc *doc,
+                                                const yyjson_alc *alc);
 
 /** Copies and returns a new immutable document from input,
     returns NULL on error. This makes a `deep-copy` on the mutable value.
@@ -1666,7 +2145,10 @@ yyjson_api yyjson_doc *yyjson_mut_doc_imut_copy(yyjson_mut_doc *doc, const yyjso
     @note `mut_val` -> `imut_doc`.
     @warning This function is recursive and may cause a stack overflow
         if the object level is too deep. */
-yyjson_api yyjson_doc *yyjson_mut_val_imut_copy(yyjson_mut_val *val, const yyjson_alc *alc);
+yyjson_api yyjson_doc *yyjson_mut_val_imut_copy(yyjson_mut_val *val,
+                                                const yyjson_alc *alc);
+
+
 
 /*==============================================================================
  * Mutable JSON Value Type API
@@ -1728,6 +2210,8 @@ yyjson_api_inline bool yyjson_mut_is_obj(yyjson_mut_val *val);
     Returns false if `val` is NULL. */
 yyjson_api_inline bool yyjson_mut_is_ctn(yyjson_mut_val *val);
 
+
+
 /*==============================================================================
  * Mutable JSON Value Content API
  *============================================================================*/
@@ -1773,6 +2257,10 @@ yyjson_api_inline int yyjson_mut_get_int(yyjson_mut_val *val);
     Returns 0.0 if `val` is NULL or type is not real(double). */
 yyjson_api_inline double yyjson_mut_get_real(yyjson_mut_val *val);
 
+/** Returns the content and typecast to `double` if the value is number.
+    Returns 0.0 if `val` is NULL or type is not number(uint/sint/real). */
+yyjson_api_inline double yyjson_mut_get_num(yyjson_mut_val *val);
+
 /** Returns the content if the value is string.
     Returns NULL if `val` is NULL or type is not string. */
 yyjson_api_inline const char *yyjson_mut_get_str(yyjson_mut_val *val);
@@ -1784,24 +2272,28 @@ yyjson_api_inline size_t yyjson_mut_get_len(yyjson_mut_val *val);
 /** Returns whether the JSON value is equals to a string.
     The `str` should be a null-terminated UTF-8 string.
     Returns false if input is NULL or type is not string. */
-yyjson_api_inline bool yyjson_mut_equals_str(yyjson_mut_val *val, const char *str);
+yyjson_api_inline bool yyjson_mut_equals_str(yyjson_mut_val *val,
+                                             const char *str);
 
 /** Returns whether the JSON value is equals to a string.
     The `str` should be a UTF-8 string, null-terminator is not required.
     Returns false if input is NULL or type is not string. */
-yyjson_api_inline bool yyjson_mut_equals_strn(yyjson_mut_val *val, const char *str, size_t len);
+yyjson_api_inline bool yyjson_mut_equals_strn(yyjson_mut_val *val,
+                                              const char *str, size_t len);
 
 /** Returns whether two JSON values are equal (deep compare).
     Returns false if input is NULL.
-
+    @note the result may be inaccurate if object has duplicate keys.
     @warning This function is recursive and may cause a stack overflow
         if the object level is too deep. */
-yyjson_api_inline bool yyjson_mut_equals(yyjson_mut_val *lhs, yyjson_mut_val *rhs);
+yyjson_api_inline bool yyjson_mut_equals(yyjson_mut_val *lhs,
+                                         yyjson_mut_val *rhs);
 
 /** Set the value to raw.
     Returns false if input is NULL.
     @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_raw(yyjson_mut_val *val, const char *raw, size_t len);
+yyjson_api_inline bool yyjson_mut_set_raw(yyjson_mut_val *val,
+                                          const char *raw, size_t len);
 
 /** Set the value to null.
     Returns false if input is NULL.
@@ -1841,7 +2333,8 @@ yyjson_api_inline bool yyjson_mut_set_str(yyjson_mut_val *val, const char *str);
 /** Set the value to string (with length).
     Returns false if input is NULL.
     @warning This function should not be used on an existing object or array. */
-yyjson_api_inline bool yyjson_mut_set_strn(yyjson_mut_val *val, const char *str, size_t len);
+yyjson_api_inline bool yyjson_mut_set_strn(yyjson_mut_val *val,
+                                           const char *str, size_t len);
 
 /** Set the value to array.
     Returns false if input is NULL.
@@ -1853,33 +2346,41 @@ yyjson_api_inline bool yyjson_mut_set_arr(yyjson_mut_val *val);
     @warning This function should not be used on an existing object or array. */
 yyjson_api_inline bool yyjson_mut_set_obj(yyjson_mut_val *val);
 
+
+
 /*==============================================================================
  * Mutable JSON Value Creation API
  *============================================================================*/
 
 /** Creates and returns a raw value, returns NULL on error.
     The `str` should be a null-terminated UTF-8 string.
-
+    
     @warning The input string is not copied, you should keep this string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc, const char *str);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc,
+                                                 const char *str);
 
 /** Creates and returns a raw value, returns NULL on error.
     The `str` should be a UTF-8 string, null-terminator is not required.
-
+    
     @warning The input string is not copied, you should keep this string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn(yyjson_mut_doc *doc, const char *str, size_t len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn(yyjson_mut_doc *doc,
+                                                  const char *str,
+                                                  size_t len);
 
 /** Creates and returns a raw value, returns NULL on error.
     The `str` should be a null-terminated UTF-8 string.
     The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy(yyjson_mut_doc *doc, const char *str);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy(yyjson_mut_doc *doc,
+                                                    const char *str);
 
 /** Creates and returns a raw value, returns NULL on error.
     The `str` should be a UTF-8 string, null-terminator is not required.
     The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy(yyjson_mut_doc *doc, const char *str, size_t len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy(yyjson_mut_doc *doc,
+                                                     const char *str,
+                                                     size_t len);
 
 /** Creates and returns a null value, returns NULL on error. */
 yyjson_api_inline yyjson_mut_val *yyjson_mut_null(yyjson_mut_doc *doc);
@@ -1891,41 +2392,54 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_true(yyjson_mut_doc *doc);
 yyjson_api_inline yyjson_mut_val *yyjson_mut_false(yyjson_mut_doc *doc);
 
 /** Creates and returns a bool value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_bool(yyjson_mut_doc *doc, bool val);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_bool(yyjson_mut_doc *doc,
+                                                  bool val);
 
 /** Creates and returns an unsigned integer value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_uint(yyjson_mut_doc *doc, uint64_t num);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_uint(yyjson_mut_doc *doc,
+                                                  uint64_t num);
 
 /** Creates and returns a signed integer value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_sint(yyjson_mut_doc *doc, int64_t num);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_sint(yyjson_mut_doc *doc,
+                                                  int64_t num);
 
 /** Creates and returns a signed integer value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_int(yyjson_mut_doc *doc, int64_t num);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_int(yyjson_mut_doc *doc,
+                                                 int64_t num);
 
 /** Creates and returns an real number value, returns NULL on error. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_real(yyjson_mut_doc *doc, double num);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_real(yyjson_mut_doc *doc,
+                                                  double num);
 
 /** Creates and returns a string value, returns NULL on error.
     The `str` should be a null-terminated UTF-8 string.
     @warning The input string is not copied, you should keep this string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_str(yyjson_mut_doc *doc, const char *str);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_str(yyjson_mut_doc *doc,
+                                                 const char *str);
 
 /** Creates and returns a string value, returns NULL on error.
     The `str` should be a UTF-8 string, null-terminator is not required.
     @warning The input string is not copied, you should keep this string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strn(yyjson_mut_doc *doc, const char *str, size_t len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_strn(yyjson_mut_doc *doc,
+                                                  const char *str,
+                                                  size_t len);
 
 /** Creates and returns a string value, returns NULL on error.
     The `str` should be a null-terminated UTF-8 string.
     The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strcpy(yyjson_mut_doc *doc, const char *str);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_strcpy(yyjson_mut_doc *doc,
+                                                    const char *str);
 
 /** Creates and returns a string value, returns NULL on error.
     The `str` should be a UTF-8 string, null-terminator is not required.
     The input string is copied and held by the document. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy(yyjson_mut_doc *doc, const char *str, size_t len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy(yyjson_mut_doc *doc,
+                                                     const char *str,
+                                                     size_t len);
+
+
 
 /*==============================================================================
  * Mutable JSON Array API
@@ -1938,7 +2452,8 @@ yyjson_api_inline size_t yyjson_mut_arr_size(yyjson_mut_val *arr);
 /** Returns the element at the specified position in this array.
     Returns NULL if array is NULL/empty or the index is out of bounds.
     @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get(yyjson_mut_val *arr, size_t idx);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get(yyjson_mut_val *arr,
+                                                     size_t idx);
 
 /** Returns the first element of this array.
     Returns NULL if `arr` is NULL/empty or type is not array. */
@@ -1948,21 +2463,22 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_first(yyjson_mut_val *arr);
     Returns NULL if `arr` is NULL/empty or type is not array. */
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_last(yyjson_mut_val *arr);
 
+
+
 /*==============================================================================
  * Mutable JSON Array Iterator API
  *============================================================================*/
 
 /**
  A mutable JSON array iterator.
-
+ 
  @warning You should not modify the array while iterating over it, but you can
     use `yyjson_mut_arr_iter_remove()` to remove current value.
-
+ 
  @par Example
  @code
     yyjson_mut_val *val;
-    yyjson_mut_arr_iter iter;
-    yyjson_mut_arr_iter_init(arr, &iter);
+    yyjson_mut_arr_iter iter = yyjson_mut_arr_iter_with(arr);
     while ((val = yyjson_mut_arr_iter_next(&iter))) {
         your_func(val);
         if (your_val_is_unused(val)) {
@@ -1971,45 +2487,67 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_last(yyjson_mut_val *arr);
     }
  @endcode
  */
-typedef struct yyjson_mut_arr_iter yyjson_mut_arr_iter;
+typedef struct yyjson_mut_arr_iter {
+    size_t idx; /**< next value's index */
+    size_t max; /**< maximum index (arr.size) */
+    yyjson_mut_val *cur; /**< current value */
+    yyjson_mut_val *pre; /**< previous value */
+    yyjson_mut_val *arr; /**< the array being iterated */
+} yyjson_mut_arr_iter;
 
 /**
  Initialize an iterator for this array.
-
+ 
  @param arr The array to be iterated over.
     If this parameter is NULL or not an array, `iter` will be set to empty.
  @param iter The iterator to be initialized.
     If this parameter is NULL, the function will fail and return false.
  @return true if the `iter` has been successfully initialized.
-
+ 
  @note The iterator does not need to be destroyed.
  */
-yyjson_api_inline bool yyjson_mut_arr_iter_init(yyjson_mut_val *arr, yyjson_mut_arr_iter *iter);
+yyjson_api_inline bool yyjson_mut_arr_iter_init(yyjson_mut_val *arr,
+    yyjson_mut_arr_iter *iter);
+
+/**
+ Create an iterator with an array , same as `yyjson_mut_arr_iter_init()`.
+ 
+ @param arr The array to be iterated over.
+    If this parameter is NULL or not an array, an empty iterator will returned.
+ @return A new iterator for the array.
+ 
+ @note The iterator does not need to be destroyed.
+ */
+yyjson_api_inline yyjson_mut_arr_iter yyjson_mut_arr_iter_with(
+    yyjson_mut_val *arr);
 
 /**
  Returns whether the iteration has more elements.
  If `iter` is NULL, this function will return false.
  */
-yyjson_api_inline bool yyjson_mut_arr_iter_has_next(yyjson_mut_arr_iter *iter);
+yyjson_api_inline bool yyjson_mut_arr_iter_has_next(
+    yyjson_mut_arr_iter *iter);
 
 /**
  Returns the next element in the iteration, or NULL on end.
  If `iter` is NULL, this function will return NULL.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next(yyjson_mut_arr_iter *iter);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next(
+    yyjson_mut_arr_iter *iter);
 
 /**
  Removes and returns current element in the iteration.
  If `iter` is NULL, this function will return NULL.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(yyjson_mut_arr_iter *iter);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(
+    yyjson_mut_arr_iter *iter);
 
 /**
  Macro for iterating over an array.
  It works like iterator, but with a more intuitive API.
-
+ 
  @warning You should not modify the array while iterating over it.
-
+ 
  @par Example
  @code
     size_t idx, max;
@@ -2019,9 +2557,15 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(yyjson_mut_arr_iter
     }
  @endcode
  */
-#define yyjson_mut_arr_foreach(arr, idx, max, val)                                                                     \
-	for ((idx) = 0, (max) = yyjson_mut_arr_size(arr), (val) = yyjson_mut_arr_get_first(arr); (idx) < (max);            \
-	     (idx)++, (val) = (val)->next)
+#define yyjson_mut_arr_foreach(arr, idx, max, val) \
+    for ((idx) = 0, \
+        (max) = yyjson_mut_arr_size(arr), \
+        (val) = yyjson_mut_arr_get_first(arr); \
+        (idx) < (max); \
+        (idx)++, \
+        (val) = (val)->next)
+
+
 
 /*==============================================================================
  * Mutable JSON Array Creation API
@@ -2036,246 +2580,260 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr(yyjson_mut_doc *doc);
 
 /**
  Creates and returns a new mutable array with the given boolean values.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of boolean values.
  @param count The value count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const bool vals[3] = { true, false, true };
     yyjson_mut_val *arr = yyjson_mut_arr_with_bool(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_bool(yyjson_mut_doc *doc, const bool *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_bool(
+    yyjson_mut_doc *doc, const bool *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given sint numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of sint numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const int64_t vals[3] = { -1, 0, 1 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_sint64(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint(yyjson_mut_doc *doc, const int64_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint(
+    yyjson_mut_doc *doc, const int64_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given uint numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of uint numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const uint64_t vals[3] = { 0, 1, 0 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_uint(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint(yyjson_mut_doc *doc, const uint64_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint(
+    yyjson_mut_doc *doc, const uint64_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given real numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of real numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const double vals[3] = { 0.1, 0.2, 0.3 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_real(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_real(yyjson_mut_doc *doc, const double *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_real(
+    yyjson_mut_doc *doc, const double *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given int8 numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of int8 numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const int8_t vals[3] = { -1, 0, 1 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_sint8(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint8(yyjson_mut_doc *doc, const int8_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint8(
+    yyjson_mut_doc *doc, const int8_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given int16 numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of int16 numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const int16_t vals[3] = { -1, 0, 1 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_sint16(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint16(yyjson_mut_doc *doc, const int16_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint16(
+    yyjson_mut_doc *doc, const int16_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given int32 numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of int32 numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const int32_t vals[3] = { -1, 0, 1 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_sint32(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint32(yyjson_mut_doc *doc, const int32_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint32(
+    yyjson_mut_doc *doc, const int32_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given int64 numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of int64 numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const int64_t vals[3] = { -1, 0, 1 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_sint64(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint64(yyjson_mut_doc *doc, const int64_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint64(
+    yyjson_mut_doc *doc, const int64_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given uint8 numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of uint8 numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const uint8_t vals[3] = { 0, 1, 0 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_uint8(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint8(yyjson_mut_doc *doc, const uint8_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint8(
+    yyjson_mut_doc *doc, const uint8_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given uint16 numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of uint16 numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const uint16_t vals[3] = { 0, 1, 0 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_uint16(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint16(yyjson_mut_doc *doc, const uint16_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint16(
+    yyjson_mut_doc *doc, const uint16_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given uint32 numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of uint32 numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const uint32_t vals[3] = { 0, 1, 0 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_uint32(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint32(yyjson_mut_doc *doc, const uint32_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint32(
+    yyjson_mut_doc *doc, const uint32_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given uint64 numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of uint64 numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
      const uint64_t vals[3] = { 0, 1, 0 };
      yyjson_mut_val *arr = yyjson_mut_arr_with_uint64(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint64(yyjson_mut_doc *doc, const uint64_t *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint64(
+    yyjson_mut_doc *doc, const uint64_t *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given float numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of float numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const float vals[3] = { -1.0f, 0.0f, 1.0f };
     yyjson_mut_val *arr = yyjson_mut_arr_with_float(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float(yyjson_mut_doc *doc, const float *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float(
+    yyjson_mut_doc *doc, const float *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given double numbers.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of double numbers.
  @param count The number count. If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const double vals[3] = { -1.0, 0.0, 1.0 };
     yyjson_mut_val *arr = yyjson_mut_arr_with_double(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double(yyjson_mut_doc *doc, const double *vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double(
+    yyjson_mut_doc *doc, const double *vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given strings, these strings
  will not be copied.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of UTF-8 null-terminator strings.
@@ -2283,23 +2841,24 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double(yyjson_mut_doc *doc
  @param count The number of values in `vals`.
     If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @warning The input strings are not copied, you should keep these strings
     unmodified for the lifetime of this JSON document. If these strings will be
     modified, you should use `yyjson_mut_arr_with_strcpy()` instead.
-
+ 
  @par Example
  @code
     const char *vals[3] = { "a", "b", "c" };
     yyjson_mut_val *arr = yyjson_mut_arr_with_str(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str(yyjson_mut_doc *doc, const char **vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str(
+    yyjson_mut_doc *doc, const char **vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given strings and string
  lengths, these strings will not be copied.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of UTF-8 strings, null-terminator is not required.
@@ -2308,11 +2867,11 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str(yyjson_mut_doc *doc, c
  @param count The number of strings in `vals`.
     If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @warning The input strings are not copied, you should keep these strings
     unmodified for the lifetime of this JSON document. If these strings will be
     modified, you should use `yyjson_mut_arr_with_strncpy()` instead.
-
+ 
  @par Example
  @code
     const char *vals[3] = { "a", "bb", "c" };
@@ -2320,13 +2879,13 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str(yyjson_mut_doc *doc, c
     yyjson_mut_val *arr = yyjson_mut_arr_with_strn(doc, vals, lens, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn(yyjson_mut_doc *doc, const char **vals, const size_t *lens,
-                                                           size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn(
+    yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count);
 
 /**
  Creates and returns a new mutable array with the given strings, these strings
  will be copied.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of UTF-8 null-terminator strings.
@@ -2334,19 +2893,20 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn(yyjson_mut_doc *doc, 
  @param count The number of values in `vals`.
     If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const char *vals[3] = { "a", "b", "c" };
     yyjson_mut_val *arr = yyjson_mut_arr_with_strcpy(doc, vals, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy(yyjson_mut_doc *doc, const char **vals, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy(
+    yyjson_mut_doc *doc, const char **vals, size_t count);
 
 /**
  Creates and returns a new mutable array with the given strings and string
  lengths, these strings will be copied.
-
+ 
  @param doc A mutable document, used for memory allocation only.
     If this parameter is NULL, the function will fail and return NULL.
  @param vals A C array of UTF-8 strings, null-terminator is not required.
@@ -2355,7 +2915,7 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy(yyjson_mut_doc *doc
  @param count The number of strings in `vals`.
     If this value is 0, an empty array will return.
  @return The new array. NULL if input is invalid or memory allocation failed.
-
+ 
  @par Example
  @code
     const char *vals[3] = { "a", "bb", "c" };
@@ -2363,8 +2923,10 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy(yyjson_mut_doc *doc
     yyjson_mut_val *arr = yyjson_mut_arr_with_strn(doc, vals, lens, 3);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy(yyjson_mut_doc *doc, const char **vals,
-                                                              const size_t *lens, size_t count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy(
+    yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count);
+
+
 
 /*==============================================================================
  * Mutable JSON Array Modification API
@@ -2380,7 +2942,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy(yyjson_mut_doc *do
  @return Whether successful.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr, yyjson_mut_val *val, size_t idx);
+yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr,
+                                             yyjson_mut_val *val, size_t idx);
 
 /**
  Inserts a value at the end of the array.
@@ -2389,7 +2952,8 @@ yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr, yyjson_mut_val
  @param val The value to be inserted. Returns false if it is NULL.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr, yyjson_mut_val *val);
+yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr,
+                                             yyjson_mut_val *val);
 
 /**
  Inserts a value at the head of the array.
@@ -2398,7 +2962,8 @@ yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr, yyjson_mut_val
  @param val The value to be inserted. Returns false if it is NULL.
  @return    Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr, yyjson_mut_val *val);
+yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr,
+                                              yyjson_mut_val *val);
 
 /**
  Replaces a value at index and returns old value.
@@ -2410,7 +2975,9 @@ yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr, yyjson_mut_va
  @return Old value, or NULL on error.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr, size_t idx, yyjson_mut_val *val);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr,
+                                                         size_t idx,
+                                                         yyjson_mut_val *val);
 
 /**
  Removes and returns a value at index.
@@ -2421,7 +2988,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr, si
  @return Old value, or NULL on error.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr, size_t idx);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr,
+                                                        size_t idx);
 
 /**
  Removes and returns the first value in this array.
@@ -2429,7 +2997,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr, siz
     Returns false if it is NULL or not an array.
  @return The first value, or NULL on error.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(yyjson_mut_val *arr);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(
+    yyjson_mut_val *arr);
 
 /**
  Removes and returns the last value in this array.
@@ -2437,7 +3006,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(yyjson_mut_val *ar
     Returns false if it is NULL or not an array.
  @return The last value, or NULL on error.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(yyjson_mut_val *arr);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(
+    yyjson_mut_val *arr);
 
 /**
  Removes all values within a specified range in the array.
@@ -2448,7 +3018,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(yyjson_mut_val *arr
  @return Whether successful.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline bool yyjson_mut_arr_remove_range(yyjson_mut_val *arr, size_t idx, size_t len);
+yyjson_api_inline bool yyjson_mut_arr_remove_range(yyjson_mut_val *arr,
+                                                   size_t idx, size_t len);
 
 /**
  Removes all values in this array.
@@ -2465,7 +3036,10 @@ yyjson_api_inline bool yyjson_mut_arr_clear(yyjson_mut_val *arr);
  @param idx Index (or times) to rotate.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline bool yyjson_mut_arr_rotate(yyjson_mut_val *arr, size_t idx);
+yyjson_api_inline bool yyjson_mut_arr_rotate(yyjson_mut_val *arr,
+                                             size_t idx);
+
+
 
 /*==============================================================================
  * Mutable JSON Array Modification Convenience API
@@ -2478,7 +3052,8 @@ yyjson_api_inline bool yyjson_mut_arr_rotate(yyjson_mut_val *arr, size_t idx);
  @param val The value to be inserted. Returns false if it is NULL.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_val(yyjson_mut_val *arr, yyjson_mut_val *val);
+yyjson_api_inline bool yyjson_mut_arr_add_val(yyjson_mut_val *arr,
+                                              yyjson_mut_val *val);
 
 /**
  Adds a `null` value at the end of the array.
@@ -2487,7 +3062,8 @@ yyjson_api_inline bool yyjson_mut_arr_add_val(yyjson_mut_val *arr, yyjson_mut_va
     Returns false if it is NULL or not an array.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc, yyjson_mut_val *arr);
+yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr);
 
 /**
  Adds a `true` value at the end of the array.
@@ -2496,7 +3072,8 @@ yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc, yyjson_mut_v
     Returns false if it is NULL or not an array.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc, yyjson_mut_val *arr);
+yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr);
 
 /**
  Adds a `false` value at the end of the array.
@@ -2505,7 +3082,8 @@ yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc, yyjson_mut_v
     Returns false if it is NULL or not an array.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc, yyjson_mut_val *arr);
+yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc,
+                                                yyjson_mut_val *arr);
 
 /**
  Adds a bool value at the end of the array.
@@ -2515,7 +3093,9 @@ yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc, yyjson_mut_
  @param val The bool value to be added.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc, yyjson_mut_val *arr, bool val);
+yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               bool val);
 
 /**
  Adds an unsigned integer value at the end of the array.
@@ -2525,7 +3105,9 @@ yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc, yyjson_mut_v
  @param num The number to be added.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc, yyjson_mut_val *arr, uint64_t num);
+yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               uint64_t num);
 
 /**
  Adds a signed integer value at the end of the array.
@@ -2535,7 +3117,9 @@ yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc, yyjson_mut_v
  @param num The number to be added.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc, yyjson_mut_val *arr, int64_t num);
+yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               int64_t num);
 
 /**
  Adds a integer value at the end of the array.
@@ -2545,7 +3129,9 @@ yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc, yyjson_mut_v
  @param num The number to be added.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc, yyjson_mut_val *arr, int64_t num);
+yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *arr,
+                                              int64_t num);
 
 /**
  Adds a double value at the end of the array.
@@ -2555,7 +3141,9 @@ yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc, yyjson_mut_va
  @param num The number to be added.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc, yyjson_mut_val *arr, double num);
+yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               double num);
 
 /**
  Adds a string value at the end of the array (no copy).
@@ -2567,7 +3155,9 @@ yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc, yyjson_mut_v
  @warning The input string is not copied, you should keep this string unmodified
     for the lifetime of this JSON document.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *str);
+yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *arr,
+                                              const char *str);
 
 /**
  Adds a string value at the end of the array (no copy).
@@ -2580,7 +3170,10 @@ yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc, yyjson_mut_va
  @warning The input string is not copied, you should keep this string unmodified
     for the lifetime of this JSON document.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *str, size_t len);
+yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               const char *str,
+                                               size_t len);
 
 /**
  Adds a string value at the end of the array (copied).
@@ -2590,7 +3183,9 @@ yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc, yyjson_mut_v
  @param str A null-terminated UTF-8 string.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *str);
+yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *arr,
+                                                 const char *str);
 
 /**
  Adds a string value at the end of the array (copied).
@@ -2601,7 +3196,9 @@ yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc, yyjson_mut
  @param len The length of the string, in bytes.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *str,
+yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  const char *str,
                                                   size_t len);
 
 /**
@@ -2611,7 +3208,8 @@ yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc, yyjson_mu
     Returns false if it is NULL or not an array.
  @return The new array, or NULL on error.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr(yyjson_mut_doc *doc, yyjson_mut_val *arr);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr(yyjson_mut_doc *doc,
+                                                         yyjson_mut_val *arr);
 
 /**
  Creates and adds a new object at the end of the array.
@@ -2620,7 +3218,10 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr(yyjson_mut_doc *doc, yy
     Returns false if it is NULL or not an array.
  @return The new object, or NULL on error.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj(yyjson_mut_doc *doc, yyjson_mut_val *arr);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj(yyjson_mut_doc *doc,
+                                                         yyjson_mut_val *arr);
+
+
 
 /*==============================================================================
  * Mutable JSON Object API
@@ -2633,21 +3234,26 @@ yyjson_api_inline size_t yyjson_mut_obj_size(yyjson_mut_val *obj);
 /** Returns the value to which the specified key is mapped.
     Returns NULL if this object contains no mapping for the key.
     Returns NULL if `obj/key` is NULL, or type is not object.
-
+    
     The `key` should be a null-terminated UTF-8 string.
-
+    
     @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_get(yyjson_mut_val *obj, const char *key);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_get(yyjson_mut_val *obj,
+                                                     const char *key);
 
 /** Returns the value to which the specified key is mapped.
     Returns NULL if this object contains no mapping for the key.
     Returns NULL if `obj/key` is NULL, or type is not object.
-
+    
     The `key` should be a UTF-8 string, null-terminator is not required.
     The `key_len` should be the length of the key, in bytes.
-
+    
     @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn(yyjson_mut_val *obj, const char *key, size_t key_len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn(yyjson_mut_val *obj,
+                                                      const char *key,
+                                                      size_t key_len);
+
+
 
 /*==============================================================================
  * Mutable JSON Object Iterator API
@@ -2655,15 +3261,14 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn(yyjson_mut_val *obj, const
 
 /**
  A mutable JSON object iterator.
-
+ 
  @warning You should not modify the object while iterating over it, but you can
     use `yyjson_mut_obj_iter_remove()` to remove current value.
-
+ 
  @par Example
  @code
     yyjson_mut_val *key, *val;
-    yyjson_mut_obj_iter iter;
-    yyjson_mut_obj_iter_init(obj, &iter);
+    yyjson_mut_obj_iter iter = yyjson_mut_obj_iter_with(obj);
     while ((key = yyjson_mut_obj_iter_next(&iter))) {
         val = yyjson_mut_obj_iter_get_val(key);
         your_func(key, val);
@@ -2672,101 +3277,125 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn(yyjson_mut_val *obj, const
         }
     }
  @endcode
-
+ 
  If the ordering of the keys is known at compile-time, you can use this method
  to speed up value lookups:
  @code
     // {"k1":1, "k2": 3, "k3": 3}
     yyjson_mut_val *key, *val;
-    yyjson_mut_obj_iter iter;
-    yyjson_mut_obj_iter_init(obj, &iter);
+    yyjson_mut_obj_iter iter = yyjson_mut_obj_iter_with(obj);
     yyjson_mut_val *v1 = yyjson_mut_obj_iter_get(&iter, "k1");
     yyjson_mut_val *v3 = yyjson_mut_obj_iter_get(&iter, "k3");
  @endcode
  @see `yyjson_mut_obj_iter_get()` and `yyjson_mut_obj_iter_getn()`
  */
-typedef struct yyjson_mut_obj_iter yyjson_mut_obj_iter;
+typedef struct yyjson_mut_obj_iter {
+    size_t idx; /**< next key's index */
+    size_t max; /**< maximum key index (obj.size) */
+    yyjson_mut_val *cur; /**< current key */
+    yyjson_mut_val *pre; /**< previous key */
+    yyjson_mut_val *obj; /**< the object being iterated */
+} yyjson_mut_obj_iter;
 
 /**
  Initialize an iterator for this object.
-
+ 
  @param obj The object to be iterated over.
     If this parameter is NULL or not an array, `iter` will be set to empty.
  @param iter The iterator to be initialized.
     If this parameter is NULL, the function will fail and return false.
  @return true if the `iter` has been successfully initialized.
-
+ 
  @note The iterator does not need to be destroyed.
  */
-yyjson_api_inline bool yyjson_mut_obj_iter_init(yyjson_mut_val *obj, yyjson_mut_obj_iter *iter);
+yyjson_api_inline bool yyjson_mut_obj_iter_init(yyjson_mut_val *obj,
+    yyjson_mut_obj_iter *iter);
+
+/**
+ Create an iterator with an object, same as `yyjson_obj_iter_init()`.
+ 
+ @param obj The object to be iterated over.
+    If this parameter is NULL or not an object, an empty iterator will returned.
+ @return A new iterator for the object.
+ 
+ @note The iterator does not need to be destroyed.
+ */
+yyjson_api_inline yyjson_mut_obj_iter yyjson_mut_obj_iter_with(
+    yyjson_mut_val *obj);
 
 /**
  Returns whether the iteration has more elements.
  If `iter` is NULL, this function will return false.
  */
-yyjson_api_inline bool yyjson_mut_obj_iter_has_next(yyjson_mut_obj_iter *iter);
+yyjson_api_inline bool yyjson_mut_obj_iter_has_next(
+    yyjson_mut_obj_iter *iter);
 
 /**
  Returns the next key in the iteration, or NULL on end.
  If `iter` is NULL, this function will return NULL.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_next(yyjson_mut_obj_iter *iter);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_next(
+    yyjson_mut_obj_iter *iter);
 
 /**
  Returns the value for key inside the iteration.
  If `iter` is NULL, this function will return NULL.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val(yyjson_mut_val *key);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val(
+    yyjson_mut_val *key);
 
 /**
- Removes and returns current key-value pair in the iteration.
+ Removes current key-value pair in the iteration, returns the removed value.
  If `iter` is NULL, this function will return NULL.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove(yyjson_mut_obj_iter *iter);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove(
+    yyjson_mut_obj_iter *iter);
 
 /**
  Iterates to a specified key and returns the value.
-
+ 
  This function does the same thing as `yyjson_mut_obj_get()`, but is much faster
  if the ordering of the keys is known at compile-time and you are using the same
  order to look up the values. If the key exists in this object, then the
  iterator will stop at the next key, otherwise the iterator will not change and
  NULL is returned.
-
+ 
  @param iter The object iterator, should not be NULL.
  @param key The key, should be a UTF-8 string with null-terminator.
  @return The value to which the specified key is mapped.
     NULL if this object contains no mapping for the key or input is invalid.
-
+ 
  @warning This function takes a linear search time if the key is not nearby.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get(yyjson_mut_obj_iter *iter, const char *key);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get(
+    yyjson_mut_obj_iter *iter, const char *key);
 
 /**
  Iterates to a specified key and returns the value.
-
+ 
  This function does the same thing as `yyjson_mut_obj_getn()` but is much faster
  if the ordering of the keys is known at compile-time and you are using the same
  order to look up the values. If the key exists in this object, then the
  iterator will stop at the next key, otherwise the iterator will not change and
  NULL is returned.
-
+ 
  @param iter The object iterator, should not be NULL.
  @param key The key, should be a UTF-8 string, null-terminator is not required.
  @param key_len The the length of `key`, in bytes.
  @return The value to which the specified key is mapped.
     NULL if this object contains no mapping for the key or input is invalid.
-
+ 
  @warning This function takes a linear search time if the key is not nearby.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(yyjson_mut_obj_iter *iter, const char *key, size_t key_len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(
+    yyjson_mut_obj_iter *iter, const char *key, size_t key_len);
 
 /**
  Macro for iterating over an object.
  It works like iterator, but with a more intuitive API.
-
+ 
  @warning You should not modify the object while iterating over it.
-
+ 
  @par Example
  @code
     size_t idx, max;
@@ -2776,10 +3405,17 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(yyjson_mut_obj_iter *
     }
  @endcode
  */
-#define yyjson_mut_obj_foreach(obj, idx, max, key, val)                                                                \
-	for ((idx) = 0, (max) = yyjson_mut_obj_size(obj),                                                                  \
-	    (key) = (max) ? ((yyjson_mut_val *)(obj)->uni.ptr)->next->next : NULL, (val) = (key) ? (key)->next : NULL;     \
-	     (idx) < (max); (idx)++, (key) = (val)->next, (val) = (key)->next)
+#define yyjson_mut_obj_foreach(obj, idx, max, key, val) \
+    for ((idx) = 0, \
+        (max) = yyjson_mut_obj_size(obj), \
+        (key) = (max) ? ((yyjson_mut_val *)(obj)->uni.ptr)->next->next : NULL, \
+        (val) = (key) ? (key)->next : NULL; \
+        (idx) < (max); \
+        (idx)++, \
+        (key) = (val)->next, \
+        (val) = (key)->next)
+
+
 
 /*==============================================================================
  * Mutable JSON Object Creation API
@@ -2792,10 +3428,10 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj(yyjson_mut_doc *doc);
  Creates and returns a mutable object with keys and values, returns NULL on
  error. The keys and values are not copied. The strings should be a
  null-terminated UTF-8 string.
-
+ 
  @warning The input string is not copied, you should keep this string
     unmodified for the lifetime of this JSON document.
-
+ 
  @par Example
  @code
     const char *keys[2] = { "id", "name" };
@@ -2803,24 +3439,30 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj(yyjson_mut_doc *doc);
     yyjson_mut_val *obj = yyjson_mut_obj_with_str(doc, keys, vals, 2);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc, const char **keys, const char **vals,
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc,
+                                                          const char **keys,
+                                                          const char **vals,
                                                           size_t count);
 
 /**
  Creates and returns a mutable object with key-value pairs and pair count,
  returns NULL on error. The keys and values are not copied. The strings should
  be a null-terminated UTF-8 string.
-
+ 
  @warning The input string is not copied, you should keep this string
     unmodified for the lifetime of this JSON document.
-
+ 
  @par Example
  @code
     const char *kv_pairs[4] = { "id", "01", "name", "Harry" };
     yyjson_mut_val *obj = yyjson_mut_obj_with_kv(doc, kv_pairs, 2);
  @endcode
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc, const char **kv_pairs, size_t pair_count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc,
+                                                         const char **kv_pairs,
+                                                         size_t pair_count);
+
+
 
 /*==============================================================================
  * Mutable JSON Object Modification API
@@ -2835,7 +3477,9 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc, co
  @param val The value to add to the object.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_obj_add(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val);
+yyjson_api_inline bool yyjson_mut_obj_add(yyjson_mut_val *obj,
+                                          yyjson_mut_val *key,
+                                          yyjson_mut_val *val);
 /**
  Sets a key-value pair at the end of the object.
  This function may remove all key-value pairs for the given key before add.
@@ -2846,7 +3490,9 @@ yyjson_api_inline bool yyjson_mut_obj_add(yyjson_mut_val *obj, yyjson_mut_val *k
     is same as `yyjson_mut_obj_remove()`.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_obj_put(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val);
+yyjson_api_inline bool yyjson_mut_obj_put(yyjson_mut_val *obj,
+                                          yyjson_mut_val *key,
+                                          yyjson_mut_val *val);
 
 /**
  Inserts a key-value pair to the object at the given position.
@@ -2858,7 +3504,10 @@ yyjson_api_inline bool yyjson_mut_obj_put(yyjson_mut_val *obj, yyjson_mut_val *k
  @param idx The index to which to insert the new pair.
  @return Whether successful.
  */
-yyjson_api_inline bool yyjson_mut_obj_insert(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val, size_t idx);
+yyjson_api_inline bool yyjson_mut_obj_insert(yyjson_mut_val *obj,
+                                             yyjson_mut_val *key,
+                                             yyjson_mut_val *val,
+                                             size_t idx);
 
 /**
  Removes all key-value pair from the object with given key.
@@ -2867,7 +3516,8 @@ yyjson_api_inline bool yyjson_mut_obj_insert(yyjson_mut_val *obj, yyjson_mut_val
  @return The first matched value, or NULL if no matched value.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove(yyjson_mut_val *obj, yyjson_mut_val *key);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove(yyjson_mut_val *obj,
+                                                        yyjson_mut_val *key);
 
 /**
  Removes all key-value pair from the object with given key.
@@ -2876,7 +3526,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove(yyjson_mut_val *obj, yyj
  @return The first matched value, or NULL if no matched value.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key(yyjson_mut_val *obj, const char *key);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key(
+    yyjson_mut_val *obj, const char *key);
 
 /**
  Removes all key-value pair from the object with given key.
@@ -2886,7 +3537,8 @@ yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key(yyjson_mut_val *obj,
  @return The first matched value, or NULL if no matched value.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_keyn(yyjson_mut_val *obj, const char *key, size_t key_len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_keyn(
+    yyjson_mut_val *obj, const char *key, size_t key_len);
 
 /**
  Removes all key-value pairs in this object.
@@ -2904,7 +3556,9 @@ yyjson_api_inline bool yyjson_mut_obj_clear(yyjson_mut_val *obj);
  @return Whether successful.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline bool yyjson_mut_obj_replace(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val);
+yyjson_api_inline bool yyjson_mut_obj_replace(yyjson_mut_val *obj,
+                                              yyjson_mut_val *key,
+                                              yyjson_mut_val *val);
 
 /**
  Rotates key-value pairs in the object for the given number of times.
@@ -2915,7 +3569,10 @@ yyjson_api_inline bool yyjson_mut_obj_replace(yyjson_mut_val *obj, yyjson_mut_va
  @return Whether successful.
  @warning This function takes a linear search time.
  */
-yyjson_api_inline bool yyjson_mut_obj_rotate(yyjson_mut_val *obj, size_t idx);
+yyjson_api_inline bool yyjson_mut_obj_rotate(yyjson_mut_val *obj,
+                                             size_t idx);
+
+
 
 /*==============================================================================
  * Mutable JSON Object Modification Convenience API
@@ -2924,95 +3581,116 @@ yyjson_api_inline bool yyjson_mut_obj_rotate(yyjson_mut_val *obj, size_t idx);
 /** Adds a `null` value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_null(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key);
+yyjson_api_inline bool yyjson_mut_obj_add_null(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *key);
 
 /** Adds a `true` value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_true(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key);
+yyjson_api_inline bool yyjson_mut_obj_add_true(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *key);
 
 /** Adds a `false` value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_false(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key);
+yyjson_api_inline bool yyjson_mut_obj_add_false(yyjson_mut_doc *doc,
+                                                yyjson_mut_val *obj,
+                                                const char *key);
 
 /** Adds a bool value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_bool(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, bool val);
+yyjson_api_inline bool yyjson_mut_obj_add_bool(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *key, bool val);
 
 /** Adds an unsigned integer value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_uint(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, uint64_t val);
+yyjson_api_inline bool yyjson_mut_obj_add_uint(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *key, uint64_t val);
 
 /** Adds a signed integer value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_sint(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, int64_t val);
+yyjson_api_inline bool yyjson_mut_obj_add_sint(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *key, int64_t val);
 
 /** Adds an int value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_int(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, int64_t val);
+yyjson_api_inline bool yyjson_mut_obj_add_int(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *obj,
+                                              const char *key, int64_t val);
 
 /** Adds a double value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_real(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, double val);
+yyjson_api_inline bool yyjson_mut_obj_add_real(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *key, double val);
 
 /** Adds a string value at the end of the object.
     The `key` and `val` should be null-terminated UTF-8 strings.
     This function allows duplicated key in one object.
-
-    @warning The key/value string are not copied, you should keep these strings
+    
+    @warning The key/value strings are not copied, you should keep these strings
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_str(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key,
-                                              const char *val);
+yyjson_api_inline bool yyjson_mut_obj_add_str(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *obj,
+                                              const char *key, const char *val);
 
 /** Adds a string value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     The `val` should be a UTF-8 string, null-terminator is not required.
     The `len` should be the length of the `val`, in bytes.
     This function allows duplicated key in one object.
-
-    @warning The key/value string are not copied, you should keep these strings
+    
+    @warning The key/value strings are not copied, you should keep these strings
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_strn(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key,
+yyjson_api_inline bool yyjson_mut_obj_add_strn(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *key,
                                                const char *val, size_t len);
 
 /** Adds a string value at the end of the object.
     The `key` and `val` should be null-terminated UTF-8 strings.
     The value string is copied.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_strcpy(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key,
+yyjson_api_inline bool yyjson_mut_obj_add_strcpy(yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *obj,
+                                                 const char *key,
                                                  const char *val);
 
 /** Adds a string value at the end of the object.
@@ -3020,139 +3698,783 @@ yyjson_api_inline bool yyjson_mut_obj_add_strcpy(yyjson_mut_doc *doc, yyjson_mut
     The `val` should be a UTF-8 string, null-terminator is not required.
     The `len` should be the length of the `val`, in bytes.
     This function allows duplicated key in one object.
-
-    @warning The key/value string are not copied, you should keep these strings
+    
+    @warning The key strings are not copied, you should keep these strings
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_strncpy(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key,
+yyjson_api_inline bool yyjson_mut_obj_add_strncpy(yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key,
                                                   const char *val, size_t len);
+
+/**
+ Creates and adds a new array to the target object.
+ The `key` should be a null-terminated UTF-8 string.
+ This function allows duplicated key in one object.
+ 
+ @warning The key string is not copied, you should keep these strings
+          unmodified for the lifetime of this JSON document.
+ @return The new array, or NULL on error.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_add_arr(yyjson_mut_doc *doc,
+                                                         yyjson_mut_val *obj,
+                                                         const char *key);
+
+/**
+ Creates and adds a new object to the target object.
+ The `key` should be a null-terminated UTF-8 string.
+ This function allows duplicated key in one object.
+ 
+ @warning The key string is not copied, you should keep these strings
+          unmodified for the lifetime of this JSON document.
+ @return The new object, or NULL on error.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_add_obj(yyjson_mut_doc *doc,
+                                                         yyjson_mut_val *obj,
+                                                         const char *key);
 
 /** Adds a JSON value at the end of the object.
     The `key` should be a null-terminated UTF-8 string.
     This function allows duplicated key in one object.
-
-    @warning The key string are not copied, you should keep the string
+    
+    @warning The key string is not copied, you should keep the string
         unmodified for the lifetime of this JSON document. */
-yyjson_api_inline bool yyjson_mut_obj_add_val(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key,
+yyjson_api_inline bool yyjson_mut_obj_add_val(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *obj,
+                                              const char *key,
                                               yyjson_mut_val *val);
 
 /** Removes all key-value pairs for the given key.
     Returns the first value to which the specified key is mapped or NULL if this
     object contains no mapping for the key.
     The `key` should be a null-terminated UTF-8 string.
-
+    
     @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_str(yyjson_mut_val *obj, const char *key);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_str(
+    yyjson_mut_val *obj, const char *key);
 
 /** Removes all key-value pairs for the given key.
     Returns the first value to which the specified key is mapped or NULL if this
     object contains no mapping for the key.
     The `key` should be a UTF-8 string, null-terminator is not required.
     The `len` should be the length of the key, in bytes.
-
+    
     @warning This function takes a linear search time. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_strn(yyjson_mut_val *obj, const char *key, size_t len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_strn(
+    yyjson_mut_val *obj, const char *key, size_t len);
 
 /** Replaces all matching keys with the new key.
     Returns true if at least one key was renamed.
     The `key` and `new_key` should be a null-terminated UTF-8 string.
     The `new_key` is copied and held by doc.
-
+    
     @warning This function takes a linear search time.
     If `new_key` already exists, it will cause duplicate keys.
  */
-yyjson_api_inline bool yyjson_mut_obj_rename_key(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key,
+yyjson_api_inline bool yyjson_mut_obj_rename_key(yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *obj,
+                                                 const char *key,
                                                  const char *new_key);
 
 /** Replaces all matching keys with the new key.
     Returns true if at least one key was renamed.
     The `key` and `new_key` should be a UTF-8 string,
     null-terminator is not required. The `new_key` is copied and held by doc.
-
+    
     @warning This function takes a linear search time.
     If `new_key` already exists, it will cause duplicate keys.
  */
-yyjson_api_inline bool yyjson_mut_obj_rename_keyn(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, size_t len,
-                                                  const char *new_key, size_t new_len);
+yyjson_api_inline bool yyjson_mut_obj_rename_keyn(yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key,
+                                                  size_t len,
+                                                  const char *new_key,
+                                                  size_t new_len);
+
+
 
 /*==============================================================================
- * JSON Pointer API
+ * JSON Pointer API (RFC 6901)
  * https://tools.ietf.org/html/rfc6901
  *============================================================================*/
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a null-terminated UTF-8 string.
+/** JSON Pointer error code. */
+typedef uint32_t yyjson_ptr_code;
 
-    Returns NULL if there's no matched value.
-    Returns NULL if `val/ptr` is NULL or `val` is not object. */
-yyjson_api_inline yyjson_val *yyjson_get_pointer(yyjson_val *val, const char *ptr);
+/** No JSON pointer error. */
+static const yyjson_ptr_code YYJSON_PTR_ERR_NONE = 0;
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `ptr`, in bytes.
+/** Invalid input parameter, such as NULL input. */
+static const yyjson_ptr_code YYJSON_PTR_ERR_PARAMETER = 1;
 
-    Returns NULL if there's no matched value.
-    Returns NULL if `val/ptr` is NULL or `val` is not object. */
-yyjson_api_inline yyjson_val *yyjson_get_pointern(yyjson_val *val, const char *ptr, size_t len);
+/** JSON pointer syntax error, such as invalid escape, token no prefix. */
+static const yyjson_ptr_code YYJSON_PTR_ERR_SYNTAX = 2;
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a null-terminated UTF-8 string.
+/** JSON pointer resolve failed, such as index out of range, key not found. */
+static const yyjson_ptr_code YYJSON_PTR_ERR_RESOLVE = 3;
 
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_val *yyjson_doc_get_pointer(yyjson_doc *doc, const char *ptr);
+/** Document's root is NULL, but it is required for the function call. */
+static const yyjson_ptr_code YYJSON_PTR_ERR_NULL_ROOT = 4;
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `ptr`, in bytes.
+/** Cannot set root as the target is not a document. */
+static const yyjson_ptr_code YYJSON_PTR_ERR_SET_ROOT = 5;
 
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_val *yyjson_doc_get_pointern(yyjson_doc *doc, const char *ptr, size_t len);
+/** The memory allocation failed and a new value could not be created. */
+static const yyjson_ptr_code YYJSON_PTR_ERR_MEMORY_ALLOCATION = 6;
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a null-terminated UTF-8 string.
+/** Error information for JSON pointer. */
+typedef struct yyjson_ptr_err {
+    /** Error code, see `yyjson_ptr_code` for all possible values. */
+    yyjson_ptr_code code;
+    /** Error message, constant, no need to free (NULL if no error). */
+    const char *msg;
+    /** Error byte position for input JSON pointer (0 if no error). */
+    size_t pos;
+} yyjson_ptr_err;
 
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointer(yyjson_mut_val *val, const char *ptr);
+/**
+ A context for JSON pointer operation.
+ 
+ This struct stores the context of JSON Pointer operation result. The struct
+ can be used with three helper functions: `ctx_append()`, `ctx_replace()`, and
+ `ctx_remove()`, which perform the corresponding operations on the container
+ without re-parsing the JSON Pointer.
+ 
+ For example:
+ @code
+    // doc before: {"a":[0,1,null]}
+    // ptr: "/a/2"
+    val = yyjson_mut_doc_ptr_getx(doc, ptr, strlen(ptr), &ctx, &err);
+    if (yyjson_is_null(val)) {
+        yyjson_ptr_ctx_remove(&ctx);
+    }
+    // doc after: {"a":[0,1]}
+ @endcode
+ */
+typedef struct yyjson_ptr_ctx {
+    /**
+     The container (parent) of the target value. It can be either an array or
+     an object. If the target location has no value, but all its parent
+     containers exist, and the target location can be used to insert a new
+     value, then `ctn` is the parent container of the target location.
+     Otherwise, `ctn` is NULL.
+     */
+    yyjson_mut_val *ctn;
+    /**
+     The previous sibling of the target value. It can be either a value in an
+     array or a key in an object. As the container is a `circular linked list`
+     of elements, `pre` is the previous node of the target value. If the
+     operation is `add` or `set`, then `pre` is the previous node of the new
+     value, not the original target value. If the target value does not exist,
+     `pre` is NULL.
+     */
+    yyjson_mut_val *pre;
+    /**
+     The removed value if the operation is `set`, `replace` or `remove`. It can
+     be used to restore the original state of the document if needed.
+     */
+    yyjson_mut_val *old;
+} yyjson_ptr_ctx;
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `ptr`, in bytes.
+/**
+ Get value by a JSON Pointer.
+ @param doc The JSON document to be queried.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @return The value referenced by the JSON pointer.
+    NULL if `doc` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_val *yyjson_doc_ptr_get(yyjson_doc *doc,
+                                                 const char *ptr);
 
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointern(yyjson_mut_val *val, const char *ptr, size_t len);
+/**
+ Get value by a JSON Pointer.
+ @param doc The JSON document to be queried.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @return The value referenced by the JSON pointer.
+    NULL if `doc` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_val *yyjson_doc_ptr_getn(yyjson_doc *doc,
+                                                  const char *ptr, size_t len);
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a null-terminated UTF-8 string.
+/**
+ Get value by a JSON Pointer.
+ @param doc The JSON document to be queried.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return The value referenced by the JSON pointer.
+    NULL if `doc` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_val *yyjson_doc_ptr_getx(yyjson_doc *doc,
+                                                  const char *ptr, size_t len,
+                                                  yyjson_ptr_err *err);
 
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(yyjson_mut_doc *doc, const char *ptr);
+/**
+ Get value by a JSON Pointer.
+ @param val The JSON value to be queried.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @return The value referenced by the JSON pointer.
+    NULL if `val` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_val *yyjson_ptr_get(yyjson_val *val,
+                                             const char *ptr);
 
-/** Get a JSON value with JSON Pointer (RFC 6901).
-    The `ptr` should be a UTF-8 string, null-terminator is not required.
-    The `len` should be the length of the `ptr`, in bytes.
+/**
+ Get value by a JSON Pointer.
+ @param val The JSON value to be queried.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @return The value referenced by the JSON pointer.
+    NULL if `val` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_val *yyjson_ptr_getn(yyjson_val *val,
+                                              const char *ptr, size_t len);
 
-    Returns NULL if there's no matched value. */
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointern(yyjson_mut_doc *doc, const char *ptr, size_t len);
+/**
+ Get value by a JSON Pointer.
+ @param val The JSON value to be queried.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return The value referenced by the JSON pointer.
+    NULL if `val` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_val *yyjson_ptr_getx(yyjson_val *val,
+                                              const char *ptr, size_t len,
+                                              yyjson_ptr_err *err);
+
+/**
+ Get value by a JSON Pointer.
+ @param doc The JSON document to be queried.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @return The value referenced by the JSON pointer.
+    NULL if `doc` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_get(yyjson_mut_doc *doc,
+                                                         const char *ptr);
+
+/**
+ Get value by a JSON Pointer.
+ @param doc The JSON document to be queried.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @return The value referenced by the JSON pointer.
+    NULL if `doc` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_getn(yyjson_mut_doc *doc,
+                                                          const char *ptr,
+                                                          size_t len);
+
+/**
+ Get value by a JSON Pointer.
+ @param doc The JSON document to be queried.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return The value referenced by the JSON pointer.
+    NULL if `doc` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_getx(yyjson_mut_doc *doc,
+                                                          const char *ptr,
+                                                          size_t len,
+                                                          yyjson_ptr_ctx *ctx,
+                                                          yyjson_ptr_err *err);
+
+/**
+ Get value by a JSON Pointer.
+ @param val The JSON value to be queried.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @return The value referenced by the JSON pointer.
+    NULL if `val` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_get(yyjson_mut_val *val,
+                                                     const char *ptr);
+
+/**
+ Get value by a JSON Pointer.
+ @param val The JSON value to be queried.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @return The value referenced by the JSON pointer.
+    NULL if `val` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_getn(yyjson_mut_val *val,
+                                                      const char *ptr,
+                                                      size_t len);
+
+/**
+ Get value by a JSON Pointer.
+ @param val The JSON value to be queried.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return The value referenced by the JSON pointer.
+    NULL if `val` or `ptr` is NULL, or the JSON pointer cannot be resolved.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_getx(yyjson_mut_val *val,
+                                                      const char *ptr,
+                                                      size_t len,
+                                                      yyjson_ptr_ctx *ctx,
+                                                      yyjson_ptr_err *err);
+
+/**
+ Add (insert) value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @param new_val The value to be added.
+ @return true if JSON pointer is valid and new value is added, false otherwise.
+ @note The parent nodes will be created if they do not exist.
+ */
+yyjson_api_inline bool yyjson_mut_doc_ptr_add(yyjson_mut_doc *doc,
+                                              const char *ptr,
+                                              yyjson_mut_val *new_val);
+
+/**
+ Add (insert) value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The value to be added.
+ @return true if JSON pointer is valid and new value is added, false otherwise.
+ @note The parent nodes will be created if they do not exist.
+ */
+yyjson_api_inline bool yyjson_mut_doc_ptr_addn(yyjson_mut_doc *doc,
+                                               const char *ptr, size_t len,
+                                               yyjson_mut_val *new_val);
+
+/**
+ Add (insert) value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The value to be added.
+ @param create_parent Whether to create parent nodes if not exist.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return true if JSON pointer is valid and new value is added, false otherwise.
+ */
+yyjson_api_inline bool yyjson_mut_doc_ptr_addx(yyjson_mut_doc *doc,
+                                               const char *ptr, size_t len,
+                                               yyjson_mut_val *new_val,
+                                               bool create_parent,
+                                               yyjson_ptr_ctx *ctx,
+                                               yyjson_ptr_err *err);
+
+/**
+ Add (insert) value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @param doc Only used to create new values when needed.
+ @param new_val The value to be added.
+ @return true if JSON pointer is valid and new value is added, false otherwise.
+ @note The parent nodes will be created if they do not exist.
+ */
+yyjson_api_inline bool yyjson_mut_ptr_add(yyjson_mut_val *val,
+                                          const char *ptr,
+                                          yyjson_mut_val *new_val,
+                                          yyjson_mut_doc *doc);
+
+/**
+ Add (insert) value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param doc Only used to create new values when needed.
+ @param new_val The value to be added.
+ @return true if JSON pointer is valid and new value is added, false otherwise.
+ @note The parent nodes will be created if they do not exist.
+ */
+yyjson_api_inline bool yyjson_mut_ptr_addn(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc);
+
+/**
+ Add (insert) value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param doc Only used to create new values when needed.
+ @param new_val The value to be added.
+ @param create_parent Whether to create parent nodes if not exist.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return true if JSON pointer is valid and new value is added, false otherwise.
+ */
+yyjson_api_inline bool yyjson_mut_ptr_addx(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc,
+                                           bool create_parent,
+                                           yyjson_ptr_ctx *ctx,
+                                           yyjson_ptr_err *err);
+
+/**
+ Set value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @param new_val The value to be set, pass NULL to remove.
+ @return true if JSON pointer is valid and new value is set, false otherwise.
+ @note The parent nodes will be created if they do not exist.
+    If the target value already exists, it will be replaced by the new value.
+ */
+yyjson_api_inline bool yyjson_mut_doc_ptr_set(yyjson_mut_doc *doc,
+                                              const char *ptr,
+                                              yyjson_mut_val *new_val);
+
+/**
+ Set value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The value to be set, pass NULL to remove.
+ @return true if JSON pointer is valid and new value is set, false otherwise.
+ @note The parent nodes will be created if they do not exist.
+    If the target value already exists, it will be replaced by the new value.
+ */
+yyjson_api_inline bool yyjson_mut_doc_ptr_setn(yyjson_mut_doc *doc,
+                                               const char *ptr, size_t len,
+                                               yyjson_mut_val *new_val);
+
+/**
+ Set value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The value to be set, pass NULL to remove.
+ @param create_parent Whether to create parent nodes if not exist.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return true if JSON pointer is valid and new value is set, false otherwise.
+ @note If the target value already exists, it will be replaced by the new value.
+ */
+yyjson_api_inline bool yyjson_mut_doc_ptr_setx(yyjson_mut_doc *doc,
+                                               const char *ptr, size_t len,
+                                               yyjson_mut_val *new_val,
+                                               bool create_parent,
+                                               yyjson_ptr_ctx *ctx,
+                                               yyjson_ptr_err *err);
+
+/**
+ Set value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @param new_val The value to be set, pass NULL to remove.
+ @param doc Only used to create new values when needed.
+ @return true if JSON pointer is valid and new value is set, false otherwise.
+ @note The parent nodes will be created if they do not exist.
+    If the target value already exists, it will be replaced by the new value.
+ */
+yyjson_api_inline bool yyjson_mut_ptr_set(yyjson_mut_val *val,
+                                          const char *ptr,
+                                          yyjson_mut_val *new_val,
+                                          yyjson_mut_doc *doc);
+
+/**
+ Set value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The value to be set, pass NULL to remove.
+ @param doc Only used to create new values when needed.
+ @return true if JSON pointer is valid and new value is set, false otherwise.
+ @note The parent nodes will be created if they do not exist.
+    If the target value already exists, it will be replaced by the new value.
+ */
+yyjson_api_inline bool yyjson_mut_ptr_setn(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc);
+
+/**
+ Set value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The value to be set, pass NULL to remove.
+ @param doc Only used to create new values when needed.
+ @param create_parent Whether to create parent nodes if not exist.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return true if JSON pointer is valid and new value is set, false otherwise.
+ @note If the target value already exists, it will be replaced by the new value.
+ */
+yyjson_api_inline bool yyjson_mut_ptr_setx(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc,
+                                           bool create_parent,
+                                           yyjson_ptr_ctx *ctx,
+                                           yyjson_ptr_err *err);
+
+/**
+ Replace value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @param new_val The new value to replace the old one.
+ @return The old value that was replaced, or NULL if not found.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_replace(
+    yyjson_mut_doc *doc, const char *ptr, yyjson_mut_val *new_val);
+
+/**
+ Replace value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The new value to replace the old one.
+ @return The old value that was replaced, or NULL if not found.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_replacen(
+    yyjson_mut_doc *doc, const char *ptr, size_t len, yyjson_mut_val *new_val);
+
+/**
+ Replace value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The new value to replace the old one.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return The old value that was replaced, or NULL if not found.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_replacex(
+    yyjson_mut_doc *doc, const char *ptr, size_t len, yyjson_mut_val *new_val,
+    yyjson_ptr_ctx *ctx, yyjson_ptr_err *err);
+
+/**
+ Replace value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @param new_val The new value to replace the old one.
+ @return The old value that was replaced, or NULL if not found.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_replace(
+    yyjson_mut_val *val, const char *ptr, yyjson_mut_val *new_val);
+
+/**
+ Replace value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The new value to replace the old one.
+ @return The old value that was replaced, or NULL if not found.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_replacen(
+    yyjson_mut_val *val, const char *ptr, size_t len, yyjson_mut_val *new_val);
+
+/**
+ Replace value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param new_val The new value to replace the old one.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return The old value that was replaced, or NULL if not found.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_replacex(
+    yyjson_mut_val *val, const char *ptr, size_t len, yyjson_mut_val *new_val,
+    yyjson_ptr_ctx *ctx, yyjson_ptr_err *err);
+
+/**
+ Remove value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @return The removed value, or NULL on error.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_remove(
+    yyjson_mut_doc *doc, const char *ptr);
+
+/**
+ Remove value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @return The removed value, or NULL on error.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_removen(
+    yyjson_mut_doc *doc, const char *ptr, size_t len);
+
+/**
+ Remove value by a JSON pointer.
+ @param doc The target JSON document.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return The removed value, or NULL on error.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_removex(
+    yyjson_mut_doc *doc, const char *ptr, size_t len,
+    yyjson_ptr_ctx *ctx, yyjson_ptr_err *err);
+
+/**
+ Remove value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8 with null-terminator).
+ @return The removed value, or NULL on error.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_remove(yyjson_mut_val *val,
+                                                        const char *ptr);
+
+/**
+ Remove value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @return The removed value, or NULL on error.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_removen(yyjson_mut_val *val,
+                                                         const char *ptr,
+                                                         size_t len);
+
+/**
+ Remove value by a JSON pointer.
+ @param val The target JSON value.
+ @param ptr The JSON pointer string (UTF-8, null-terminator is not required).
+ @param len The length of `ptr` in bytes.
+ @param ctx A pointer to store the result context, or NULL if not needed.
+ @param err A pointer to store the error information, or NULL if not needed.
+ @return The removed value, or NULL on error.
+ */
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_removex(yyjson_mut_val *val,
+                                                         const char *ptr,
+                                                         size_t len,
+                                                         yyjson_ptr_ctx *ctx,
+                                                         yyjson_ptr_err *err);
+
+/**
+ Append value by JSON pointer context.
+ @param ctx The context from the `yyjson_mut_ptr_xxx()` calls.
+ @param key New key if `ctx->ctn` is object, or NULL if `ctx->ctn` is array.
+ @param val New value to be added.
+ @return true on success or false on fail.
+ */
+yyjson_api_inline bool yyjson_ptr_ctx_append(yyjson_ptr_ctx *ctx,
+                                             yyjson_mut_val *key,
+                                             yyjson_mut_val *val);
+
+/**
+ Replace value by JSON pointer context.
+ @param ctx The context from the `yyjson_mut_ptr_xxx()` calls.
+ @param val New value to be replaced.
+ @return true on success or false on fail.
+ @note If success, the old value will be returned via `ctx->old`.
+ */
+yyjson_api_inline bool yyjson_ptr_ctx_replace(yyjson_ptr_ctx *ctx,
+                                              yyjson_mut_val *val);
+
+/**
+ Remove value by JSON pointer context.
+ @param ctx The context from the `yyjson_mut_ptr_xxx()` calls.
+ @return true on success or false on fail.
+ @note If success, the old value will be returned via `ctx->old`.
+ */
+yyjson_api_inline bool yyjson_ptr_ctx_remove(yyjson_ptr_ctx *ctx);
+
+
 
 /*==============================================================================
- * JSON Merge-Patch API
+ * JSON Patch API (RFC 6902)
+ * https://tools.ietf.org/html/rfc6902
+ *============================================================================*/
+
+/** Result code for JSON patch. */
+typedef uint32_t yyjson_patch_code;
+
+/** Success, no error. */
+static const yyjson_patch_code YYJSON_PATCH_SUCCESS = 0;
+
+/** Invalid parameter, such as NULL input or non-array patch. */
+static const yyjson_patch_code YYJSON_PATCH_ERROR_INVALID_PARAMETER = 1;
+
+/** Memory allocation failure occurs. */
+static const yyjson_patch_code YYJSON_PATCH_ERROR_MEMORY_ALLOCATION = 2;
+
+/** JSON patch operation is not object type. */
+static const yyjson_patch_code YYJSON_PATCH_ERROR_INVALID_OPERATION = 3;
+
+/** JSON patch operation is missing a required key. */
+static const yyjson_patch_code YYJSON_PATCH_ERROR_MISSING_KEY = 4;
+
+/** JSON patch operation member is invalid. */
+static const yyjson_patch_code YYJSON_PATCH_ERROR_INVALID_MEMBER = 5;
+
+/** JSON patch operation `test` not equal. */
+static const yyjson_patch_code YYJSON_PATCH_ERROR_EQUAL = 6;
+
+/** JSON patch operation failed on JSON pointer. */
+static const yyjson_patch_code YYJSON_PATCH_ERROR_POINTER = 7;
+
+/** Error information for JSON patch. */
+typedef struct yyjson_patch_err {
+    /** Error code, see `yyjson_patch_code` for all possible values. */
+    yyjson_patch_code code;
+    /** Index of the error operation (0 if no error). */
+    size_t idx;
+    /** Error message, constant, no need to free (NULL if no error). */
+    const char *msg;
+    /** JSON pointer error if `code == YYJSON_PATCH_ERROR_POINTER`. */
+    yyjson_ptr_err ptr;
+} yyjson_patch_err;
+
+/**
+ Creates and returns a patched JSON value (RFC 6902).
+ The memory of the returned value is allocated by the `doc`.
+ The `err` is used to receive error information, pass NULL if not needed.
+ Returns NULL if the patch could not be applied.
+ */
+yyjson_api yyjson_mut_val *yyjson_patch(yyjson_mut_doc *doc,
+                                        yyjson_val *orig,
+                                        yyjson_val *patch,
+                                        yyjson_patch_err *err);
+
+/**
+ Creates and returns a patched JSON value (RFC 6902).
+ The memory of the returned value is allocated by the `doc`.
+ The `err` is used to receive error information, pass NULL if not needed.
+ Returns NULL if the patch could not be applied.
+ */
+yyjson_api yyjson_mut_val *yyjson_mut_patch(yyjson_mut_doc *doc,
+                                            yyjson_mut_val *orig,
+                                            yyjson_mut_val *patch,
+                                            yyjson_patch_err *err);
+
+
+
+/*==============================================================================
+ * JSON Merge-Patch API (RFC 7386)
  * https://tools.ietf.org/html/rfc7386
  *============================================================================*/
 
-/** Creates and returns a merge-patched JSON value (RFC 7386).
-    The memory of the returned value is allocated by the `doc`.
-    Returns NULL if the patch could not be applied.
+/**
+ Creates and returns a merge-patched JSON value (RFC 7386).
+ The memory of the returned value is allocated by the `doc`.
+ Returns NULL if the patch could not be applied.
 
-    @warning This function is recursive and may cause a stack overflow if the
-        object level is too deep. */
-yyjson_api yyjson_mut_val *yyjson_merge_patch(yyjson_mut_doc *doc, yyjson_val *orig, yyjson_val *patch);
+ @warning This function is recursive and may cause a stack overflow if the
+    object level is too deep.
+ */
+yyjson_api yyjson_mut_val *yyjson_merge_patch(yyjson_mut_doc *doc,
+                                              yyjson_val *orig,
+                                              yyjson_val *patch);
 
-/** Creates and returns a merge-patched JSON value (RFC 7386).
-    The memory of the returned value is allocated by the `doc`.
-    Returns NULL if the patch could not be applied.
+/**
+ Creates and returns a merge-patched JSON value (RFC 7386).
+ The memory of the returned value is allocated by the `doc`.
+ Returns NULL if the patch could not be applied.
 
-    @warning This function is recursive and may cause a stack overflow if the
-        object level is too deep. */
-yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc, yyjson_mut_val *orig, yyjson_mut_val *patch);
+ @warning This function is recursive and may cause a stack overflow if the
+    object level is too deep.
+ */
+yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *orig,
+                                                  yyjson_mut_val *patch);
+
+
 
 /*==============================================================================
  * JSON Structure (Implementation)
@@ -3160,688 +4482,774 @@ yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc, yyjson_mu
 
 /** Payload of a JSON value (8 bytes). */
 typedef union yyjson_val_uni {
-	uint64_t u64;
-	int64_t i64;
-	double f64;
-	const char *str;
-	void *ptr;
-	size_t ofs;
+    uint64_t    u64;
+    int64_t     i64;
+    double      f64;
+    const char *str;
+    void       *ptr;
+    size_t      ofs;
 } yyjson_val_uni;
 
 /**
  Immutable JSON value, 16 bytes.
  */
 struct yyjson_val {
-	uint64_t tag;       /**< type, subtype and length */
-	yyjson_val_uni uni; /**< payload */
+    uint64_t tag; /**< type, subtype and length */
+    yyjson_val_uni uni; /**< payload */
 };
 
 struct yyjson_doc {
-	/** Root value of the document (nonnull). */
-	yyjson_val *root;
-	/** Allocator used by document (nonnull). */
-	yyjson_alc alc;
-	/** The total number of bytes read when parsing JSON (nonzero). */
-	size_t dat_read;
-	/** The total number of value read when parsing JSON (nonzero). */
-	size_t val_read;
-	/** The string pool used by JSON values (nullable). */
-	char *str_pool;
+    /** Root value of the document (nonnull). */
+    yyjson_val *root;
+    /** Allocator used by document (nonnull). */
+    yyjson_alc alc;
+    /** The total number of bytes read when parsing JSON (nonzero). */
+    size_t dat_read;
+    /** The total number of value read when parsing JSON (nonzero). */
+    size_t val_read;
+    /** The string pool used by JSON values (nullable). */
+    char *str_pool;
 };
+
+
 
 /*==============================================================================
  * Unsafe JSON Value API (Implementation)
  *============================================================================*/
 
+/*
+ Whether the string does not need to be escaped for serialization.
+ This function is used to optimize the writing speed of small constant strings.
+ This function works only if the compiler can evaluate it at compile time.
+ 
+ Clang supports it since v8.0,
+    earlier versions do not support constant_p(strlen) and return false.
+ GCC supports it since at least v4.4,
+    earlier versions may compile it as run-time instructions.
+ ICC supports it since at least v16,
+    earlier versions are uncertain.
+ 
+ @param str The C string.
+ @param len The returnd value from strlen(str).
+ */
+yyjson_api_inline bool unsafe_yyjson_is_str_noesc(const char *str, size_t len) {
+#if YYJSON_HAS_CONSTANT_P && \
+    (!YYJSON_IS_REAL_GCC || yyjson_gcc_available(4, 4, 0))
+    if (yyjson_constant_p(len) && len <= 32) {
+        /*
+         Same as the following loop:
+         
+         for (size_t i = 0; i < len; i++) {
+             char c = str[i];
+             if (c < ' ' || c > '~' || c == '"' || c == '\\') return false;
+         }
+         
+         GCC evaluates it at compile time only if the string length is within 17
+         and -O3 (which turns on the -fpeel-loops flag) is used.
+         So the loop is unrolled for GCC.
+         */
+#       define yyjson_repeat32_incr(x) \
+            x(0)  x(1)  x(2)  x(3)  x(4)  x(5)  x(6)  x(7)  \
+            x(8)  x(9)  x(10) x(11) x(12) x(13) x(14) x(15) \
+            x(16) x(17) x(18) x(19) x(20) x(21) x(22) x(23) \
+            x(24) x(25) x(26) x(27) x(28) x(29) x(30) x(31)
+#       define yyjson_check_char_noesc(i) \
+            if (i < len) { \
+                char c = str[i]; \
+                if (c < ' ' || c > '~' || c == '"' || c == '\\') return false; }
+        yyjson_repeat32_incr(yyjson_check_char_noesc)
+#       undef yyjson_repeat32_incr
+#       undef yyjson_check_char_noesc
+        return true;
+    }
+#else
+    (void)str;
+    (void)len;
+#endif
+    return false;
+}
+
 yyjson_api_inline yyjson_type unsafe_yyjson_get_type(void *val) {
-	uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
-	return (yyjson_type)(tag & YYJSON_TYPE_MASK);
+    uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
+    return (yyjson_type)(tag & YYJSON_TYPE_MASK);
 }
 
 yyjson_api_inline yyjson_subtype unsafe_yyjson_get_subtype(void *val) {
-	uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
-	return (yyjson_subtype)(tag & YYJSON_SUBTYPE_MASK);
+    uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
+    return (yyjson_subtype)(tag & YYJSON_SUBTYPE_MASK);
 }
 
 yyjson_api_inline uint8_t unsafe_yyjson_get_tag(void *val) {
-	uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
-	return (uint8_t)(tag & YYJSON_TAG_MASK);
+    uint8_t tag = (uint8_t)((yyjson_val *)val)->tag;
+    return (uint8_t)(tag & YYJSON_TAG_MASK);
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_raw(void *val) {
-	return unsafe_yyjson_get_type(val) == YYJSON_TYPE_RAW;
+    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_RAW;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_null(void *val) {
-	return unsafe_yyjson_get_type(val) == YYJSON_TYPE_NULL;
+    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_NULL;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_bool(void *val) {
-	return unsafe_yyjson_get_type(val) == YYJSON_TYPE_BOOL;
+    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_BOOL;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_num(void *val) {
-	return unsafe_yyjson_get_type(val) == YYJSON_TYPE_NUM;
+    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_NUM;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_str(void *val) {
-	return unsafe_yyjson_get_type(val) == YYJSON_TYPE_STR;
+    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_STR;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_arr(void *val) {
-	return unsafe_yyjson_get_type(val) == YYJSON_TYPE_ARR;
+    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_ARR;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_obj(void *val) {
-	return unsafe_yyjson_get_type(val) == YYJSON_TYPE_OBJ;
+    return unsafe_yyjson_get_type(val) == YYJSON_TYPE_OBJ;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_ctn(void *val) {
-	uint8_t mask = YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ;
-	return (unsafe_yyjson_get_tag(val) & mask) == mask;
+    uint8_t mask = YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ;
+    return (unsafe_yyjson_get_tag(val) & mask) == mask;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_uint(void *val) {
-	const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-	return unsafe_yyjson_get_tag(val) == patt;
+    const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+    return unsafe_yyjson_get_tag(val) == patt;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_sint(void *val) {
-	const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-	return unsafe_yyjson_get_tag(val) == patt;
+    const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+    return unsafe_yyjson_get_tag(val) == patt;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_int(void *val) {
-	const uint8_t mask = YYJSON_TAG_MASK & (~YYJSON_SUBTYPE_SINT);
-	const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-	return (unsafe_yyjson_get_tag(val) & mask) == patt;
+    const uint8_t mask = YYJSON_TAG_MASK & (~YYJSON_SUBTYPE_SINT);
+    const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+    return (unsafe_yyjson_get_tag(val) & mask) == patt;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_real(void *val) {
-	const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-	return unsafe_yyjson_get_tag(val) == patt;
+    const uint8_t patt = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+    return unsafe_yyjson_get_tag(val) == patt;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_true(void *val) {
-	const uint8_t patt = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
-	return unsafe_yyjson_get_tag(val) == patt;
+    const uint8_t patt = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
+    return unsafe_yyjson_get_tag(val) == patt;
 }
 
 yyjson_api_inline bool unsafe_yyjson_is_false(void *val) {
-	const uint8_t patt = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
-	return unsafe_yyjson_get_tag(val) == patt;
+    const uint8_t patt = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
+    return unsafe_yyjson_get_tag(val) == patt;
 }
 
 yyjson_api_inline bool unsafe_yyjson_arr_is_flat(yyjson_val *val) {
-	size_t ofs = val->uni.ofs;
-	size_t len = (size_t)(val->tag >> YYJSON_TAG_BIT);
-	return len * sizeof(yyjson_val) + sizeof(yyjson_val) == ofs;
+    size_t ofs = val->uni.ofs;
+    size_t len = (size_t)(val->tag >> YYJSON_TAG_BIT);
+    return len * sizeof(yyjson_val) + sizeof(yyjson_val) == ofs;
 }
 
 yyjson_api_inline const char *unsafe_yyjson_get_raw(void *val) {
-	return ((yyjson_val *)val)->uni.str;
+    return ((yyjson_val *)val)->uni.str;
 }
 
 yyjson_api_inline bool unsafe_yyjson_get_bool(void *val) {
-	uint8_t tag = unsafe_yyjson_get_tag(val);
-	return (bool)((tag & YYJSON_SUBTYPE_MASK) >> YYJSON_TYPE_BIT);
+    uint8_t tag = unsafe_yyjson_get_tag(val);
+    return (bool)((tag & YYJSON_SUBTYPE_MASK) >> YYJSON_TYPE_BIT);
 }
 
 yyjson_api_inline uint64_t unsafe_yyjson_get_uint(void *val) {
-	return ((yyjson_val *)val)->uni.u64;
+    return ((yyjson_val *)val)->uni.u64;
 }
 
 yyjson_api_inline int64_t unsafe_yyjson_get_sint(void *val) {
-	return ((yyjson_val *)val)->uni.i64;
+    return ((yyjson_val *)val)->uni.i64;
 }
 
 yyjson_api_inline int unsafe_yyjson_get_int(void *val) {
-	return (int)((yyjson_val *)val)->uni.i64;
+    return (int)((yyjson_val *)val)->uni.i64;
 }
 
 yyjson_api_inline double unsafe_yyjson_get_real(void *val) {
-	return ((yyjson_val *)val)->uni.f64;
+    return ((yyjson_val *)val)->uni.f64;
+}
+
+yyjson_api_inline double unsafe_yyjson_get_num(void *val) {
+    uint8_t tag = unsafe_yyjson_get_tag(val);
+    if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL)) {
+        return ((yyjson_val *)val)->uni.f64;
+    } else if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT)) {
+        return (double)((yyjson_val *)val)->uni.i64;
+    } else if (tag == (YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT)) {
+#if YYJSON_U64_TO_F64_NO_IMPL
+        uint64_t msb = ((uint64_t)1) << 63;
+        uint64_t num = ((yyjson_val *)val)->uni.u64;
+        if ((num & msb) == 0) {
+            return (double)(int64_t)num;
+        } else {
+            return ((double)(int64_t)((num >> 1) | (num & 1))) * (double)2.0;
+        }
+#else
+        return (double)((yyjson_val *)val)->uni.u64;
+#endif
+    }
+    return 0.0;
 }
 
 yyjson_api_inline const char *unsafe_yyjson_get_str(void *val) {
-	return ((yyjson_val *)val)->uni.str;
+    return ((yyjson_val *)val)->uni.str;
 }
 
 yyjson_api_inline size_t unsafe_yyjson_get_len(void *val) {
-	return (size_t)(((yyjson_val *)val)->tag >> YYJSON_TAG_BIT);
+    return (size_t)(((yyjson_val *)val)->tag >> YYJSON_TAG_BIT);
 }
 
 yyjson_api_inline yyjson_val *unsafe_yyjson_get_first(yyjson_val *ctn) {
-	return ctn + 1;
+    return ctn + 1;
 }
 
 yyjson_api_inline yyjson_val *unsafe_yyjson_get_next(yyjson_val *val) {
-	bool is_ctn = unsafe_yyjson_is_ctn(val);
-	size_t ctn_ofs = val->uni.ofs;
-	size_t ofs = (is_ctn ? ctn_ofs : sizeof(yyjson_val));
-	return (yyjson_val *)(void *)((uint8_t *)val + ofs);
+    bool is_ctn = unsafe_yyjson_is_ctn(val);
+    size_t ctn_ofs = val->uni.ofs;
+    size_t ofs = (is_ctn ? ctn_ofs : sizeof(yyjson_val));
+    return (yyjson_val *)(void *)((uint8_t *)val + ofs);
 }
 
-yyjson_api_inline bool unsafe_yyjson_equals_strn(void *val, const char *str, size_t len) {
-	uint64_t tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-	return ((yyjson_val *)val)->tag == tag && duckdb::FastMemcmp(((yyjson_val *)val)->uni.str, str, len) == 0;
+yyjson_api_inline bool unsafe_yyjson_equals_strn(void *val, const char *str,
+                                                 size_t len) {
+    return unsafe_yyjson_get_len(val) == len &&
+           memcmp(((yyjson_val *)val)->uni.str, str, len) == 0;
 }
 
 yyjson_api_inline bool unsafe_yyjson_equals_str(void *val, const char *str) {
-	return unsafe_yyjson_equals_strn(val, str, strlen(str));
+    return unsafe_yyjson_equals_strn(val, str, strlen(str));
 }
 
-yyjson_api_inline void unsafe_yyjson_set_type(void *val, yyjson_type type, yyjson_subtype subtype) {
-	uint8_t tag = (type | subtype);
-	uint64_t new_tag = ((yyjson_val *)val)->tag;
-	new_tag = (new_tag & (~(uint64_t)YYJSON_TAG_MASK)) | (uint64_t)tag;
-	((yyjson_val *)val)->tag = new_tag;
-}
-
-yyjson_api_inline void unsafe_yyjson_set_tag(void *val, uint8_t tag) {
-	uint64_t new_tag = ((yyjson_val *)val)->tag;
-	new_tag = (new_tag & (~(uint64_t)YYJSON_TAG_MASK)) | (uint64_t)tag;
-	((yyjson_val *)val)->tag = new_tag;
+yyjson_api_inline void unsafe_yyjson_set_type(void *val, yyjson_type type,
+                                              yyjson_subtype subtype) {
+    uint8_t tag = (type | subtype);
+    uint64_t new_tag = ((yyjson_val *)val)->tag;
+    new_tag = (new_tag & (~(uint64_t)YYJSON_TAG_MASK)) | (uint64_t)tag;
+    ((yyjson_val *)val)->tag = new_tag;
 }
 
 yyjson_api_inline void unsafe_yyjson_set_len(void *val, size_t len) {
-	uint64_t tag = ((yyjson_val *)val)->tag & YYJSON_TAG_MASK;
-	tag |= (uint64_t)len << YYJSON_TAG_BIT;
-	((yyjson_val *)val)->tag = tag;
+    uint64_t tag = ((yyjson_val *)val)->tag & YYJSON_TAG_MASK;
+    tag |= (uint64_t)len << YYJSON_TAG_BIT;
+    ((yyjson_val *)val)->tag = tag;
 }
 
-yyjson_api_inline void unsafe_yyjson_set_raw(void *val, const char *raw, size_t len) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_RAW, YYJSON_SUBTYPE_NONE);
-	unsafe_yyjson_set_len(val, len);
-	((yyjson_val *)val)->uni.str = raw;
+yyjson_api_inline void unsafe_yyjson_inc_len(void *val) {
+    uint64_t tag = ((yyjson_val *)val)->tag;
+    tag += (uint64_t)(1 << YYJSON_TAG_BIT);
+    ((yyjson_val *)val)->tag = tag;
+}
+
+yyjson_api_inline void unsafe_yyjson_set_raw(void *val, const char *raw,
+                                             size_t len) {
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_RAW, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len(val, len);
+    ((yyjson_val *)val)->uni.str = raw;
 }
 
 yyjson_api_inline void unsafe_yyjson_set_null(void *val) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_NULL, YYJSON_SUBTYPE_NONE);
-	unsafe_yyjson_set_len(val, 0);
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_NULL, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len(val, 0);
 }
 
 yyjson_api_inline void unsafe_yyjson_set_bool(void *val, bool num) {
-	yyjson_subtype subtype = num ? YYJSON_SUBTYPE_TRUE : YYJSON_SUBTYPE_FALSE;
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_BOOL, subtype);
-	unsafe_yyjson_set_len(val, 0);
+    yyjson_subtype subtype = num ? YYJSON_SUBTYPE_TRUE : YYJSON_SUBTYPE_FALSE;
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_BOOL, subtype);
+    unsafe_yyjson_set_len(val, 0);
 }
 
 yyjson_api_inline void unsafe_yyjson_set_uint(void *val, uint64_t num) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_UINT);
-	unsafe_yyjson_set_len(val, 0);
-	((yyjson_val *)val)->uni.u64 = num;
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_UINT);
+    unsafe_yyjson_set_len(val, 0);
+    ((yyjson_val *)val)->uni.u64 = num;
 }
 
 yyjson_api_inline void unsafe_yyjson_set_sint(void *val, int64_t num) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_SINT);
-	unsafe_yyjson_set_len(val, 0);
-	((yyjson_val *)val)->uni.i64 = num;
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_SINT);
+    unsafe_yyjson_set_len(val, 0);
+    ((yyjson_val *)val)->uni.i64 = num;
 }
 
 yyjson_api_inline void unsafe_yyjson_set_real(void *val, double num) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_REAL);
-	unsafe_yyjson_set_len(val, 0);
-	((yyjson_val *)val)->uni.f64 = num;
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_NUM, YYJSON_SUBTYPE_REAL);
+    unsafe_yyjson_set_len(val, 0);
+    ((yyjson_val *)val)->uni.f64 = num;
 }
 
 yyjson_api_inline void unsafe_yyjson_set_str(void *val, const char *str) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_STR, YYJSON_SUBTYPE_NONE);
-	unsafe_yyjson_set_len(val, strlen(str));
-	((yyjson_val *)val)->uni.str = str;
+    size_t len = strlen(str);
+    bool noesc = unsafe_yyjson_is_str_noesc(str, len);
+    yyjson_subtype sub = noesc ? YYJSON_SUBTYPE_NOESC : YYJSON_SUBTYPE_NONE;
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_STR, sub);
+    unsafe_yyjson_set_len(val, len);
+    ((yyjson_val *)val)->uni.str = str;
 }
 
-yyjson_api_inline void unsafe_yyjson_set_strn(void *val, const char *str, size_t len) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_STR, YYJSON_SUBTYPE_NONE);
-	unsafe_yyjson_set_len(val, len);
-	((yyjson_val *)val)->uni.str = str;
+yyjson_api_inline void unsafe_yyjson_set_strn(void *val, const char *str,
+                                              size_t len) {
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_STR, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len(val, len);
+    ((yyjson_val *)val)->uni.str = str;
 }
 
 yyjson_api_inline void unsafe_yyjson_set_arr(void *val, size_t size) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_ARR, YYJSON_SUBTYPE_NONE);
-	unsafe_yyjson_set_len(val, size);
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_ARR, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len(val, size);
 }
 
 yyjson_api_inline void unsafe_yyjson_set_obj(void *val, size_t size) {
-	unsafe_yyjson_set_type(val, YYJSON_TYPE_OBJ, YYJSON_SUBTYPE_NONE);
-	unsafe_yyjson_set_len(val, size);
+    unsafe_yyjson_set_type(val, YYJSON_TYPE_OBJ, YYJSON_SUBTYPE_NONE);
+    unsafe_yyjson_set_len(val, size);
 }
+
+
 
 /*==============================================================================
  * JSON Document API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline yyjson_val *yyjson_doc_get_root(yyjson_doc *doc) {
-	return doc ? doc->root : NULL;
+    return doc ? doc->root : NULL;
 }
 
 yyjson_api_inline size_t yyjson_doc_get_read_size(yyjson_doc *doc) {
-	return doc ? doc->dat_read : 0;
+    return doc ? doc->dat_read : 0;
 }
 
 yyjson_api_inline size_t yyjson_doc_get_val_count(yyjson_doc *doc) {
-	return doc ? doc->val_read : 0;
+    return doc ? doc->val_read : 0;
 }
 
 yyjson_api_inline void yyjson_doc_free(yyjson_doc *doc) {
-	if (doc) {
-		yyjson_alc alc = doc->alc;
-		if (doc->str_pool)
-			alc.free(alc.ctx, doc->str_pool);
-		alc.free(alc.ctx, doc);
-	}
+    if (doc) {
+        yyjson_alc alc = doc->alc;
+        memset(&doc->alc, 0, sizeof(alc));
+        if (doc->str_pool) alc.free(alc.ctx, doc->str_pool);
+        alc.free(alc.ctx, doc);
+    }
 }
+
+
 
 /*==============================================================================
  * JSON Value Type API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline bool yyjson_is_raw(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_raw(val) : false;
+    return val ? unsafe_yyjson_is_raw(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_null(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_null(val) : false;
+    return val ? unsafe_yyjson_is_null(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_true(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_true(val) : false;
+    return val ? unsafe_yyjson_is_true(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_false(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_false(val) : false;
+    return val ? unsafe_yyjson_is_false(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_bool(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_bool(val) : false;
+    return val ? unsafe_yyjson_is_bool(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_uint(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_uint(val) : false;
+    return val ? unsafe_yyjson_is_uint(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_sint(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_sint(val) : false;
+    return val ? unsafe_yyjson_is_sint(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_int(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_int(val) : false;
+    return val ? unsafe_yyjson_is_int(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_real(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_real(val) : false;
+    return val ? unsafe_yyjson_is_real(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_num(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_num(val) : false;
+    return val ? unsafe_yyjson_is_num(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_str(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_str(val) : false;
+    return val ? unsafe_yyjson_is_str(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_arr(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_arr(val) : false;
+    return val ? unsafe_yyjson_is_arr(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_obj(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_obj(val) : false;
+    return val ? unsafe_yyjson_is_obj(val) : false;
 }
 
 yyjson_api_inline bool yyjson_is_ctn(yyjson_val *val) {
-	return val ? unsafe_yyjson_is_ctn(val) : false;
+    return val ? unsafe_yyjson_is_ctn(val) : false;
 }
+
+
 
 /*==============================================================================
  * JSON Value Content API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline yyjson_type yyjson_get_type(yyjson_val *val) {
-	return val ? unsafe_yyjson_get_type(val) : YYJSON_TYPE_NONE;
+    return val ? unsafe_yyjson_get_type(val) : YYJSON_TYPE_NONE;
 }
 
 yyjson_api_inline yyjson_subtype yyjson_get_subtype(yyjson_val *val) {
-	return val ? unsafe_yyjson_get_subtype(val) : YYJSON_SUBTYPE_NONE;
+    return val ? unsafe_yyjson_get_subtype(val) : YYJSON_SUBTYPE_NONE;
 }
 
 yyjson_api_inline uint8_t yyjson_get_tag(yyjson_val *val) {
-	return val ? unsafe_yyjson_get_tag(val) : 0;
+    return val ? unsafe_yyjson_get_tag(val) : 0;
 }
 
 yyjson_api_inline const char *yyjson_get_type_desc(yyjson_val *val) {
-	switch (yyjson_get_tag(val)) {
-	case YYJSON_TYPE_RAW | YYJSON_SUBTYPE_NONE:
-		return "raw";
-	case YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE:
-		return "null";
-	case YYJSON_TYPE_STR | YYJSON_SUBTYPE_NONE:
-		return "string";
-	case YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE:
-		return "array";
-	case YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE:
-		return "object";
-	case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE:
-		return "true";
-	case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE:
-		return "false";
-	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT:
-		return "uint";
-	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT:
-		return "sint";
-	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL:
-		return "real";
-	default:
-		return "unknown";
-	}
+    switch (yyjson_get_tag(val)) {
+        case YYJSON_TYPE_RAW  | YYJSON_SUBTYPE_NONE:  return "raw";
+        case YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE:  return "null";
+        case YYJSON_TYPE_STR  | YYJSON_SUBTYPE_NONE:  return "string";
+        case YYJSON_TYPE_STR  | YYJSON_SUBTYPE_NOESC: return "string";
+        case YYJSON_TYPE_ARR  | YYJSON_SUBTYPE_NONE:  return "array";
+        case YYJSON_TYPE_OBJ  | YYJSON_SUBTYPE_NONE:  return "object";
+        case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE:  return "true";
+        case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE: return "false";
+        case YYJSON_TYPE_NUM  | YYJSON_SUBTYPE_UINT:  return "uint";
+        case YYJSON_TYPE_NUM  | YYJSON_SUBTYPE_SINT:  return "sint";
+        case YYJSON_TYPE_NUM  | YYJSON_SUBTYPE_REAL:  return "real";
+        default:                                      return "unknown";
+    }
 }
 
 yyjson_api_inline const char *yyjson_get_raw(yyjson_val *val) {
-	return yyjson_is_raw(val) ? unsafe_yyjson_get_raw(val) : NULL;
+    return yyjson_is_raw(val) ? unsafe_yyjson_get_raw(val) : NULL;
 }
 
 yyjson_api_inline bool yyjson_get_bool(yyjson_val *val) {
-	return yyjson_is_bool(val) ? unsafe_yyjson_get_bool(val) : false;
+    return yyjson_is_bool(val) ? unsafe_yyjson_get_bool(val) : false;
 }
 
 yyjson_api_inline uint64_t yyjson_get_uint(yyjson_val *val) {
-	return yyjson_is_int(val) ? unsafe_yyjson_get_uint(val) : 0;
+    return yyjson_is_int(val) ? unsafe_yyjson_get_uint(val) : 0;
 }
 
 yyjson_api_inline int64_t yyjson_get_sint(yyjson_val *val) {
-	return yyjson_is_int(val) ? unsafe_yyjson_get_sint(val) : 0;
+    return yyjson_is_int(val) ? unsafe_yyjson_get_sint(val) : 0;
 }
 
 yyjson_api_inline int yyjson_get_int(yyjson_val *val) {
-	return yyjson_is_int(val) ? unsafe_yyjson_get_int(val) : 0;
+    return yyjson_is_int(val) ? unsafe_yyjson_get_int(val) : 0;
 }
 
 yyjson_api_inline double yyjson_get_real(yyjson_val *val) {
-	return yyjson_is_real(val) ? unsafe_yyjson_get_real(val) : 0.0;
+    return yyjson_is_real(val) ? unsafe_yyjson_get_real(val) : 0.0;
+}
+
+yyjson_api_inline double yyjson_get_num(yyjson_val *val) {
+    return val ? unsafe_yyjson_get_num(val) : 0.0;
 }
 
 yyjson_api_inline const char *yyjson_get_str(yyjson_val *val) {
-	return yyjson_is_str(val) ? unsafe_yyjson_get_str(val) : NULL;
+    return yyjson_is_str(val) ? unsafe_yyjson_get_str(val) : NULL;
 }
 
 yyjson_api_inline size_t yyjson_get_len(yyjson_val *val) {
-	return val ? unsafe_yyjson_get_len(val) : 0;
+    return val ? unsafe_yyjson_get_len(val) : 0;
 }
 
 yyjson_api_inline bool yyjson_equals_str(yyjson_val *val, const char *str) {
-	if (yyjson_likely(val && str)) {
-		return unsafe_yyjson_equals_str(val, str);
-	}
-	return false;
+    if (yyjson_likely(val && str)) {
+        return unsafe_yyjson_is_str(val) &&
+               unsafe_yyjson_equals_str(val, str);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_equals_strn(yyjson_val *val, const char *str, size_t len) {
-	if (yyjson_likely(val && str)) {
-		return unsafe_yyjson_equals_strn(val, str, len);
-	}
-	return false;
+yyjson_api_inline bool yyjson_equals_strn(yyjson_val *val, const char *str,
+                                          size_t len) {
+    if (yyjson_likely(val && str)) {
+        return unsafe_yyjson_is_str(val) &&
+               unsafe_yyjson_equals_strn(val, str, len);
+    }
+    return false;
 }
 
 yyjson_api bool unsafe_yyjson_equals(yyjson_val *lhs, yyjson_val *rhs);
 
 yyjson_api_inline bool yyjson_equals(yyjson_val *lhs, yyjson_val *rhs) {
-	if (yyjson_unlikely(!lhs || !rhs))
-		return false;
-	return unsafe_yyjson_equals(lhs, rhs);
+    if (yyjson_unlikely(!lhs || !rhs)) return false;
+    return unsafe_yyjson_equals(lhs, rhs);
 }
 
-yyjson_api_inline bool yyjson_set_raw(yyjson_val *val, const char *raw, size_t len) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	unsafe_yyjson_set_raw(val, raw, len);
-	return true;
+yyjson_api_inline bool yyjson_set_raw(yyjson_val *val,
+                                      const char *raw, size_t len) {
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    unsafe_yyjson_set_raw(val, raw, len);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_set_null(yyjson_val *val) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	unsafe_yyjson_set_null(val);
-	return true;
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    unsafe_yyjson_set_null(val);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_set_bool(yyjson_val *val, bool num) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	unsafe_yyjson_set_bool(val, num);
-	return true;
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    unsafe_yyjson_set_bool(val, num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_set_uint(yyjson_val *val, uint64_t num) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	unsafe_yyjson_set_uint(val, num);
-	return true;
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    unsafe_yyjson_set_uint(val, num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_set_sint(yyjson_val *val, int64_t num) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	unsafe_yyjson_set_sint(val, num);
-	return true;
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    unsafe_yyjson_set_sint(val, num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_set_int(yyjson_val *val, int num) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	unsafe_yyjson_set_sint(val, (int64_t)num);
-	return true;
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    unsafe_yyjson_set_sint(val, (int64_t)num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_set_real(yyjson_val *val, double num) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	unsafe_yyjson_set_real(val, num);
-	return true;
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    unsafe_yyjson_set_real(val, num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_set_str(yyjson_val *val, const char *str) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	if (yyjson_unlikely(!str))
-		return false;
-	unsafe_yyjson_set_str(val, str);
-	return true;
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    if (yyjson_unlikely(!str)) return false;
+    unsafe_yyjson_set_str(val, str);
+    return true;
 }
 
-yyjson_api_inline bool yyjson_set_strn(yyjson_val *val, const char *str, size_t len) {
-	if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val)))
-		return false;
-	if (yyjson_unlikely(!str))
-		return false;
-	unsafe_yyjson_set_strn(val, str, len);
-	return true;
+yyjson_api_inline bool yyjson_set_strn(yyjson_val *val,
+                                       const char *str, size_t len) {
+    if (yyjson_unlikely(!val || unsafe_yyjson_is_ctn(val))) return false;
+    if (yyjson_unlikely(!str)) return false;
+    unsafe_yyjson_set_strn(val, str, len);
+    return true;
 }
+
+
 
 /*==============================================================================
  * JSON Array API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline size_t yyjson_arr_size(yyjson_val *arr) {
-	return yyjson_is_arr(arr) ? unsafe_yyjson_get_len(arr) : 0;
+    return yyjson_is_arr(arr) ? unsafe_yyjson_get_len(arr) : 0;
 }
 
 yyjson_api_inline yyjson_val *yyjson_arr_get(yyjson_val *arr, size_t idx) {
-	if (yyjson_likely(yyjson_is_arr(arr))) {
-		if (yyjson_likely(unsafe_yyjson_get_len(arr) > idx)) {
-			yyjson_val *val = unsafe_yyjson_get_first(arr);
-			if (unsafe_yyjson_arr_is_flat(arr)) {
-				return val + idx;
-			} else {
-				while (idx-- > 0)
-					val = unsafe_yyjson_get_next(val);
-				return val;
-			}
-		}
-	}
-	return NULL;
+    if (yyjson_likely(yyjson_is_arr(arr))) {
+        if (yyjson_likely(unsafe_yyjson_get_len(arr) > idx)) {
+            yyjson_val *val = unsafe_yyjson_get_first(arr);
+            if (unsafe_yyjson_arr_is_flat(arr)) {
+                return val + idx;
+            } else {
+                while (idx-- > 0) val = unsafe_yyjson_get_next(val);
+                return val;
+            }
+        }
+    }
+    return NULL;
 }
 
 yyjson_api_inline yyjson_val *yyjson_arr_get_first(yyjson_val *arr) {
-	if (yyjson_likely(yyjson_is_arr(arr))) {
-		if (yyjson_likely(unsafe_yyjson_get_len(arr) > 0)) {
-			return unsafe_yyjson_get_first(arr);
-		}
-	}
-	return NULL;
+    if (yyjson_likely(yyjson_is_arr(arr))) {
+        if (yyjson_likely(unsafe_yyjson_get_len(arr) > 0)) {
+            return unsafe_yyjson_get_first(arr);
+        }
+    }
+    return NULL;
 }
 
 yyjson_api_inline yyjson_val *yyjson_arr_get_last(yyjson_val *arr) {
-	if (yyjson_likely(yyjson_is_arr(arr))) {
-		size_t len = unsafe_yyjson_get_len(arr);
-		if (yyjson_likely(len > 0)) {
-			yyjson_val *val = unsafe_yyjson_get_first(arr);
-			if (unsafe_yyjson_arr_is_flat(arr)) {
-				return val + (len - 1);
-			} else {
-				while (len-- > 1)
-					val = unsafe_yyjson_get_next(val);
-				return val;
-			}
-		}
-	}
-	return NULL;
+    if (yyjson_likely(yyjson_is_arr(arr))) {
+        size_t len = unsafe_yyjson_get_len(arr);
+        if (yyjson_likely(len > 0)) {
+            yyjson_val *val = unsafe_yyjson_get_first(arr);
+            if (unsafe_yyjson_arr_is_flat(arr)) {
+                return val + (len - 1);
+            } else {
+                while (len-- > 1) val = unsafe_yyjson_get_next(val);
+                return val;
+            }
+        }
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * JSON Array Iterator API (Implementation)
  *============================================================================*/
 
-struct yyjson_arr_iter {
-	size_t idx;      /**< current index, from 0 */
-	size_t max;      /**< maximum index, idx < max */
-	yyjson_val *cur; /**< current value */
-};
+yyjson_api_inline bool yyjson_arr_iter_init(yyjson_val *arr,
+                                            yyjson_arr_iter *iter) {
+    if (yyjson_likely(yyjson_is_arr(arr) && iter)) {
+        iter->idx = 0;
+        iter->max = unsafe_yyjson_get_len(arr);
+        iter->cur = unsafe_yyjson_get_first(arr);
+        return true;
+    }
+    if (iter) memset(iter, 0, sizeof(yyjson_arr_iter));
+    return false;
+}
 
-yyjson_api_inline bool yyjson_arr_iter_init(yyjson_val *arr, yyjson_arr_iter *iter) {
-	if (yyjson_likely(yyjson_is_arr(arr) && iter)) {
-		iter->idx = 0;
-		iter->max = unsafe_yyjson_get_len(arr);
-		iter->cur = unsafe_yyjson_get_first(arr);
-		return true;
-	}
-	if (iter)
-		memset(iter, 0, sizeof(yyjson_arr_iter));
-	return false;
+yyjson_api_inline yyjson_arr_iter yyjson_arr_iter_with(yyjson_val *arr) {
+    yyjson_arr_iter iter;
+    yyjson_arr_iter_init(arr, &iter);
+    return iter;
 }
 
 yyjson_api_inline bool yyjson_arr_iter_has_next(yyjson_arr_iter *iter) {
-	return iter ? iter->idx < iter->max : false;
+    return iter ? iter->idx < iter->max : false;
 }
 
 yyjson_api_inline yyjson_val *yyjson_arr_iter_next(yyjson_arr_iter *iter) {
-	yyjson_val *val;
-	if (iter && iter->idx < iter->max) {
-		val = iter->cur;
-		iter->cur = unsafe_yyjson_get_next(val);
-		iter->idx++;
-		return val;
-	}
-	return NULL;
+    yyjson_val *val;
+    if (iter && iter->idx < iter->max) {
+        val = iter->cur;
+        iter->cur = unsafe_yyjson_get_next(val);
+        iter->idx++;
+        return val;
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * JSON Object API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline size_t yyjson_obj_size(yyjson_val *obj) {
-	return yyjson_is_obj(obj) ? unsafe_yyjson_get_len(obj) : 0;
+    return yyjson_is_obj(obj) ? unsafe_yyjson_get_len(obj) : 0;
 }
 
-yyjson_api_inline yyjson_val *yyjson_obj_get(yyjson_val *obj, const char *key) {
-	return yyjson_obj_getn(obj, key, key ? strlen(key) : 0);
+yyjson_api_inline yyjson_val *yyjson_obj_get(yyjson_val *obj,
+                                             const char *key) {
+    return yyjson_obj_getn(obj, key, key ? strlen(key) : 0);
 }
 
-yyjson_api_inline yyjson_val *yyjson_obj_getn(yyjson_val *obj, const char *_key, size_t key_len) {
-	uint64_t tag = (((uint64_t)key_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-	if (yyjson_likely(yyjson_is_obj(obj) && _key)) {
-		size_t len = unsafe_yyjson_get_len(obj);
-		yyjson_val *key = unsafe_yyjson_get_first(obj);
-		while (len-- > 0) {
-			if (key->tag == tag && duckdb::FastMemcmp(key->uni.ptr, _key, key_len) == 0) {
-				return key + 1;
-			}
-			key = unsafe_yyjson_get_next(key + 1);
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_val *yyjson_obj_getn(yyjson_val *obj,
+                                              const char *_key,
+                                              size_t key_len) {
+    if (yyjson_likely(yyjson_is_obj(obj) && _key)) {
+        size_t len = unsafe_yyjson_get_len(obj);
+        yyjson_val *key = unsafe_yyjson_get_first(obj);
+        while (len-- > 0) {
+            if (unsafe_yyjson_equals_strn(key, _key, key_len)) return key + 1;
+            key = unsafe_yyjson_get_next(key + 1);
+        }
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * JSON Object Iterator API (Implementation)
  *============================================================================*/
 
-struct yyjson_obj_iter {
-	size_t idx;      /**< current key index, from 0 */
-	size_t max;      /**< maximum key index, idx < max */
-	yyjson_val *cur; /**< current key */
-	yyjson_val *obj; /**< the object being iterated */
-};
+yyjson_api_inline bool yyjson_obj_iter_init(yyjson_val *obj,
+                                            yyjson_obj_iter *iter) {
+    if (yyjson_likely(yyjson_is_obj(obj) && iter)) {
+        iter->idx = 0;
+        iter->max = unsafe_yyjson_get_len(obj);
+        iter->cur = unsafe_yyjson_get_first(obj);
+        iter->obj = obj;
+        return true;
+    }
+    if (iter) memset(iter, 0, sizeof(yyjson_obj_iter));
+    return false;
+}
 
-yyjson_api_inline bool yyjson_obj_iter_init(yyjson_val *obj, yyjson_obj_iter *iter) {
-	if (yyjson_likely(yyjson_is_obj(obj) && iter)) {
-		iter->idx = 0;
-		iter->max = unsafe_yyjson_get_len(obj);
-		iter->cur = unsafe_yyjson_get_first(obj);
-		iter->obj = obj;
-		return true;
-	}
-	if (iter)
-		memset(iter, 0, sizeof(yyjson_obj_iter));
-	return false;
+yyjson_api_inline yyjson_obj_iter yyjson_obj_iter_with(yyjson_val *obj) {
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(obj, &iter);
+    return iter;
 }
 
 yyjson_api_inline bool yyjson_obj_iter_has_next(yyjson_obj_iter *iter) {
-	return iter ? iter->idx < iter->max : false;
+    return iter ? iter->idx < iter->max : false;
 }
 
 yyjson_api_inline yyjson_val *yyjson_obj_iter_next(yyjson_obj_iter *iter) {
-	if (iter && iter->idx < iter->max) {
-		yyjson_val *key = iter->cur;
-		iter->idx++;
-		iter->cur = unsafe_yyjson_get_next(key + 1);
-		return key;
-	}
-	return NULL;
+    if (iter && iter->idx < iter->max) {
+        yyjson_val *key = iter->cur;
+        iter->idx++;
+        iter->cur = unsafe_yyjson_get_next(key + 1);
+        return key;
+    }
+    return NULL;
 }
 
 yyjson_api_inline yyjson_val *yyjson_obj_iter_get_val(yyjson_val *key) {
-	return key ? key + 1 : NULL;
+    return key ? key + 1 : NULL;
 }
 
-yyjson_api_inline yyjson_val *yyjson_obj_iter_get(yyjson_obj_iter *iter, const char *key) {
-	return yyjson_obj_iter_getn(iter, key, key ? strlen(key) : 0);
+yyjson_api_inline yyjson_val *yyjson_obj_iter_get(yyjson_obj_iter *iter,
+                                                  const char *key) {
+    return yyjson_obj_iter_getn(iter, key, key ? strlen(key) : 0);
 }
 
-yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter, const char *key, size_t key_len) {
-	if (iter && key) {
-		size_t idx = iter->idx;
-		size_t max = iter->max;
-		yyjson_val *cur = iter->cur;
-		if (yyjson_unlikely(idx == max)) {
-			idx = 0;
-			cur = unsafe_yyjson_get_first(iter->obj);
-		}
-		while (idx++ < max) {
-			yyjson_val *next = unsafe_yyjson_get_next(cur + 1);
-			if (unsafe_yyjson_get_len(cur) == key_len && duckdb::FastMemcmp(cur->uni.str, key, key_len) == 0) {
-				iter->idx = idx;
-				iter->cur = next;
-				return cur + 1;
-			}
-			cur = next;
-			if (idx == iter->max && iter->idx < iter->max) {
-				idx = 0;
-				max = iter->idx;
-				cur = unsafe_yyjson_get_first(iter->obj);
-			}
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter,
+                                                   const char *key,
+                                                   size_t key_len) {
+    if (iter && key) {
+        size_t idx = iter->idx;
+        size_t max = iter->max;
+        yyjson_val *cur = iter->cur;
+        if (yyjson_unlikely(idx == max)) {
+            idx = 0;
+            cur = unsafe_yyjson_get_first(iter->obj);
+        }
+        while (idx++ < max) {
+            yyjson_val *next = unsafe_yyjson_get_next(cur + 1);
+            if (unsafe_yyjson_equals_strn(cur, key, key_len)) {
+                iter->idx = idx;
+                iter->cur = next;
+                return cur + 1;
+            }
+            cur = next;
+            if (idx == iter->max && iter->idx < iter->max) {
+                idx = 0;
+                max = iter->idx;
+                cur = unsafe_yyjson_get_first(iter->obj);
+            }
+        }
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Structure (Implementation)
@@ -3853,1658 +5261,2660 @@ yyjson_api_inline yyjson_val *yyjson_obj_iter_getn(yyjson_obj_iter *iter, const 
  The 'next' field links all elements inside the container to be a cycle.
  */
 struct yyjson_mut_val {
-	uint64_t tag;         /**< type, subtype and length */
-	yyjson_val_uni uni;   /**< payload */
-	yyjson_mut_val *next; /**< the next value in circular linked list */
+    uint64_t tag; /**< type, subtype and length */
+    yyjson_val_uni uni; /**< payload */
+    yyjson_mut_val *next; /**< the next value in circular linked list */
 };
 
 /**
  A memory chunk in string memory pool.
  */
 typedef struct yyjson_str_chunk {
-	struct yyjson_str_chunk *next;
-	/* flexible array member here */
+    struct yyjson_str_chunk *next; /* next chunk linked list */
+    size_t chunk_size; /* chunk size in bytes */
+    /* char str[]; flexible array member */
 } yyjson_str_chunk;
 
 /**
  A memory pool to hold all strings in a mutable document.
  */
 typedef struct yyjson_str_pool {
-	char *cur;                /* cursor inside current chunk */
-	char *end;                /* the end of current chunk */
-	size_t chunk_size;        /* chunk size in bytes while creating new chunk */
-	size_t chunk_size_max;    /* maximum chunk size in bytes */
-	yyjson_str_chunk *chunks; /* a linked list of chunks, nullable */
+    char *cur; /* cursor inside current chunk */
+    char *end; /* the end of current chunk */
+    size_t chunk_size; /* chunk size in bytes while creating new chunk */
+    size_t chunk_size_max; /* maximum chunk size in bytes */
+    yyjson_str_chunk *chunks; /* a linked list of chunks, nullable */
 } yyjson_str_pool;
 
 /**
  A memory chunk in value memory pool.
+ `sizeof(yyjson_val_chunk)` should not larger than `sizeof(yyjson_mut_val)`.
  */
 typedef struct yyjson_val_chunk {
-	struct yyjson_val_chunk *next;
-	/* flexible array member here */
+    struct yyjson_val_chunk *next; /* next chunk linked list */
+    size_t chunk_size; /* chunk size in bytes */
+    /* char pad[sizeof(yyjson_mut_val) - sizeof(yyjson_val_chunk)]; padding */
+    /* yyjson_mut_val vals[]; flexible array member */
 } yyjson_val_chunk;
 
 /**
  A memory pool to hold all values in a mutable document.
  */
 typedef struct yyjson_val_pool {
-	yyjson_mut_val *cur;      /* cursor inside current chunk */
-	yyjson_mut_val *end;      /* the end of current chunk */
-	size_t chunk_size;        /* chunk size in bytes while creating new chunk */
-	size_t chunk_size_max;    /* maximum chunk size in bytes */
-	yyjson_val_chunk *chunks; /* a linked list of chunks, nullable */
+    yyjson_mut_val *cur; /* cursor inside current chunk */
+    yyjson_mut_val *end; /* the end of current chunk */
+    size_t chunk_size; /* chunk size in bytes while creating new chunk */
+    size_t chunk_size_max; /* maximum chunk size in bytes */
+    yyjson_val_chunk *chunks; /* a linked list of chunks, nullable */
 } yyjson_val_pool;
 
 struct yyjson_mut_doc {
-	yyjson_mut_val *root;     /**< root value of the JSON document, nullable */
-	yyjson_alc alc;           /**< a valid allocator, nonnull */
-	yyjson_str_pool str_pool; /**< string memory pool */
-	yyjson_val_pool val_pool; /**< value memory pool */
+    yyjson_mut_val *root; /**< root value of the JSON document, nullable */
+    yyjson_alc alc; /**< a valid allocator, nonnull */
+    yyjson_str_pool str_pool; /**< string memory pool */
+    yyjson_val_pool val_pool; /**< value memory pool */
 };
 
 /* Ensures the capacity to at least equal to the specified byte length. */
-yyjson_api bool unsafe_yyjson_str_pool_grow(yyjson_str_pool *pool, const yyjson_alc *alc, size_t len);
+yyjson_api bool unsafe_yyjson_str_pool_grow(yyjson_str_pool *pool,
+                                            const yyjson_alc *alc,
+                                            size_t len);
 
 /* Ensures the capacity to at least equal to the specified value count. */
-yyjson_api bool unsafe_yyjson_val_pool_grow(yyjson_val_pool *pool, const yyjson_alc *alc, size_t count);
+yyjson_api bool unsafe_yyjson_val_pool_grow(yyjson_val_pool *pool,
+                                            const yyjson_alc *alc,
+                                            size_t count);
 
-yyjson_api_inline char *unsafe_yyjson_mut_strncpy(yyjson_mut_doc *doc, const char *str, size_t len) {
-	char *mem;
-	const yyjson_alc *alc = &doc->alc;
-	yyjson_str_pool *pool = &doc->str_pool;
-
-	if (!str)
-		return NULL;
-	if (yyjson_unlikely((size_t)(pool->end - pool->cur) <= len)) {
-		if (yyjson_unlikely(!unsafe_yyjson_str_pool_grow(pool, alc, len + 1))) {
-			return NULL;
-		}
-	}
-
-	mem = pool->cur;
-	pool->cur = mem + len + 1;
-	memcpy((void *)mem, (const void *)str, len);
-	mem[len] = '\0';
-	return mem;
+/* Allocate memory for string. */
+yyjson_api_inline char *unsafe_yyjson_mut_str_alc(yyjson_mut_doc *doc,
+                                                  size_t len) {
+    char *mem;
+    const yyjson_alc *alc = &doc->alc;
+    yyjson_str_pool *pool = &doc->str_pool;
+    if (yyjson_unlikely((size_t)(pool->end - pool->cur) <= len)) {
+        if (yyjson_unlikely(!unsafe_yyjson_str_pool_grow(pool, alc, len + 1))) {
+            return NULL;
+        }
+    }
+    mem = pool->cur;
+    pool->cur = mem + len + 1;
+    return mem;
 }
 
-yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_val(yyjson_mut_doc *doc, size_t count) {
-	yyjson_mut_val *val;
-	yyjson_alc *alc = &doc->alc;
-	yyjson_val_pool *pool = &doc->val_pool;
-	if (yyjson_unlikely((size_t)(pool->end - pool->cur) < count)) {
-		if (yyjson_unlikely(!unsafe_yyjson_val_pool_grow(pool, alc, count))) {
-			return NULL;
-		}
-	}
-
-	val = pool->cur;
-	pool->cur += count;
-	return val;
+yyjson_api_inline char *unsafe_yyjson_mut_strncpy(yyjson_mut_doc *doc,
+                                                  const char *str, size_t len) {
+    char *mem = unsafe_yyjson_mut_str_alc(doc, len);
+    if (yyjson_unlikely(!mem)) return NULL;
+    memcpy((void *)mem, (const void *)str, len);
+    mem[len] = '\0';
+    return mem;
 }
+
+yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_val(yyjson_mut_doc *doc,
+                                                        size_t count) {
+    yyjson_mut_val *val;
+    yyjson_alc *alc = &doc->alc;
+    yyjson_val_pool *pool = &doc->val_pool;
+    if (yyjson_unlikely((size_t)(pool->end - pool->cur) < count)) {
+        if (yyjson_unlikely(!unsafe_yyjson_val_pool_grow(pool, alc, count))) {
+            return NULL;
+        }
+    }
+    val = pool->cur;
+    pool->cur += count;
+    return val;
+}
+
+
 
 /*==============================================================================
  * Mutable JSON Document API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_root(yyjson_mut_doc *doc) {
-	return doc ? doc->root : NULL;
+    return doc ? doc->root : NULL;
 }
 
-yyjson_api_inline void yyjson_mut_doc_set_root(yyjson_mut_doc *doc, yyjson_mut_val *root) {
-	if (doc)
-		doc->root = root;
+yyjson_api_inline void yyjson_mut_doc_set_root(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *root) {
+    if (doc) doc->root = root;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Value Type API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline bool yyjson_mut_is_raw(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_raw(val) : false;
+    return val ? unsafe_yyjson_is_raw(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_null(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_null(val) : false;
+    return val ? unsafe_yyjson_is_null(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_true(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_true(val) : false;
+    return val ? unsafe_yyjson_is_true(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_false(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_false(val) : false;
+    return val ? unsafe_yyjson_is_false(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_bool(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_bool(val) : false;
+    return val ? unsafe_yyjson_is_bool(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_uint(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_uint(val) : false;
+    return val ? unsafe_yyjson_is_uint(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_sint(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_sint(val) : false;
+    return val ? unsafe_yyjson_is_sint(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_int(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_int(val) : false;
+    return val ? unsafe_yyjson_is_int(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_real(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_real(val) : false;
+    return val ? unsafe_yyjson_is_real(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_num(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_num(val) : false;
+    return val ? unsafe_yyjson_is_num(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_str(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_str(val) : false;
+    return val ? unsafe_yyjson_is_str(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_arr(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_arr(val) : false;
+    return val ? unsafe_yyjson_is_arr(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_obj(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_obj(val) : false;
+    return val ? unsafe_yyjson_is_obj(val) : false;
 }
 
 yyjson_api_inline bool yyjson_mut_is_ctn(yyjson_mut_val *val) {
-	return val ? unsafe_yyjson_is_ctn(val) : false;
+    return val ? unsafe_yyjson_is_ctn(val) : false;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Value Content API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline yyjson_type yyjson_mut_get_type(yyjson_mut_val *val) {
-	return yyjson_get_type((yyjson_val *)val);
+    return yyjson_get_type((yyjson_val *)val);
 }
 
 yyjson_api_inline yyjson_subtype yyjson_mut_get_subtype(yyjson_mut_val *val) {
-	return yyjson_get_subtype((yyjson_val *)val);
+    return yyjson_get_subtype((yyjson_val *)val);
 }
 
 yyjson_api_inline uint8_t yyjson_mut_get_tag(yyjson_mut_val *val) {
-	return yyjson_get_tag((yyjson_val *)val);
+    return yyjson_get_tag((yyjson_val *)val);
 }
 
 yyjson_api_inline const char *yyjson_mut_get_type_desc(yyjson_mut_val *val) {
-	return yyjson_get_type_desc((yyjson_val *)val);
+    return yyjson_get_type_desc((yyjson_val *)val);
 }
 
 yyjson_api_inline const char *yyjson_mut_get_raw(yyjson_mut_val *val) {
-	return yyjson_get_raw((yyjson_val *)val);
+    return yyjson_get_raw((yyjson_val *)val);
 }
 
 yyjson_api_inline bool yyjson_mut_get_bool(yyjson_mut_val *val) {
-	return yyjson_get_bool((yyjson_val *)val);
+    return yyjson_get_bool((yyjson_val *)val);
 }
 
 yyjson_api_inline uint64_t yyjson_mut_get_uint(yyjson_mut_val *val) {
-	return yyjson_get_uint((yyjson_val *)val);
+    return yyjson_get_uint((yyjson_val *)val);
 }
 
 yyjson_api_inline int64_t yyjson_mut_get_sint(yyjson_mut_val *val) {
-	return yyjson_get_sint((yyjson_val *)val);
+    return yyjson_get_sint((yyjson_val *)val);
 }
 
 yyjson_api_inline int yyjson_mut_get_int(yyjson_mut_val *val) {
-	return yyjson_get_int((yyjson_val *)val);
+    return yyjson_get_int((yyjson_val *)val);
 }
 
 yyjson_api_inline double yyjson_mut_get_real(yyjson_mut_val *val) {
-	return yyjson_get_real((yyjson_val *)val);
+    return yyjson_get_real((yyjson_val *)val);
+}
+
+yyjson_api_inline double yyjson_mut_get_num(yyjson_mut_val *val) {
+    return yyjson_get_num((yyjson_val *)val);
 }
 
 yyjson_api_inline const char *yyjson_mut_get_str(yyjson_mut_val *val) {
-	return yyjson_get_str((yyjson_val *)val);
+    return yyjson_get_str((yyjson_val *)val);
 }
 
 yyjson_api_inline size_t yyjson_mut_get_len(yyjson_mut_val *val) {
-	return yyjson_get_len((yyjson_val *)val);
+    return yyjson_get_len((yyjson_val *)val);
 }
 
-yyjson_api_inline bool yyjson_mut_equals_str(yyjson_mut_val *val, const char *str) {
-	return yyjson_equals_str((yyjson_val *)val, str);
+yyjson_api_inline bool yyjson_mut_equals_str(yyjson_mut_val *val,
+                                             const char *str) {
+    return yyjson_equals_str((yyjson_val *)val, str);
 }
 
-yyjson_api_inline bool yyjson_mut_equals_strn(yyjson_mut_val *val, const char *str, size_t len) {
-	return yyjson_equals_strn((yyjson_val *)val, str, len);
+yyjson_api_inline bool yyjson_mut_equals_strn(yyjson_mut_val *val,
+                                              const char *str, size_t len) {
+    return yyjson_equals_strn((yyjson_val *)val, str, len);
 }
 
-yyjson_api bool unsafe_yyjson_mut_equals(yyjson_mut_val *lhs, yyjson_mut_val *rhs);
+yyjson_api bool unsafe_yyjson_mut_equals(yyjson_mut_val *lhs,
+                                         yyjson_mut_val *rhs);
 
-yyjson_api_inline bool yyjson_mut_equals(yyjson_mut_val *lhs, yyjson_mut_val *rhs) {
-	if (yyjson_unlikely(!lhs || !rhs))
-		return false;
-	return unsafe_yyjson_mut_equals(lhs, rhs);
+yyjson_api_inline bool yyjson_mut_equals(yyjson_mut_val *lhs,
+                                         yyjson_mut_val *rhs) {
+    if (yyjson_unlikely(!lhs || !rhs)) return false;
+    return unsafe_yyjson_mut_equals(lhs, rhs);
 }
 
-yyjson_api_inline bool yyjson_mut_set_raw(yyjson_mut_val *val, const char *raw, size_t len) {
-	if (yyjson_unlikely(!val || !raw))
-		return false;
-	unsafe_yyjson_set_raw(val, raw, len);
-	return true;
+yyjson_api_inline bool yyjson_mut_set_raw(yyjson_mut_val *val,
+                                          const char *raw, size_t len) {
+    if (yyjson_unlikely(!val || !raw)) return false;
+    unsafe_yyjson_set_raw(val, raw, len);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_mut_set_null(yyjson_mut_val *val) {
-	if (yyjson_unlikely(!val))
-		return false;
-	unsafe_yyjson_set_null(val);
-	return true;
+    if (yyjson_unlikely(!val)) return false;
+    unsafe_yyjson_set_null(val);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_mut_set_bool(yyjson_mut_val *val, bool num) {
-	if (yyjson_unlikely(!val))
-		return false;
-	unsafe_yyjson_set_bool(val, num);
-	return true;
+    if (yyjson_unlikely(!val)) return false;
+    unsafe_yyjson_set_bool(val, num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_mut_set_uint(yyjson_mut_val *val, uint64_t num) {
-	if (yyjson_unlikely(!val))
-		return false;
-	unsafe_yyjson_set_uint(val, num);
-	return true;
+    if (yyjson_unlikely(!val)) return false;
+    unsafe_yyjson_set_uint(val, num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_mut_set_sint(yyjson_mut_val *val, int64_t num) {
-	if (yyjson_unlikely(!val))
-		return false;
-	unsafe_yyjson_set_sint(val, num);
-	return true;
+    if (yyjson_unlikely(!val)) return false;
+    unsafe_yyjson_set_sint(val, num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_mut_set_int(yyjson_mut_val *val, int num) {
-	if (yyjson_unlikely(!val))
-		return false;
-	unsafe_yyjson_set_sint(val, (int64_t)num);
-	return true;
+    if (yyjson_unlikely(!val)) return false;
+    unsafe_yyjson_set_sint(val, (int64_t)num);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_mut_set_real(yyjson_mut_val *val, double num) {
-	if (yyjson_unlikely(!val))
-		return false;
-	unsafe_yyjson_set_real(val, num);
-	return true;
+    if (yyjson_unlikely(!val)) return false;
+    unsafe_yyjson_set_real(val, num);
+    return true;
 }
 
-yyjson_api_inline bool yyjson_mut_set_str(yyjson_mut_val *val, const char *str) {
-	if (yyjson_unlikely(!val || !str))
-		return false;
-	unsafe_yyjson_set_str(val, str);
-	return true;
+yyjson_api_inline bool yyjson_mut_set_str(yyjson_mut_val *val,
+                                          const char *str) {
+    if (yyjson_unlikely(!val || !str)) return false;
+    unsafe_yyjson_set_str(val, str);
+    return true;
 }
 
-yyjson_api_inline bool yyjson_mut_set_strn(yyjson_mut_val *val, const char *str, size_t len) {
-	if (yyjson_unlikely(!val || !str))
-		return false;
-	unsafe_yyjson_set_strn(val, str, len);
-	return true;
+yyjson_api_inline bool yyjson_mut_set_strn(yyjson_mut_val *val,
+                                           const char *str, size_t len) {
+    if (yyjson_unlikely(!val || !str)) return false;
+    unsafe_yyjson_set_strn(val, str, len);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_mut_set_arr(yyjson_mut_val *val) {
-	if (yyjson_unlikely(!val))
-		return false;
-	unsafe_yyjson_set_arr(val, 0);
-	return true;
+    if (yyjson_unlikely(!val)) return false;
+    unsafe_yyjson_set_arr(val, 0);
+    return true;
 }
 
 yyjson_api_inline bool yyjson_mut_set_obj(yyjson_mut_val *val) {
-	if (yyjson_unlikely(!val))
-		return false;
-	unsafe_yyjson_set_obj(val, 0);
-	return true;
+    if (yyjson_unlikely(!val)) return false;
+    unsafe_yyjson_set_obj(val, 0);
+    return true;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Value Creation API (Implementation)
  *============================================================================*/
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc, const char *str) {
-	if (yyjson_likely(str))
-		return yyjson_mut_rawn(doc, str, strlen(str));
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_raw(yyjson_mut_doc *doc,
+                                                 const char *str) {
+    if (yyjson_likely(str)) return yyjson_mut_rawn(doc, str, strlen(str));
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn(yyjson_mut_doc *doc, const char *str, size_t len) {
-	if (yyjson_likely(doc && str)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
-			val->uni.str = str;
-			return val;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawn(yyjson_mut_doc *doc,
+                                                  const char *str,
+                                                  size_t len) {
+    if (yyjson_likely(doc && str)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+            val->uni.str = str;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy(yyjson_mut_doc *doc, const char *str) {
-	if (yyjson_likely(str))
-		return yyjson_mut_rawncpy(doc, str, strlen(str));
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawcpy(yyjson_mut_doc *doc,
+                                                    const char *str) {
+    if (yyjson_likely(str)) return yyjson_mut_rawncpy(doc, str, strlen(str));
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy(yyjson_mut_doc *doc, const char *str, size_t len) {
-	if (yyjson_likely(doc && str)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		char *new_str = unsafe_yyjson_mut_strncpy(doc, str, len);
-		if (yyjson_likely(val && new_str)) {
-			val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
-			val->uni.str = new_str;
-			return val;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_rawncpy(yyjson_mut_doc *doc,
+                                                     const char *str,
+                                                     size_t len) {
+    if (yyjson_likely(doc && str)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        char *new_str = unsafe_yyjson_mut_strncpy(doc, str, len);
+        if (yyjson_likely(val && new_str)) {
+            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+            val->uni.str = new_str;
+            return val;
+        }
+    }
+    return NULL;
 }
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_null(yyjson_mut_doc *doc) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE;
-			return val;
-		}
-	}
-	return NULL;
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE;
+            return val;
+        }
+    }
+    return NULL;
 }
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_true(yyjson_mut_doc *doc) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
-			return val;
-		}
-	}
-	return NULL;
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
+            return val;
+        }
+    }
+    return NULL;
 }
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_false(yyjson_mut_doc *doc) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
-			return val;
-		}
-	}
-	return NULL;
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_bool(yyjson_mut_doc *doc, bool _val) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)_val << 3);
-			return val;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_bool(yyjson_mut_doc *doc,
+                                                  bool _val) {
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            _val = !!_val;
+            val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)_val << 3);
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_uint(yyjson_mut_doc *doc, uint64_t num) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-			val->uni.u64 = num;
-			return val;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_uint(yyjson_mut_doc *doc,
+                                                  uint64_t num) {
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+            val->uni.u64 = num;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_sint(yyjson_mut_doc *doc, int64_t num) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-			val->uni.i64 = num;
-			return val;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_sint(yyjson_mut_doc *doc,
+                                                  int64_t num) {
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+            val->uni.i64 = num;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_int(yyjson_mut_doc *doc, int64_t num) {
-	return yyjson_mut_sint(doc, num);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_int(yyjson_mut_doc *doc,
+                                                 int64_t num) {
+    return yyjson_mut_sint(doc, num);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_real(yyjson_mut_doc *doc, double num) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-			val->uni.f64 = num;
-			return val;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_real(yyjson_mut_doc *doc,
+                                                  double num) {
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+            val->uni.f64 = num;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_str(yyjson_mut_doc *doc, const char *str) {
-	if (yyjson_likely(str))
-		return yyjson_mut_strn(doc, str, strlen(str));
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_str(yyjson_mut_doc *doc,
+                                                 const char *str) {
+    if (yyjson_likely(doc && str)) {
+        size_t len = strlen(str);
+        bool noesc = unsafe_yyjson_is_str_noesc(str, len);
+        yyjson_subtype sub = noesc ? YYJSON_SUBTYPE_NOESC : YYJSON_SUBTYPE_NONE;
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) |
+                        (uint64_t)(YYJSON_TYPE_STR | sub);
+            val->uni.str = str;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strn(yyjson_mut_doc *doc, const char *str, size_t len) {
-	if (yyjson_likely(doc && str)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-			val->uni.str = str;
-			return val;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_strn(yyjson_mut_doc *doc,
+                                                  const char *str,
+                                                  size_t len) {
+    if (yyjson_likely(doc && str)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+            val->uni.str = str;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strcpy(yyjson_mut_doc *doc, const char *str) {
-	if (yyjson_likely(str))
-		return yyjson_mut_strncpy(doc, str, strlen(str));
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_strcpy(yyjson_mut_doc *doc,
+                                                    const char *str) {
+    if (yyjson_likely(doc && str)) {
+        size_t len = strlen(str);
+        bool noesc = unsafe_yyjson_is_str_noesc(str, len);
+        yyjson_subtype sub = noesc ? YYJSON_SUBTYPE_NOESC : YYJSON_SUBTYPE_NONE;
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        char *new_str = unsafe_yyjson_mut_strncpy(doc, str, len);
+        if (yyjson_likely(val && new_str)) {
+            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) |
+                        (uint64_t)(YYJSON_TYPE_STR | sub);
+            val->uni.str = new_str;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy(yyjson_mut_doc *doc, const char *str, size_t len) {
-	if (yyjson_likely(doc && str)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		char *new_str = unsafe_yyjson_mut_strncpy(doc, str, len);
-		if (yyjson_likely(val && new_str)) {
-			val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-			val->uni.str = new_str;
-			return val;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_strncpy(yyjson_mut_doc *doc,
+                                                     const char *str,
+                                                     size_t len) {
+    if (yyjson_likely(doc && str)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        char *new_str = unsafe_yyjson_mut_strncpy(doc, str, len);
+        if (yyjson_likely(val && new_str)) {
+            val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+            val->uni.str = new_str;
+            return val;
+        }
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Array API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline size_t yyjson_mut_arr_size(yyjson_mut_val *arr) {
-	return yyjson_mut_is_arr(arr) ? unsafe_yyjson_get_len(arr) : 0;
+    return yyjson_mut_is_arr(arr) ? unsafe_yyjson_get_len(arr) : 0;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get(yyjson_mut_val *arr, size_t idx) {
-	if (yyjson_likely(idx < yyjson_mut_arr_size(arr))) {
-		yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr;
-		while (idx-- > 0)
-			val = val->next;
-		return val->next;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get(yyjson_mut_val *arr,
+                                                     size_t idx) {
+    if (yyjson_likely(idx < yyjson_mut_arr_size(arr))) {
+        yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr;
+        while (idx-- > 0) val = val->next;
+        return val->next;
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_first(yyjson_mut_val *arr) {
-	if (yyjson_likely(yyjson_mut_arr_size(arr) > 0)) {
-		return ((yyjson_mut_val *)arr->uni.ptr)->next;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_first(
+    yyjson_mut_val *arr) {
+    if (yyjson_likely(yyjson_mut_arr_size(arr) > 0)) {
+        return ((yyjson_mut_val *)arr->uni.ptr)->next;
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_last(yyjson_mut_val *arr) {
-	if (yyjson_likely(yyjson_mut_arr_size(arr) > 0)) {
-		return ((yyjson_mut_val *)arr->uni.ptr);
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_get_last(
+    yyjson_mut_val *arr) {
+    if (yyjson_likely(yyjson_mut_arr_size(arr) > 0)) {
+        return ((yyjson_mut_val *)arr->uni.ptr);
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Array Iterator API (Implementation)
  *============================================================================*/
 
-struct yyjson_mut_arr_iter {
-	size_t idx;          /**< current index, from 0 */
-	size_t max;          /**< maximum index, idx < max */
-	yyjson_mut_val *cur; /**< current value */
-	yyjson_mut_val *pre; /**< previous value */
-	yyjson_mut_val *arr; /**< the array being iterated */
-};
+yyjson_api_inline bool yyjson_mut_arr_iter_init(yyjson_mut_val *arr,
+                                                yyjson_mut_arr_iter *iter) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && iter)) {
+        iter->idx = 0;
+        iter->max = unsafe_yyjson_get_len(arr);
+        iter->cur = iter->max ? (yyjson_mut_val *)arr->uni.ptr : NULL;
+        iter->pre = NULL;
+        iter->arr = arr;
+        return true;
+    }
+    if (iter) memset(iter, 0, sizeof(yyjson_mut_arr_iter));
+    return false;
+}
 
-yyjson_api_inline bool yyjson_mut_arr_iter_init(yyjson_mut_val *arr, yyjson_mut_arr_iter *iter) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr) && iter)) {
-		iter->idx = 0;
-		iter->max = unsafe_yyjson_get_len(arr);
-		iter->cur = iter->max ? (yyjson_mut_val *)arr->uni.ptr : NULL;
-		iter->pre = NULL;
-		iter->arr = arr;
-		return true;
-	}
-	if (iter)
-		memset(iter, 0, sizeof(yyjson_mut_arr_iter));
-	return false;
+yyjson_api_inline yyjson_mut_arr_iter yyjson_mut_arr_iter_with(
+    yyjson_mut_val *arr) {
+    yyjson_mut_arr_iter iter;
+    yyjson_mut_arr_iter_init(arr, &iter);
+    return iter;
 }
 
 yyjson_api_inline bool yyjson_mut_arr_iter_has_next(yyjson_mut_arr_iter *iter) {
-	return iter ? iter->idx < iter->max : false;
+    return iter ? iter->idx < iter->max : false;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next(yyjson_mut_arr_iter *iter) {
-	if (iter && iter->idx < iter->max) {
-		yyjson_mut_val *val = iter->cur;
-		iter->pre = val;
-		iter->cur = val->next;
-		iter->idx++;
-		return iter->cur;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_next(
+    yyjson_mut_arr_iter *iter) {
+    if (iter && iter->idx < iter->max) {
+        yyjson_mut_val *val = iter->cur;
+        iter->pre = val;
+        iter->cur = val->next;
+        iter->idx++;
+        return iter->cur;
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(yyjson_mut_arr_iter *iter) {
-	if (yyjson_likely(iter && 0 < iter->idx && iter->idx <= iter->max)) {
-		yyjson_mut_val *prev = iter->pre;
-		yyjson_mut_val *cur = iter->cur;
-		yyjson_mut_val *next = cur->next;
-		if (yyjson_unlikely(iter->idx == iter->max))
-			iter->arr->uni.ptr = prev;
-		iter->idx--;
-		iter->max--;
-		unsafe_yyjson_set_len(iter->arr, iter->max);
-		prev->next = next;
-		iter->cur = next;
-		return cur;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_iter_remove(
+    yyjson_mut_arr_iter *iter) {
+    if (yyjson_likely(iter && 0 < iter->idx && iter->idx <= iter->max)) {
+        yyjson_mut_val *prev = iter->pre;
+        yyjson_mut_val *cur = iter->cur;
+        yyjson_mut_val *next = cur->next;
+        if (yyjson_unlikely(iter->idx == iter->max)) iter->arr->uni.ptr = prev;
+        iter->idx--;
+        iter->max--;
+        unsafe_yyjson_set_len(iter->arr, iter->max);
+        prev->next = next;
+        iter->cur = next;
+        return cur;
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Array Creation API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_arr(yyjson_mut_doc *doc) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE;
-			return val;
-		}
-	}
-	return NULL;
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-#define yyjson_mut_arr_with_func(func)                                                                                 \
-	if (yyjson_likely(doc && ((0 < count && count < (~(size_t)0) / sizeof(yyjson_mut_val) && vals) || count == 0))) {  \
-		yyjson_mut_val *arr = unsafe_yyjson_mut_val(doc, 1 + count);                                                   \
-		if (yyjson_likely(arr)) {                                                                                      \
-			arr->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;                                          \
-			if (count > 0) {                                                                                           \
-				size_t i;                                                                                              \
-				for (i = 0; i < count; i++) {                                                                          \
-					yyjson_mut_val *val = arr + i + 1;                                                                 \
-					func val->next = val + 1;                                                                          \
-				}                                                                                                      \
-				arr[count].next = arr + 1;                                                                             \
-				arr->uni.ptr = arr + count;                                                                            \
-			}                                                                                                          \
-			return arr;                                                                                                \
-		}                                                                                                              \
-	}                                                                                                                  \
-	return NULL
+#define yyjson_mut_arr_with_func(func) \
+    if (yyjson_likely(doc && ((0 < count && count < \
+        (~(size_t)0) / sizeof(yyjson_mut_val) && vals) || count == 0))) { \
+        yyjson_mut_val *arr = unsafe_yyjson_mut_val(doc, 1 + count); \
+        if (yyjson_likely(arr)) { \
+            arr->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR; \
+            if (count > 0) { \
+                size_t i; \
+                for (i = 0; i < count; i++) { \
+                    yyjson_mut_val *val = arr + i + 1; \
+                    func \
+                    val->next = val + 1; \
+                } \
+                arr[count].next = arr + 1; \
+                arr->uni.ptr = arr + count; \
+            } \
+            return arr; \
+        } \
+    } \
+    return NULL
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_bool(yyjson_mut_doc *doc, const bool *vals, size_t count) {
-	yyjson_mut_arr_with_func({ val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)vals[i] << 3); });
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_bool(
+    yyjson_mut_doc *doc, const bool *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        bool _val = !!vals[i];
+        val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)_val << 3);
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint(yyjson_mut_doc *doc, const int64_t *vals, size_t count) {
-	return yyjson_mut_arr_with_sint64(doc, vals, count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint(
+    yyjson_mut_doc *doc, const int64_t *vals, size_t count) {
+    return yyjson_mut_arr_with_sint64(doc, vals, count);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint(yyjson_mut_doc *doc, const uint64_t *vals, size_t count) {
-	return yyjson_mut_arr_with_uint64(doc, vals, count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint(
+    yyjson_mut_doc *doc, const uint64_t *vals, size_t count) {
+    return yyjson_mut_arr_with_uint64(doc, vals, count);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_real(yyjson_mut_doc *doc, const double *vals, size_t count) {
-	return yyjson_mut_arr_with_double(doc, vals, count);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_real(
+    yyjson_mut_doc *doc, const double *vals, size_t count) {
+    return yyjson_mut_arr_with_double(doc, vals, count);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint8(yyjson_mut_doc *doc, const int8_t *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-		val->uni.i64 = (int64_t)vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint8(
+    yyjson_mut_doc *doc, const int8_t *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+        val->uni.i64 = (int64_t)vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint16(yyjson_mut_doc *doc, const int16_t *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-		val->uni.i64 = vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint16(
+    yyjson_mut_doc *doc, const int16_t *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+        val->uni.i64 = vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint32(yyjson_mut_doc *doc, const int32_t *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-		val->uni.i64 = vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint32(
+    yyjson_mut_doc *doc, const int32_t *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+        val->uni.i64 = vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint64(yyjson_mut_doc *doc, const int64_t *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-		val->uni.i64 = vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_sint64(
+    yyjson_mut_doc *doc, const int64_t *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+        val->uni.i64 = vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint8(yyjson_mut_doc *doc, const uint8_t *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-		val->uni.u64 = vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint8(
+    yyjson_mut_doc *doc, const uint8_t *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+        val->uni.u64 = vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint16(yyjson_mut_doc *doc, const uint16_t *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-		val->uni.u64 = vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint16(
+    yyjson_mut_doc *doc, const uint16_t *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+        val->uni.u64 = vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint32(yyjson_mut_doc *doc, const uint32_t *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-		val->uni.u64 = vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint32(
+    yyjson_mut_doc *doc, const uint32_t *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+        val->uni.u64 = vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint64(yyjson_mut_doc *doc, const uint64_t *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-		val->uni.u64 = vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_uint64(
+    yyjson_mut_doc *doc, const uint64_t *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+        val->uni.u64 = vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float(yyjson_mut_doc *doc, const float *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-		val->uni.f64 = (double)vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_float(
+    yyjson_mut_doc *doc, const float *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+        val->uni.f64 = (double)vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double(yyjson_mut_doc *doc, const double *vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-		val->uni.f64 = vals[i];
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_double(
+    yyjson_mut_doc *doc, const double *vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+        val->uni.f64 = vals[i];
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str(yyjson_mut_doc *doc, const char **vals, size_t count) {
-	yyjson_mut_arr_with_func({
-		uint64_t len = (uint64_t)strlen(vals[i]);
-		val->tag = (len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		val->uni.str = vals[i];
-		if (yyjson_unlikely(!val->uni.str))
-			return NULL;
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_str(
+    yyjson_mut_doc *doc, const char **vals, size_t count) {
+    yyjson_mut_arr_with_func({
+        uint64_t len = (uint64_t)strlen(vals[i]);
+        val->tag = (len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->uni.str = vals[i];
+        if (yyjson_unlikely(!val->uni.str)) return NULL;
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn(yyjson_mut_doc *doc, const char **vals, const size_t *lens,
-                                                           size_t count) {
-	if (yyjson_unlikely(count > 0 && !lens))
-		return NULL;
-	yyjson_mut_arr_with_func({
-		val->tag = ((uint64_t)lens[i] << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		val->uni.str = vals[i];
-		if (yyjson_unlikely(!val->uni.str))
-			return NULL;
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strn(
+    yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count) {
+    if (yyjson_unlikely(count > 0 && !lens)) return NULL;
+    yyjson_mut_arr_with_func({
+        val->tag = ((uint64_t)lens[i] << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->uni.str = vals[i];
+        if (yyjson_unlikely(!val->uni.str)) return NULL;
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy(yyjson_mut_doc *doc, const char **vals, size_t count) {
-	size_t len;
-	const char *str;
-	yyjson_mut_arr_with_func({
-		str = vals[i];
-		if (!str)
-			return NULL;
-		len = strlen(str);
-		val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		val->uni.str = unsafe_yyjson_mut_strncpy(doc, str, len);
-		if (yyjson_unlikely(!val->uni.str))
-			return NULL;
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strcpy(
+    yyjson_mut_doc *doc, const char **vals, size_t count) {
+    size_t len;
+    const char *str;
+    yyjson_mut_arr_with_func({
+        str = vals[i];
+        if (!str) return NULL;
+        len = strlen(str);
+        val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->uni.str = unsafe_yyjson_mut_strncpy(doc, str, len);
+        if (yyjson_unlikely(!val->uni.str)) return NULL;
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy(yyjson_mut_doc *doc, const char **vals,
-                                                              const size_t *lens, size_t count) {
-	size_t len;
-	const char *str;
-	if (yyjson_unlikely(count > 0 && !lens))
-		return NULL;
-	yyjson_mut_arr_with_func({
-		str = vals[i];
-		len = lens[i];
-		val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		val->uni.str = unsafe_yyjson_mut_strncpy(doc, str, len);
-		if (yyjson_unlikely(!val->uni.str))
-			return NULL;
-	});
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_with_strncpy(
+    yyjson_mut_doc *doc, const char **vals, const size_t *lens, size_t count) {
+    size_t len;
+    const char *str;
+    if (yyjson_unlikely(count > 0 && !lens)) return NULL;
+    yyjson_mut_arr_with_func({
+        str = vals[i];
+        len = lens[i];
+        val->tag = ((uint64_t)len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->uni.str = unsafe_yyjson_mut_strncpy(doc, str, len);
+        if (yyjson_unlikely(!val->uni.str)) return NULL;
+    });
 }
 
 #undef yyjson_mut_arr_with_func
+
+
 
 /*==============================================================================
  * Mutable JSON Array Modification API (Implementation)
  *============================================================================*/
 
-yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr, yyjson_mut_val *val, size_t idx) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
-		size_t len = unsafe_yyjson_get_len(arr);
-		if (yyjson_likely(idx <= len)) {
-			unsafe_yyjson_set_len(arr, len + 1);
-			if (len == 0) {
-				val->next = val;
-				arr->uni.ptr = val;
-			} else {
-				yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-				yyjson_mut_val *next = prev->next;
-				if (idx == len) {
-					prev->next = val;
-					val->next = next;
-					arr->uni.ptr = val;
-				} else {
-					while (idx-- > 0) {
-						prev = next;
-						next = next->next;
-					}
-					prev->next = val;
-					val->next = next;
-				}
-			}
-			return true;
-		}
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_insert(yyjson_mut_val *arr,
+                                             yyjson_mut_val *val, size_t idx) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
+        size_t len = unsafe_yyjson_get_len(arr);
+        if (yyjson_likely(idx <= len)) {
+            unsafe_yyjson_set_len(arr, len + 1);
+            if (len == 0) {
+                val->next = val;
+                arr->uni.ptr = val;
+            } else {
+                yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+                yyjson_mut_val *next = prev->next;
+                if (idx == len) {
+                    prev->next = val;
+                    val->next = next;
+                    arr->uni.ptr = val;
+                } else {
+                    while (idx-- > 0) {
+                        prev = next;
+                        next = next->next;
+                    }
+                    prev->next = val;
+                    val->next = next;
+                }
+            }
+            return true;
+        }
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr, yyjson_mut_val *val) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
-		size_t len = unsafe_yyjson_get_len(arr);
-		unsafe_yyjson_set_len(arr, len + 1);
-		if (len == 0) {
-			val->next = val;
-		} else {
-			yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-			yyjson_mut_val *next = prev->next;
-			prev->next = val;
-			val->next = next;
-		}
-		arr->uni.ptr = val;
-		return true;
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_append(yyjson_mut_val *arr,
+                                             yyjson_mut_val *val) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
+        size_t len = unsafe_yyjson_get_len(arr);
+        unsafe_yyjson_set_len(arr, len + 1);
+        if (len == 0) {
+            val->next = val;
+        } else {
+            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+            yyjson_mut_val *next = prev->next;
+            prev->next = val;
+            val->next = next;
+        }
+        arr->uni.ptr = val;
+        return true;
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr, yyjson_mut_val *val) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
-		size_t len = unsafe_yyjson_get_len(arr);
-		unsafe_yyjson_set_len(arr, len + 1);
-		if (len == 0) {
-			val->next = val;
-			arr->uni.ptr = val;
-		} else {
-			yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-			yyjson_mut_val *next = prev->next;
-			prev->next = val;
-			val->next = next;
-		}
-		return true;
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_prepend(yyjson_mut_val *arr,
+                                              yyjson_mut_val *val) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
+        size_t len = unsafe_yyjson_get_len(arr);
+        unsafe_yyjson_set_len(arr, len + 1);
+        if (len == 0) {
+            val->next = val;
+            arr->uni.ptr = val;
+        } else {
+            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+            yyjson_mut_val *next = prev->next;
+            prev->next = val;
+            val->next = next;
+        }
+        return true;
+    }
+    return false;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr, size_t idx, yyjson_mut_val *val) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
-		size_t len = unsafe_yyjson_get_len(arr);
-		if (yyjson_likely(idx < len)) {
-			if (yyjson_likely(len > 1)) {
-				yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-				yyjson_mut_val *next = prev->next;
-				while (idx-- > 0) {
-					prev = next;
-					next = next->next;
-				}
-				prev->next = val;
-				val->next = next->next;
-				if ((void *)next == arr->uni.ptr)
-					arr->uni.ptr = val;
-				return next;
-			} else {
-				yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-				val->next = val;
-				arr->uni.ptr = val;
-				return prev;
-			}
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_replace(yyjson_mut_val *arr,
+                                                         size_t idx,
+                                                         yyjson_mut_val *val) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) && val)) {
+        size_t len = unsafe_yyjson_get_len(arr);
+        if (yyjson_likely(idx < len)) {
+            if (yyjson_likely(len > 1)) {
+                yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+                yyjson_mut_val *next = prev->next;
+                while (idx-- > 0) {
+                    prev = next;
+                    next = next->next;
+                }
+                prev->next = val;
+                val->next = next->next;
+                if ((void *)next == arr->uni.ptr) arr->uni.ptr = val;
+                return next;
+            } else {
+                yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+                val->next = val;
+                arr->uni.ptr = val;
+                return prev;
+            }
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr, size_t idx) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-		size_t len = unsafe_yyjson_get_len(arr);
-		if (yyjson_likely(idx < len)) {
-			unsafe_yyjson_set_len(arr, len - 1);
-			if (yyjson_likely(len > 1)) {
-				yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-				yyjson_mut_val *next = prev->next;
-				while (idx-- > 0) {
-					prev = next;
-					next = next->next;
-				}
-				prev->next = next->next;
-				if ((void *)next == arr->uni.ptr)
-					arr->uni.ptr = prev;
-				return next;
-			} else {
-				return ((yyjson_mut_val *)arr->uni.ptr);
-			}
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove(yyjson_mut_val *arr,
+                                                        size_t idx) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
+        size_t len = unsafe_yyjson_get_len(arr);
+        if (yyjson_likely(idx < len)) {
+            unsafe_yyjson_set_len(arr, len - 1);
+            if (yyjson_likely(len > 1)) {
+                yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+                yyjson_mut_val *next = prev->next;
+                while (idx-- > 0) {
+                    prev = next;
+                    next = next->next;
+                }
+                prev->next = next->next;
+                if ((void *)next == arr->uni.ptr) arr->uni.ptr = prev;
+                return next;
+            } else {
+                return ((yyjson_mut_val *)arr->uni.ptr);
+            }
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(yyjson_mut_val *arr) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-		size_t len = unsafe_yyjson_get_len(arr);
-		if (len > 1) {
-			yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-			yyjson_mut_val *next = prev->next;
-			prev->next = next->next;
-			unsafe_yyjson_set_len(arr, len - 1);
-			return next;
-		} else if (len == 1) {
-			yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-			unsafe_yyjson_set_len(arr, 0);
-			return prev;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_first(
+    yyjson_mut_val *arr) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
+        size_t len = unsafe_yyjson_get_len(arr);
+        if (len > 1) {
+            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+            yyjson_mut_val *next = prev->next;
+            prev->next = next->next;
+            unsafe_yyjson_set_len(arr, len - 1);
+            return next;
+        } else if (len == 1) {
+            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+            unsafe_yyjson_set_len(arr, 0);
+            return prev;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(yyjson_mut_val *arr) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-		size_t len = unsafe_yyjson_get_len(arr);
-		if (yyjson_likely(len > 1)) {
-			yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-			yyjson_mut_val *next = prev->next;
-			unsafe_yyjson_set_len(arr, len - 1);
-			while (--len > 0)
-				prev = prev->next;
-			prev->next = next;
-			next = (yyjson_mut_val *)arr->uni.ptr;
-			arr->uni.ptr = prev;
-			return next;
-		} else if (len == 1) {
-			yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
-			unsafe_yyjson_set_len(arr, 0);
-			return prev;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_remove_last(
+    yyjson_mut_val *arr) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
+        size_t len = unsafe_yyjson_get_len(arr);
+        if (yyjson_likely(len > 1)) {
+            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+            yyjson_mut_val *next = prev->next;
+            unsafe_yyjson_set_len(arr, len - 1);
+            while (--len > 0) prev = prev->next;
+            prev->next = next;
+            next = (yyjson_mut_val *)arr->uni.ptr;
+            arr->uni.ptr = prev;
+            return next;
+        } else if (len == 1) {
+            yyjson_mut_val *prev = ((yyjson_mut_val *)arr->uni.ptr);
+            unsafe_yyjson_set_len(arr, 0);
+            return prev;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_remove_range(yyjson_mut_val *arr, size_t _idx, size_t _len) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *prev, *next;
-		bool tail_removed;
-		size_t len = unsafe_yyjson_get_len(arr);
-		if (yyjson_unlikely(_idx + _len > len))
-			return false;
-		if (yyjson_unlikely(_len == 0))
-			return true;
-		unsafe_yyjson_set_len(arr, len - _len);
-		if (yyjson_unlikely(len == _len))
-			return true;
-		tail_removed = (_idx + _len == len);
-		prev = ((yyjson_mut_val *)arr->uni.ptr);
-		while (_idx-- > 0)
-			prev = prev->next;
-		next = prev->next;
-		while (_len-- > 0)
-			next = next->next;
-		prev->next = next;
-		if (yyjson_unlikely(tail_removed))
-			arr->uni.ptr = prev;
-		return true;
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_remove_range(yyjson_mut_val *arr,
+                                                   size_t _idx, size_t _len) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *prev, *next;
+        bool tail_removed;
+        size_t len = unsafe_yyjson_get_len(arr);
+        if (yyjson_unlikely(_idx + _len > len)) return false;
+        if (yyjson_unlikely(_len == 0)) return true;
+        unsafe_yyjson_set_len(arr, len - _len);
+        if (yyjson_unlikely(len == _len)) return true;
+        tail_removed = (_idx + _len == len);
+        prev = ((yyjson_mut_val *)arr->uni.ptr);
+        while (_idx-- > 0) prev = prev->next;
+        next = prev->next;
+        while (_len-- > 0) next = next->next;
+        prev->next = next;
+        if (yyjson_unlikely(tail_removed)) arr->uni.ptr = prev;
+        return true;
+    }
+    return false;
 }
 
 yyjson_api_inline bool yyjson_mut_arr_clear(yyjson_mut_val *arr) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr))) {
-		unsafe_yyjson_set_len(arr, 0);
-		return true;
-	}
-	return false;
+    if (yyjson_likely(yyjson_mut_is_arr(arr))) {
+        unsafe_yyjson_set_len(arr, 0);
+        return true;
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_rotate(yyjson_mut_val *arr, size_t idx) {
-	if (yyjson_likely(yyjson_mut_is_arr(arr) && unsafe_yyjson_get_len(arr) > idx)) {
-		yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr;
-		while (idx-- > 0)
-			val = val->next;
-		arr->uni.ptr = (void *)val;
-		return true;
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_rotate(yyjson_mut_val *arr,
+                                             size_t idx) {
+    if (yyjson_likely(yyjson_mut_is_arr(arr) &&
+                      unsafe_yyjson_get_len(arr) > idx)) {
+        yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr;
+        while (idx-- > 0) val = val->next;
+        arr->uni.ptr = (void *)val;
+        return true;
+    }
+    return false;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Array Modification Convenience API (Implementation)
  *============================================================================*/
 
-yyjson_api_inline bool yyjson_mut_arr_add_val(yyjson_mut_val *arr, yyjson_mut_val *val) {
-	return yyjson_mut_arr_append(arr, val);
+yyjson_api_inline bool yyjson_mut_arr_add_val(yyjson_mut_val *arr,
+                                              yyjson_mut_val *val) {
+    return yyjson_mut_arr_append(arr, val);
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc, yyjson_mut_val *arr) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_null(doc);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_null(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_null(doc);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc, yyjson_mut_val *arr) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_true(doc);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_true(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_true(doc);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc, yyjson_mut_val *arr) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_false(doc);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_false(yyjson_mut_doc *doc,
+                                                yyjson_mut_val *arr) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_false(doc);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc, yyjson_mut_val *arr, bool _val) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_bool(doc, _val);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_bool(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               bool _val) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_bool(doc, _val);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc, yyjson_mut_val *arr, uint64_t num) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_uint(doc, num);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_uint(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               uint64_t num) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_uint(doc, num);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc, yyjson_mut_val *arr, int64_t num) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_sint(doc, num);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_sint(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               int64_t num) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_sint(doc, num);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc, yyjson_mut_val *arr, int64_t num) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_sint(doc, num);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_int(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *arr,
+                                              int64_t num) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_sint(doc, num);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc, yyjson_mut_val *arr, double num) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_real(doc, num);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_real(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               double num) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_real(doc, num);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *str) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_str(doc, str);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_str(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *arr,
+                                              const char *str) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_str(doc, str);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *str, size_t len) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_strn(doc, str, len);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_strn(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *arr,
+                                               const char *str, size_t len) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_strn(doc, str, len);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *str) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_strcpy(doc, str);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_strcpy(yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *arr,
+                                                 const char *str) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_strcpy(doc, str);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *str,
-                                                  size_t len) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_strncpy(doc, str, len);
-		return yyjson_mut_arr_append(arr, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_arr_add_strncpy(yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *arr,
+                                                  const char *str, size_t len) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_strncpy(doc, str, len);
+        return yyjson_mut_arr_append(arr, val);
+    }
+    return false;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr(yyjson_mut_doc *doc, yyjson_mut_val *arr) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_arr(doc);
-		return yyjson_mut_arr_append(arr, val) ? val : NULL;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_arr(yyjson_mut_doc *doc,
+                                                         yyjson_mut_val *arr) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_arr(doc);
+        return yyjson_mut_arr_append(arr, val) ? val : NULL;
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj(yyjson_mut_doc *doc, yyjson_mut_val *arr) {
-	if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
-		yyjson_mut_val *val = yyjson_mut_obj(doc);
-		return yyjson_mut_arr_append(arr, val) ? val : NULL;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_arr_add_obj(yyjson_mut_doc *doc,
+                                                         yyjson_mut_val *arr) {
+    if (yyjson_likely(doc && yyjson_mut_is_arr(arr))) {
+        yyjson_mut_val *val = yyjson_mut_obj(doc);
+        return yyjson_mut_arr_append(arr, val) ? val : NULL;
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Object API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline size_t yyjson_mut_obj_size(yyjson_mut_val *obj) {
-	return yyjson_mut_is_obj(obj) ? unsafe_yyjson_get_len(obj) : 0;
+    return yyjson_mut_is_obj(obj) ? unsafe_yyjson_get_len(obj) : 0;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_get(yyjson_mut_val *obj, const char *key) {
-	return yyjson_mut_obj_getn(obj, key, key ? strlen(key) : 0);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_get(yyjson_mut_val *obj,
+                                                     const char *key) {
+    return yyjson_mut_obj_getn(obj, key, key ? strlen(key) : 0);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn(yyjson_mut_val *obj, const char *_key, size_t key_len) {
-	uint64_t tag = (((uint64_t)key_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-	size_t len = yyjson_mut_obj_size(obj);
-	if (yyjson_likely(len && _key)) {
-		yyjson_mut_val *key = ((yyjson_mut_val *)obj->uni.ptr)->next->next;
-		while (len-- > 0) {
-			if (key->tag == tag && duckdb::FastMemcmp(key->uni.ptr, _key, key_len) == 0) {
-				return key->next;
-			}
-			key = key->next->next;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_getn(yyjson_mut_val *obj,
+                                                      const char *_key,
+                                                      size_t key_len) {
+    size_t len = yyjson_mut_obj_size(obj);
+    if (yyjson_likely(len && _key)) {
+        yyjson_mut_val *key = ((yyjson_mut_val *)obj->uni.ptr)->next->next;
+        while (len-- > 0) {
+            if (unsafe_yyjson_equals_strn(key, _key, key_len)) return key->next;
+            key = key->next->next;
+        }
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Object Iterator API (Implementation)
  *============================================================================*/
 
-struct yyjson_mut_obj_iter {
-	size_t idx;          /**< current key index, from 0 */
-	size_t max;          /**< maximum key index, idx < max */
-	yyjson_mut_val *cur; /**< current key */
-	yyjson_mut_val *pre; /**< previous key */
-	yyjson_mut_val *obj; /**< the object being iterated */
-};
+yyjson_api_inline bool yyjson_mut_obj_iter_init(yyjson_mut_val *obj,
+                                                yyjson_mut_obj_iter *iter) {
+    if (yyjson_likely(yyjson_mut_is_obj(obj) && iter)) {
+        iter->idx = 0;
+        iter->max = unsafe_yyjson_get_len(obj);
+        iter->cur = iter->max ? (yyjson_mut_val *)obj->uni.ptr : NULL;
+        iter->pre = NULL;
+        iter->obj = obj;
+        return true;
+    }
+    if (iter) memset(iter, 0, sizeof(yyjson_mut_obj_iter));
+    return false;
+}
 
-yyjson_api_inline bool yyjson_mut_obj_iter_init(yyjson_mut_val *obj, yyjson_mut_obj_iter *iter) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && iter)) {
-		iter->idx = 0;
-		iter->max = unsafe_yyjson_get_len(obj);
-		iter->cur = iter->max ? (yyjson_mut_val *)obj->uni.ptr : NULL;
-		iter->pre = NULL;
-		iter->obj = obj;
-		return true;
-	}
-	if (iter)
-		memset(iter, 0, sizeof(yyjson_mut_obj_iter));
-	return false;
+yyjson_api_inline yyjson_mut_obj_iter yyjson_mut_obj_iter_with(
+    yyjson_mut_val *obj) {
+    yyjson_mut_obj_iter iter;
+    yyjson_mut_obj_iter_init(obj, &iter);
+    return iter;
 }
 
 yyjson_api_inline bool yyjson_mut_obj_iter_has_next(yyjson_mut_obj_iter *iter) {
-	return iter ? iter->idx < iter->max : false;
+    return iter ? iter->idx < iter->max : false;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_next(yyjson_mut_obj_iter *iter) {
-	if (iter && iter->idx < iter->max) {
-		yyjson_mut_val *key = iter->cur;
-		iter->pre = key;
-		iter->cur = key->next->next;
-		iter->idx++;
-		return iter->cur;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_next(
+    yyjson_mut_obj_iter *iter) {
+    if (iter && iter->idx < iter->max) {
+        yyjson_mut_val *key = iter->cur;
+        iter->pre = key;
+        iter->cur = key->next->next;
+        iter->idx++;
+        return iter->cur;
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val(yyjson_mut_val *key) {
-	return key ? key->next : NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get_val(
+    yyjson_mut_val *key) {
+    return key ? key->next : NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove(yyjson_mut_obj_iter *iter) {
-	if (yyjson_likely(iter && 0 < iter->idx && iter->idx <= iter->max)) {
-		yyjson_mut_val *prev = iter->pre;
-		yyjson_mut_val *cur = iter->cur;
-		yyjson_mut_val *next = cur->next->next;
-		if (yyjson_unlikely(iter->idx == iter->max))
-			iter->obj->uni.ptr = prev;
-		iter->idx--;
-		iter->max--;
-		unsafe_yyjson_set_len(iter->obj, iter->max);
-		prev->next->next = next;
-		iter->cur = next;
-		return cur;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_remove(
+    yyjson_mut_obj_iter *iter) {
+    if (yyjson_likely(iter && 0 < iter->idx && iter->idx <= iter->max)) {
+        yyjson_mut_val *prev = iter->pre;
+        yyjson_mut_val *cur = iter->cur;
+        yyjson_mut_val *next = cur->next->next;
+        if (yyjson_unlikely(iter->idx == iter->max)) iter->obj->uni.ptr = prev;
+        iter->idx--;
+        iter->max--;
+        unsafe_yyjson_set_len(iter->obj, iter->max);
+        prev->next->next = next;
+        iter->cur = prev;
+        return cur->next;
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get(yyjson_mut_obj_iter *iter, const char *key) {
-	return yyjson_mut_obj_iter_getn(iter, key, key ? strlen(key) : 0);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_get(
+    yyjson_mut_obj_iter *iter, const char *key) {
+    return yyjson_mut_obj_iter_getn(iter, key, key ? strlen(key) : 0);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(yyjson_mut_obj_iter *iter, const char *key, size_t key_len) {
-	if (iter && key) {
-		size_t idx = 0;
-		size_t max = iter->max;
-		yyjson_mut_val *pre, *cur = iter->cur;
-		while (idx++ < max) {
-			pre = cur;
-			cur = cur->next->next;
-			if (unsafe_yyjson_get_len(cur) == key_len && duckdb::FastMemcmp(cur->uni.str, key, key_len) == 0) {
-				iter->idx += idx;
-				if (iter->idx > max)
-					iter->idx -= max + 1;
-				iter->pre = pre;
-				iter->cur = cur;
-				return cur->next;
-			}
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_iter_getn(
+    yyjson_mut_obj_iter *iter, const char *key, size_t key_len) {
+    if (iter && key) {
+        size_t idx = 0;
+        size_t max = iter->max;
+        yyjson_mut_val *pre, *cur = iter->cur;
+        while (idx++ < max) {
+            pre = cur;
+            cur = cur->next->next;
+            if (unsafe_yyjson_equals_strn(cur, key, key_len)) {
+                iter->idx += idx;
+                if (iter->idx > max) iter->idx -= max + 1;
+                iter->pre = pre;
+                iter->cur = cur;
+                return cur->next;
+            }
+        }
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Object Creation API (Implementation)
  *============================================================================*/
 
 yyjson_api_inline yyjson_mut_val *yyjson_mut_obj(yyjson_mut_doc *doc) {
-	if (yyjson_likely(doc)) {
-		yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
-		if (yyjson_likely(val)) {
-			val->tag = YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE;
-			return val;
-		}
-	}
-	return NULL;
+    if (yyjson_likely(doc)) {
+        yyjson_mut_val *val = unsafe_yyjson_mut_val(doc, 1);
+        if (yyjson_likely(val)) {
+            val->tag = YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE;
+            return val;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc, const char **keys, const char **vals,
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_str(yyjson_mut_doc *doc,
+                                                          const char **keys,
+                                                          const char **vals,
                                                           size_t count) {
-	if (yyjson_likely(doc && ((count > 0 && keys && vals) || (count == 0)))) {
-		yyjson_mut_val *obj = unsafe_yyjson_mut_val(doc, 1 + count * 2);
-		if (yyjson_likely(obj)) {
-			obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
-			if (count > 0) {
-				size_t i;
-				for (i = 0; i < count; i++) {
-					yyjson_mut_val *key = obj + (i * 2 + 1);
-					yyjson_mut_val *val = obj + (i * 2 + 2);
-					uint64_t key_len = (uint64_t)strlen(keys[i]);
-					uint64_t val_len = (uint64_t)strlen(vals[i]);
-					key->tag = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-					val->tag = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-					key->uni.str = keys[i];
-					val->uni.str = vals[i];
-					key->next = val;
-					val->next = val + 1;
-				}
-				obj[count * 2].next = obj + 1;
-				obj->uni.ptr = obj + (count * 2 - 1);
-			}
-			return obj;
-		}
-	}
-	return NULL;
+    if (yyjson_likely(doc && ((count > 0 && keys && vals) || (count == 0)))) {
+        yyjson_mut_val *obj = unsafe_yyjson_mut_val(doc, 1 + count * 2);
+        if (yyjson_likely(obj)) {
+            obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
+            if (count > 0) {
+                size_t i;
+                for (i = 0; i < count; i++) {
+                    yyjson_mut_val *key = obj + (i * 2 + 1);
+                    yyjson_mut_val *val = obj + (i * 2 + 2);
+                    uint64_t key_len = (uint64_t)strlen(keys[i]);
+                    uint64_t val_len = (uint64_t)strlen(vals[i]);
+                    key->tag = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+                    val->tag = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+                    key->uni.str = keys[i];
+                    val->uni.str = vals[i];
+                    key->next = val;
+                    val->next = val + 1;
+                }
+                obj[count * 2].next = obj + 1;
+                obj->uni.ptr = obj + (count * 2 - 1);
+            }
+            return obj;
+        }
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc, const char **pairs, size_t count) {
-	if (yyjson_likely(doc && ((count > 0 && pairs) || (count == 0)))) {
-		yyjson_mut_val *obj = unsafe_yyjson_mut_val(doc, 1 + count * 2);
-		if (yyjson_likely(obj)) {
-			obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
-			if (count > 0) {
-				size_t i;
-				for (i = 0; i < count; i++) {
-					yyjson_mut_val *key = obj + (i * 2 + 1);
-					yyjson_mut_val *val = obj + (i * 2 + 2);
-					const char *key_str = pairs[i * 2 + 0];
-					const char *val_str = pairs[i * 2 + 1];
-					uint64_t key_len = (uint64_t)strlen(key_str);
-					uint64_t val_len = (uint64_t)strlen(val_str);
-					key->tag = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-					val->tag = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-					key->uni.str = key_str;
-					val->uni.str = val_str;
-					key->next = val;
-					val->next = val + 1;
-				}
-				obj[count * 2].next = obj + 1;
-				obj->uni.ptr = obj + (count * 2 - 1);
-			}
-			return obj;
-		}
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_with_kv(yyjson_mut_doc *doc,
+                                                         const char **pairs,
+                                                         size_t count) {
+    if (yyjson_likely(doc && ((count > 0 && pairs) || (count == 0)))) {
+        yyjson_mut_val *obj = unsafe_yyjson_mut_val(doc, 1 + count * 2);
+        if (yyjson_likely(obj)) {
+            obj->tag = ((uint64_t)count << YYJSON_TAG_BIT) | YYJSON_TYPE_OBJ;
+            if (count > 0) {
+                size_t i;
+                for (i = 0; i < count; i++) {
+                    yyjson_mut_val *key = obj + (i * 2 + 1);
+                    yyjson_mut_val *val = obj + (i * 2 + 2);
+                    const char *key_str = pairs[i * 2 + 0];
+                    const char *val_str = pairs[i * 2 + 1];
+                    uint64_t key_len = (uint64_t)strlen(key_str);
+                    uint64_t val_len = (uint64_t)strlen(val_str);
+                    key->tag = (key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+                    val->tag = (val_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+                    key->uni.str = key_str;
+                    val->uni.str = val_str;
+                    key->next = val;
+                    val->next = val + 1;
+                }
+                obj[count * 2].next = obj + 1;
+                obj->uni.ptr = obj + (count * 2 - 1);
+            }
+            return obj;
+        }
+    }
+    return NULL;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Object Modification API (Implementation)
  *============================================================================*/
 
-yyjson_api_inline void unsafe_yyjson_mut_obj_add(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val,
+yyjson_api_inline void unsafe_yyjson_mut_obj_add(yyjson_mut_val *obj,
+                                                 yyjson_mut_val *key,
+                                                 yyjson_mut_val *val,
                                                  size_t len) {
-	if (yyjson_likely(len)) {
-		yyjson_mut_val *prev_val = ((yyjson_mut_val *)obj->uni.ptr)->next;
-		yyjson_mut_val *next_key = prev_val->next;
-		prev_val->next = key;
-		val->next = next_key;
-	} else {
-		val->next = key;
-	}
-	key->next = val;
-	obj->uni.ptr = (void *)key;
-	unsafe_yyjson_set_len(obj, len + 1);
+    if (yyjson_likely(len)) {
+        yyjson_mut_val *prev_val = ((yyjson_mut_val *)obj->uni.ptr)->next;
+        yyjson_mut_val *next_key = prev_val->next;
+        prev_val->next = key;
+        val->next = next_key;
+    } else {
+        val->next = key;
+    }
+    key->next = val;
+    obj->uni.ptr = (void *)key;
+    unsafe_yyjson_set_len(obj, len + 1);
 }
 
-yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_obj_remove(yyjson_mut_val *obj, const char *key, size_t key_len,
-                                                               uint64_t key_tag) {
-	size_t obj_len = unsafe_yyjson_get_len(obj);
-	if (obj_len) {
-		yyjson_mut_val *pre_key = (yyjson_mut_val *)obj->uni.ptr;
-		yyjson_mut_val *cur_key = pre_key->next->next;
-		yyjson_mut_val *removed_item = NULL;
-		size_t i;
-		for (i = 0; i < obj_len; i++) {
-			if (key_tag == cur_key->tag && duckdb::FastMemcmp(key, cur_key->uni.ptr, key_len) == 0) {
-				if (!removed_item)
-					removed_item = cur_key->next;
-				cur_key = cur_key->next->next;
-				pre_key->next->next = cur_key;
-				if (i + 1 == obj_len)
-					obj->uni.ptr = pre_key;
-				i--;
-				obj_len--;
-			} else {
-				pre_key = cur_key;
-				cur_key = cur_key->next->next;
-			}
-		}
-		unsafe_yyjson_set_len(obj, obj_len);
-		return removed_item;
-	} else {
-		return NULL;
-	}
+yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_obj_remove(
+    yyjson_mut_val *obj, const char *key, size_t key_len) {
+    size_t obj_len = unsafe_yyjson_get_len(obj);
+    if (obj_len) {
+        yyjson_mut_val *pre_key = (yyjson_mut_val *)obj->uni.ptr;
+        yyjson_mut_val *cur_key = pre_key->next->next;
+        yyjson_mut_val *removed_item = NULL;
+        size_t i;
+        for (i = 0; i < obj_len; i++) {
+            if (unsafe_yyjson_equals_strn(cur_key, key, key_len)) {
+                if (!removed_item) removed_item = cur_key->next;
+                cur_key = cur_key->next->next;
+                pre_key->next->next = cur_key;
+                if (i + 1 == obj_len) obj->uni.ptr = pre_key;
+                i--;
+                obj_len--;
+            } else {
+                pre_key = cur_key;
+                cur_key = cur_key->next->next;
+            }
+        }
+        unsafe_yyjson_set_len(obj, obj_len);
+        return removed_item;
+    } else {
+        return NULL;
+    }
 }
 
-yyjson_api_inline bool unsafe_yyjson_mut_obj_replace(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val) {
-	size_t key_len = unsafe_yyjson_get_len(key);
-	size_t obj_len = unsafe_yyjson_get_len(obj);
-	if (obj_len) {
-		yyjson_mut_val *pre_key = (yyjson_mut_val *)obj->uni.ptr;
-		yyjson_mut_val *cur_key = pre_key->next->next;
-		size_t i;
-		for (i = 0; i < obj_len; i++) {
-			if (key->tag == cur_key->tag && duckdb::FastMemcmp(key->uni.str, cur_key->uni.ptr, key_len) == 0) {
-				cur_key->next->tag = val->tag;
-				cur_key->next->uni.u64 = val->uni.u64;
-				return true;
-			} else {
-				cur_key = cur_key->next->next;
-			}
-		}
-	}
-	return false;
+yyjson_api_inline bool unsafe_yyjson_mut_obj_replace(yyjson_mut_val *obj,
+                                                     yyjson_mut_val *key,
+                                                     yyjson_mut_val *val) {
+    size_t key_len = unsafe_yyjson_get_len(key);
+    size_t obj_len = unsafe_yyjson_get_len(obj);
+    if (obj_len) {
+        yyjson_mut_val *pre_key = (yyjson_mut_val *)obj->uni.ptr;
+        yyjson_mut_val *cur_key = pre_key->next->next;
+        size_t i;
+        for (i = 0; i < obj_len; i++) {
+            if (unsafe_yyjson_equals_strn(cur_key, key->uni.str, key_len)) {
+                cur_key->next->tag = val->tag;
+                cur_key->next->uni.u64 = val->uni.u64;
+                return true;
+            } else {
+                cur_key = cur_key->next->next;
+            }
+        }
+    }
+    return false;
 }
 
-yyjson_api_inline void unsafe_yyjson_mut_obj_rotate(yyjson_mut_val *obj, size_t idx) {
-	yyjson_mut_val *key = (yyjson_mut_val *)obj->uni.ptr;
-	while (idx-- > 0)
-		key = key->next->next;
-	obj->uni.ptr = (void *)key;
+yyjson_api_inline void unsafe_yyjson_mut_obj_rotate(yyjson_mut_val *obj,
+                                                    size_t idx) {
+    yyjson_mut_val *key = (yyjson_mut_val *)obj->uni.ptr;
+    while (idx-- > 0) key = key->next->next;
+    obj->uni.ptr = (void *)key;
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && yyjson_mut_is_str(key) && val)) {
-		unsafe_yyjson_mut_obj_add(obj, key, val, unsafe_yyjson_get_len(obj));
-		return true;
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_obj_add(yyjson_mut_val *obj,
+                                          yyjson_mut_val *key,
+                                          yyjson_mut_val *val) {
+    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
+                      yyjson_mut_is_str(key) && val)) {
+        unsafe_yyjson_mut_obj_add(obj, key, val, unsafe_yyjson_get_len(obj));
+        return true;
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_obj_put(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && yyjson_mut_is_str(key))) {
-		unsafe_yyjson_mut_obj_remove(obj, key->uni.str, unsafe_yyjson_get_len(key), key->tag);
-		if (yyjson_likely(val)) {
-			unsafe_yyjson_mut_obj_add(obj, key, val, unsafe_yyjson_get_len(obj));
-		}
-		return true;
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_obj_put(yyjson_mut_val *obj,
+                                          yyjson_mut_val *key,
+                                          yyjson_mut_val *val) {
+    bool replaced = false;
+    size_t key_len;
+    yyjson_mut_obj_iter iter;
+    yyjson_mut_val *cur_key;
+    if (yyjson_unlikely(!yyjson_mut_is_obj(obj) ||
+                        !yyjson_mut_is_str(key))) return false;
+    key_len = unsafe_yyjson_get_len(key);
+    yyjson_mut_obj_iter_init(obj, &iter);
+    while ((cur_key = yyjson_mut_obj_iter_next(&iter)) != 0) {
+        if (unsafe_yyjson_equals_strn(cur_key, key->uni.str, key_len)) {
+            if (!replaced && val) {
+                replaced = true;
+                val->next = cur_key->next->next;
+                cur_key->next = val;
+            } else {
+                yyjson_mut_obj_iter_remove(&iter);
+            }
+        }
+    }
+    if (!replaced && val) unsafe_yyjson_mut_obj_add(obj, key, val, iter.max);
+    return true;
 }
 
-yyjson_api_inline bool yyjson_mut_obj_insert(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val,
+yyjson_api_inline bool yyjson_mut_obj_insert(yyjson_mut_val *obj,
+                                             yyjson_mut_val *key,
+                                             yyjson_mut_val *val,
                                              size_t idx) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && yyjson_mut_is_str(key) && val)) {
-		size_t len = unsafe_yyjson_get_len(obj);
-		if (yyjson_likely(len >= idx)) {
-			if (len > idx) {
-				void *ptr = obj->uni.ptr;
-				unsafe_yyjson_mut_obj_rotate(obj, idx);
-				unsafe_yyjson_mut_obj_add(obj, key, val, len);
-				obj->uni.ptr = ptr;
-			} else {
-				unsafe_yyjson_mut_obj_add(obj, key, val, len);
-			}
-			return true;
-		}
-	}
-	return false;
+    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
+                      yyjson_mut_is_str(key) && val)) {
+        size_t len = unsafe_yyjson_get_len(obj);
+        if (yyjson_likely(len >= idx)) {
+            if (len > idx) {
+                void *ptr = obj->uni.ptr;
+                unsafe_yyjson_mut_obj_rotate(obj, idx);
+                unsafe_yyjson_mut_obj_add(obj, key, val, len);
+                obj->uni.ptr = ptr;
+            } else {
+                unsafe_yyjson_mut_obj_add(obj, key, val, len);
+            }
+            return true;
+        }
+    }
+    return false;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove(yyjson_mut_val *obj, yyjson_mut_val *key) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && yyjson_mut_is_str(key))) {
-		return unsafe_yyjson_mut_obj_remove(obj, key->uni.str, unsafe_yyjson_get_len(key), key->tag);
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove(yyjson_mut_val *obj,
+    yyjson_mut_val *key) {
+    if (yyjson_likely(yyjson_mut_is_obj(obj) && yyjson_mut_is_str(key))) {
+        return unsafe_yyjson_mut_obj_remove(obj, key->uni.str,
+                                            unsafe_yyjson_get_len(key));
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key(yyjson_mut_val *obj, const char *key) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && key)) {
-		size_t key_len = strlen(key);
-		uint64_t tag = ((uint64_t)key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		return unsafe_yyjson_mut_obj_remove(obj, key, key_len, tag);
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_key(
+    yyjson_mut_val *obj, const char *key) {
+    if (yyjson_likely(yyjson_mut_is_obj(obj) && key)) {
+        size_t key_len = strlen(key);
+        return unsafe_yyjson_mut_obj_remove(obj, key, key_len);
+    }
+    return NULL;
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_keyn(yyjson_mut_val *obj, const char *key, size_t key_len) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && key)) {
-		uint64_t tag = ((uint64_t)key_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		return unsafe_yyjson_mut_obj_remove(obj, key, key_len, tag);
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_keyn(
+    yyjson_mut_val *obj, const char *key, size_t key_len) {
+    if (yyjson_likely(yyjson_mut_is_obj(obj) && key)) {
+        return unsafe_yyjson_mut_obj_remove(obj, key, key_len);
+    }
+    return NULL;
 }
 
 yyjson_api_inline bool yyjson_mut_obj_clear(yyjson_mut_val *obj) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj))) {
-		unsafe_yyjson_set_len(obj, 0);
-		return true;
-	}
-	return false;
+    if (yyjson_likely(yyjson_mut_is_obj(obj))) {
+        unsafe_yyjson_set_len(obj, 0);
+        return true;
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_obj_replace(yyjson_mut_val *obj, yyjson_mut_val *key, yyjson_mut_val *val) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && yyjson_mut_is_str(key) && val)) {
-		return unsafe_yyjson_mut_obj_replace(obj, key, val);
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_obj_replace(yyjson_mut_val *obj,
+                                              yyjson_mut_val *key,
+                                              yyjson_mut_val *val) {
+    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
+                      yyjson_mut_is_str(key) && val)) {
+        return unsafe_yyjson_mut_obj_replace(obj, key, val);
+    }
+    return false;
 }
 
-yyjson_api_inline bool yyjson_mut_obj_rotate(yyjson_mut_val *obj, size_t idx) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && unsafe_yyjson_get_len(obj) > idx)) {
-		unsafe_yyjson_mut_obj_rotate(obj, idx);
-		return true;
-	}
-	return false;
+yyjson_api_inline bool yyjson_mut_obj_rotate(yyjson_mut_val *obj,
+                                             size_t idx) {
+    if (yyjson_likely(yyjson_mut_is_obj(obj) &&
+                      unsafe_yyjson_get_len(obj) > idx)) {
+        unsafe_yyjson_mut_obj_rotate(obj, idx);
+        return true;
+    }
+    return false;
 }
+
+
 
 /*==============================================================================
  * Mutable JSON Object Modification Convenience API (Implementation)
  *============================================================================*/
 
-#define yyjson_mut_obj_add_func(func)                                                                                  \
-	if (yyjson_likely(doc && yyjson_mut_is_obj(obj) && _key)) {                                                        \
-		yyjson_mut_val *key = unsafe_yyjson_mut_val(doc, 2);                                                           \
-		if (yyjson_likely(key)) {                                                                                      \
-			size_t len = unsafe_yyjson_get_len(obj);                                                                   \
-			yyjson_mut_val *val = key + 1;                                                                             \
-			key->tag = YYJSON_TYPE_STR | YYJSON_SUBTYPE_NONE;                                                          \
-			key->tag |= (uint64_t)strlen(_key) << YYJSON_TAG_BIT;                                                      \
-			key->uni.str = _key;                                                                                       \
-			func unsafe_yyjson_mut_obj_add(obj, key, val, len);                                                        \
-			return true;                                                                                               \
-		}                                                                                                              \
-	}                                                                                                                  \
-	return false
+#define yyjson_mut_obj_add_func(func) \
+    if (yyjson_likely(doc && yyjson_mut_is_obj(obj) && _key)) { \
+        yyjson_mut_val *key = unsafe_yyjson_mut_val(doc, 2); \
+        if (yyjson_likely(key)) { \
+            size_t len = unsafe_yyjson_get_len(obj); \
+            yyjson_mut_val *val = key + 1; \
+            size_t key_len = strlen(_key); \
+            bool noesc = unsafe_yyjson_is_str_noesc(_key, key_len); \
+            key->tag = YYJSON_TYPE_STR; \
+            key->tag |= noesc ? YYJSON_SUBTYPE_NOESC : YYJSON_SUBTYPE_NONE; \
+            key->tag |= (uint64_t)strlen(_key) << YYJSON_TAG_BIT; \
+            key->uni.str = _key; \
+            func \
+            unsafe_yyjson_mut_obj_add(obj, key, val, len); \
+            return true; \
+        } \
+    } \
+    return false
 
-yyjson_api_inline bool yyjson_mut_obj_add_null(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key) {
-	yyjson_mut_obj_add_func({ val->tag = YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE; });
+yyjson_api_inline bool yyjson_mut_obj_add_null(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *_key) {
+    yyjson_mut_obj_add_func({
+        val->tag = YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_true(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key) {
-	yyjson_mut_obj_add_func({ val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE; });
+yyjson_api_inline bool yyjson_mut_obj_add_true(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *_key) {
+    yyjson_mut_obj_add_func({
+        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_false(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key) {
-	yyjson_mut_obj_add_func({ val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE; });
+yyjson_api_inline bool yyjson_mut_obj_add_false(yyjson_mut_doc *doc,
+                                                yyjson_mut_val *obj,
+                                                const char *_key) {
+    yyjson_mut_obj_add_func({
+        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_bool(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key, bool _val) {
-	yyjson_mut_obj_add_func({ val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)(_val) << 3); });
+yyjson_api_inline bool yyjson_mut_obj_add_bool(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *_key,
+                                               bool _val) {
+    yyjson_mut_obj_add_func({
+        _val = !!_val;
+        val->tag = YYJSON_TYPE_BOOL | (uint8_t)((uint8_t)(_val) << 3);
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_uint(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
+yyjson_api_inline bool yyjson_mut_obj_add_uint(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *_key,
                                                uint64_t _val) {
-	yyjson_mut_obj_add_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
-		val->uni.u64 = _val;
-	});
+    yyjson_mut_obj_add_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT;
+        val->uni.u64 = _val;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_sint(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
+yyjson_api_inline bool yyjson_mut_obj_add_sint(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *_key,
                                                int64_t _val) {
-	yyjson_mut_obj_add_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-		val->uni.i64 = _val;
-	});
+    yyjson_mut_obj_add_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+        val->uni.i64 = _val;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_int(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
+yyjson_api_inline bool yyjson_mut_obj_add_int(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *obj,
+                                              const char *_key,
                                               int64_t _val) {
-	yyjson_mut_obj_add_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
-		val->uni.i64 = _val;
-	});
+    yyjson_mut_obj_add_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT;
+        val->uni.i64 = _val;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_real(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
+yyjson_api_inline bool yyjson_mut_obj_add_real(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *_key,
                                                double _val) {
-	yyjson_mut_obj_add_func({
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-		val->uni.f64 = _val;
-	});
+    yyjson_mut_obj_add_func({
+        val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+        val->uni.f64 = _val;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_str(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
+yyjson_api_inline bool yyjson_mut_obj_add_str(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *obj,
+                                              const char *_key,
                                               const char *_val) {
-	if (yyjson_unlikely(!_val))
-		return false;
-	yyjson_mut_obj_add_func({
-		val->tag = ((uint64_t)strlen(_val) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		val->uni.str = _val;
-	});
+    if (yyjson_unlikely(!_val)) return false;
+    yyjson_mut_obj_add_func({
+        size_t val_len = strlen(_val);
+        bool val_noesc = unsafe_yyjson_is_str_noesc(_val, val_len);
+        val->tag = ((uint64_t)strlen(_val) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->tag |= val_noesc ? YYJSON_SUBTYPE_NOESC : YYJSON_SUBTYPE_NONE;
+        val->uni.str = _val;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_strn(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
-                                               const char *_val, size_t _len) {
-	if (yyjson_unlikely(!_val))
-		return false;
-	yyjson_mut_obj_add_func({
-		val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		val->uni.str = _val;
-	});
+yyjson_api_inline bool yyjson_mut_obj_add_strn(yyjson_mut_doc *doc,
+                                               yyjson_mut_val *obj,
+                                               const char *_key,
+                                               const char *_val,
+                                               size_t _len) {
+    if (yyjson_unlikely(!_val)) return false;
+    yyjson_mut_obj_add_func({
+        val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->uni.str = _val;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_strcpy(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
+yyjson_api_inline bool yyjson_mut_obj_add_strcpy(yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *obj,
+                                                 const char *_key,
                                                  const char *_val) {
-	if (yyjson_unlikely(!_val))
-		return false;
-	yyjson_mut_obj_add_func({
-		size_t _len = strlen(_val);
-		val->uni.str = unsafe_yyjson_mut_strncpy(doc, _val, _len);
-		if (yyjson_unlikely(!val->uni.str))
-			return false;
-		val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-	});
+    if (yyjson_unlikely(!_val)) return false;
+    yyjson_mut_obj_add_func({
+        size_t _len = strlen(_val);
+        val->uni.str = unsafe_yyjson_mut_strncpy(doc, _val, _len);
+        if (yyjson_unlikely(!val->uni.str)) return false;
+        val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_strncpy(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
-                                                  const char *_val, size_t _len) {
-	if (yyjson_unlikely(!_val))
-		return false;
-	yyjson_mut_obj_add_func({
-		val->uni.str = unsafe_yyjson_mut_strncpy(doc, _val, _len);
-		if (yyjson_unlikely(!val->uni.str))
-			return false;
-		val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-	});
+yyjson_api_inline bool yyjson_mut_obj_add_strncpy(yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *_key,
+                                                  const char *_val,
+                                                  size_t _len) {
+    if (yyjson_unlikely(!_val)) return false;
+    yyjson_mut_obj_add_func({
+        val->uni.str = unsafe_yyjson_mut_strncpy(doc, _val, _len);
+        if (yyjson_unlikely(!val->uni.str)) return false;
+        val->tag = ((uint64_t)_len << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+    });
 }
 
-yyjson_api_inline bool yyjson_mut_obj_add_val(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *_key,
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_add_arr(yyjson_mut_doc *doc,
+                                                         yyjson_mut_val *obj,
+                                                         const char *_key) {
+    yyjson_mut_val *key = yyjson_mut_str(doc, _key);
+    yyjson_mut_val *val = yyjson_mut_arr(doc);
+    return yyjson_mut_obj_add(obj, key, val) ? val : NULL;
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_add_obj(yyjson_mut_doc *doc,
+                                                         yyjson_mut_val *obj,
+                                                         const char *_key) {
+    yyjson_mut_val *key = yyjson_mut_str(doc, _key);
+    yyjson_mut_val *val = yyjson_mut_obj(doc);
+    return yyjson_mut_obj_add(obj, key, val) ? val : NULL;
+}
+
+yyjson_api_inline bool yyjson_mut_obj_add_val(yyjson_mut_doc *doc,
+                                              yyjson_mut_val *obj,
+                                              const char *_key,
                                               yyjson_mut_val *_val) {
-	if (yyjson_unlikely(!_val))
-		return false;
-	yyjson_mut_obj_add_func({ val = _val; });
+    if (yyjson_unlikely(!_val)) return false;
+    yyjson_mut_obj_add_func({
+        val = _val;
+    });
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_str(yyjson_mut_val *obj, const char *key) {
-	return yyjson_mut_obj_remove_strn(obj, key, key ? strlen(key) : 0);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_str(yyjson_mut_val *obj,
+                                                            const char *key) {
+    return yyjson_mut_obj_remove_strn(obj, key, key ? strlen(key) : 0);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_strn(yyjson_mut_val *obj, const char *_key, size_t _len) {
-	if (yyjson_likely(yyjson_mut_is_obj(obj) && _key)) {
-		yyjson_mut_val *key;
-		yyjson_mut_obj_iter iter;
-		yyjson_mut_val *val_removed = NULL;
-		yyjson_mut_obj_iter_init(obj, &iter);
-		while ((key = yyjson_mut_obj_iter_next(&iter)) != NULL) {
-			if (unsafe_yyjson_get_len(key) == _len && duckdb::FastMemcmp(key->uni.str, _key, _len) == 0) {
-				if (!val_removed)
-					val_removed = key->next;
-				yyjson_mut_obj_iter_remove(&iter);
-			}
-		}
-		return val_removed;
-	}
-	return NULL;
+yyjson_api_inline yyjson_mut_val *yyjson_mut_obj_remove_strn(
+    yyjson_mut_val *obj, const char *_key, size_t _len) {
+    if (yyjson_likely(yyjson_mut_is_obj(obj) && _key)) {
+        yyjson_mut_val *key;
+        yyjson_mut_obj_iter iter;
+        yyjson_mut_val *val_removed = NULL;
+        yyjson_mut_obj_iter_init(obj, &iter);
+        while ((key = yyjson_mut_obj_iter_next(&iter)) != NULL) {
+            if (unsafe_yyjson_equals_strn(key, _key, _len)) {
+                if (!val_removed) val_removed = key->next;
+                yyjson_mut_obj_iter_remove(&iter);
+            }
+        }
+        return val_removed;
+    }
+    return NULL;
 }
 
-yyjson_api_inline bool yyjson_mut_obj_rename_key(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key,
+yyjson_api_inline bool yyjson_mut_obj_rename_key(yyjson_mut_doc *doc,
+                                                 yyjson_mut_val *obj,
+                                                 const char *key,
                                                  const char *new_key) {
-	if (!key || !new_key)
-		return false;
-	return yyjson_mut_obj_rename_keyn(doc, obj, key, strlen(key), new_key, strlen(new_key));
+    if (!key || !new_key) return false;
+    return yyjson_mut_obj_rename_keyn(doc, obj, key, strlen(key),
+                                      new_key, strlen(new_key));
 }
 
-yyjson_api_inline bool yyjson_mut_obj_rename_keyn(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, size_t len,
-                                                  const char *new_key, size_t new_len) {
-	char *cpy_key = NULL;
-	yyjson_mut_val *old_key;
-	yyjson_mut_obj_iter iter;
-	if (!doc || !obj || !key || !new_key)
-		return false;
-	yyjson_mut_obj_iter_init(obj, &iter);
-	while ((old_key = yyjson_mut_obj_iter_next(&iter))) {
-		if (unsafe_yyjson_equals_strn((void *)old_key, key, len)) {
-			if (!cpy_key) {
-				cpy_key = unsafe_yyjson_mut_strncpy(doc, new_key, new_len);
-				if (!cpy_key)
-					return false;
-			}
-			yyjson_mut_set_strn(old_key, cpy_key, new_len);
-		}
-	}
-	return cpy_key != NULL;
+yyjson_api_inline bool yyjson_mut_obj_rename_keyn(yyjson_mut_doc *doc,
+                                                  yyjson_mut_val *obj,
+                                                  const char *key,
+                                                  size_t len,
+                                                  const char *new_key,
+                                                  size_t new_len) {
+    char *cpy_key = NULL;
+    yyjson_mut_val *old_key;
+    yyjson_mut_obj_iter iter;
+    if (!doc || !obj || !key || !new_key) return false;
+    yyjson_mut_obj_iter_init(obj, &iter);
+    while ((old_key = yyjson_mut_obj_iter_next(&iter))) {
+        if (unsafe_yyjson_equals_strn((void *)old_key, key, len)) {
+            if (!cpy_key) {
+                cpy_key = unsafe_yyjson_mut_strncpy(doc, new_key, new_len);
+                if (!cpy_key) return false;
+            }
+            yyjson_mut_set_strn(old_key, cpy_key, new_len);
+        }
+    }
+    return cpy_key != NULL;
 }
+
+
 
 /*==============================================================================
  * JSON Pointer API (Implementation)
  *============================================================================*/
 
-/* `val` not null, `ptr` start with '/', `len` > 0. */
-yyjson_api yyjson_val *unsafe_yyjson_get_pointer(yyjson_val *val, const char *ptr, size_t len);
+#define yyjson_ptr_set_err(_code, _msg) do { \
+    if (err) { \
+        err->code = YYJSON_PTR_ERR_##_code; \
+        err->msg = _msg; \
+        err->pos = 0; \
+    } \
+} while(false)
 
-/* `val` not null, `ptr` start with '/', `len` > 0. */
-yyjson_api yyjson_mut_val *unsafe_yyjson_mut_get_pointer(yyjson_mut_val *val, const char *ptr, size_t len);
+/* require: val != NULL, *ptr == '/', len > 0 */
+yyjson_api yyjson_val *unsafe_yyjson_ptr_getx(yyjson_val *val,
+                                              const char *ptr, size_t len,
+                                              yyjson_ptr_err *err);
 
-yyjson_api_inline yyjson_val *yyjson_get_pointern(yyjson_val *val, const char *ptr, size_t len) {
-	if (!val || !ptr)
-		return NULL;
-	if (len == 0)
-		return val;
-	if (*ptr != '/')
-		return NULL;
-	return unsafe_yyjson_get_pointer(val, ptr, len);
+/* require: val != NULL, *ptr == '/', len > 0 */
+yyjson_api yyjson_mut_val *unsafe_yyjson_mut_ptr_getx(yyjson_mut_val *val,
+                                                      const char *ptr,
+                                                      size_t len,
+                                                      yyjson_ptr_ctx *ctx,
+                                                      yyjson_ptr_err *err);
+
+/* require: val/new_val/doc != NULL, *ptr == '/', len > 0 */
+yyjson_api bool unsafe_yyjson_mut_ptr_putx(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc,
+                                           bool create_parent, bool insert_new,
+                                           yyjson_ptr_ctx *ctx,
+                                           yyjson_ptr_err *err);
+
+/* require: val/err != NULL, *ptr == '/', len > 0 */
+yyjson_api yyjson_mut_val *unsafe_yyjson_mut_ptr_replacex(
+    yyjson_mut_val *val, const char *ptr, size_t len, yyjson_mut_val *new_val,
+    yyjson_ptr_ctx *ctx, yyjson_ptr_err *err);
+
+/* require: val/err != NULL, *ptr == '/', len > 0 */
+yyjson_api yyjson_mut_val *unsafe_yyjson_mut_ptr_removex(yyjson_mut_val *val,
+                                                         const char *ptr,
+                                                         size_t len,
+                                                         yyjson_ptr_ctx *ctx,
+                                                         yyjson_ptr_err *err);
+
+yyjson_api_inline yyjson_val *yyjson_doc_ptr_get(yyjson_doc *doc,
+                                                 const char *ptr) {
+    if (yyjson_unlikely(!ptr)) return NULL;
+    return yyjson_doc_ptr_getn(doc, ptr, strlen(ptr));
 }
 
-yyjson_api_inline yyjson_val *yyjson_get_pointer(yyjson_val *val, const char *ptr) {
-	if (!val || !ptr)
-		return NULL;
-	return yyjson_get_pointern(val, ptr, strlen(ptr));
+yyjson_api_inline yyjson_val *yyjson_doc_ptr_getn(yyjson_doc *doc,
+                                                  const char *ptr, size_t len) {
+    return yyjson_doc_ptr_getx(doc, ptr, len, NULL);
 }
 
-yyjson_api_inline yyjson_val *yyjson_doc_get_pointern(yyjson_doc *doc, const char *ptr, size_t len) {
-	return yyjson_get_pointern(doc ? doc->root : NULL, ptr, len);
+yyjson_api_inline yyjson_val *yyjson_doc_ptr_getx(yyjson_doc *doc,
+                                                  const char *ptr, size_t len,
+                                                  yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (yyjson_unlikely(!doc || !ptr)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(!doc->root)) {
+        yyjson_ptr_set_err(NULL_ROOT, "document's root is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        return doc->root;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return NULL;
+    }
+    return unsafe_yyjson_ptr_getx(doc->root, ptr, len, err);
 }
 
-yyjson_api_inline yyjson_val *yyjson_doc_get_pointer(yyjson_doc *doc, const char *ptr) {
-	return yyjson_get_pointer(doc ? doc->root : NULL, ptr);
+yyjson_api_inline yyjson_val *yyjson_ptr_get(yyjson_val *val,
+                                             const char *ptr) {
+    if (yyjson_unlikely(!ptr)) return NULL;
+    return yyjson_ptr_getn(val, ptr, strlen(ptr));
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointern(yyjson_mut_val *val, const char *ptr, size_t len) {
-	if (!val || !ptr)
-		return NULL;
-	if (len == 0)
-		return val;
-	if (*ptr != '/')
-		return NULL;
-	return unsafe_yyjson_mut_get_pointer(val, ptr, len);
+yyjson_api_inline yyjson_val *yyjson_ptr_getn(yyjson_val *val,
+                                              const char *ptr, size_t len) {
+    return yyjson_ptr_getx(val, ptr, len, NULL);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointer(yyjson_mut_val *val, const char *ptr) {
-	if (!val || !ptr)
-		return NULL;
-	return yyjson_mut_get_pointern(val, ptr, strlen(ptr));
+yyjson_api_inline yyjson_val *yyjson_ptr_getx(yyjson_val *val,
+                                              const char *ptr, size_t len,
+                                              yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (yyjson_unlikely(!val || !ptr)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        return val;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return NULL;
+    }
+    return unsafe_yyjson_ptr_getx(val, ptr, len, err);
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointern(yyjson_mut_doc *doc, const char *ptr, size_t len) {
-	return yyjson_mut_get_pointern(doc ? doc->root : NULL, ptr, len);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_get(yyjson_mut_doc *doc,
+                                                         const char *ptr) {
+    if (!ptr) return NULL;
+    return yyjson_mut_doc_ptr_getn(doc, ptr, strlen(ptr));
 }
 
-yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(yyjson_mut_doc *doc, const char *ptr) {
-	return yyjson_mut_get_pointer(doc ? doc->root : NULL, ptr);
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_getn(yyjson_mut_doc *doc,
+                                                          const char *ptr,
+                                                          size_t len) {
+    return yyjson_mut_doc_ptr_getx(doc, ptr, len, NULL, NULL);
 }
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_getx(yyjson_mut_doc *doc,
+                                                          const char *ptr,
+                                                          size_t len,
+                                                          yyjson_ptr_ctx *ctx,
+                                                          yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!doc || !ptr)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(!doc->root)) {
+        yyjson_ptr_set_err(NULL_ROOT, "document's root is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        return doc->root;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return NULL;
+    }
+    return unsafe_yyjson_mut_ptr_getx(doc->root, ptr, len, ctx, err);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_get(yyjson_mut_val *val,
+                                                     const char *ptr) {
+    if (!ptr) return NULL;
+    return yyjson_mut_ptr_getn(val, ptr, strlen(ptr));
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_getn(yyjson_mut_val *val,
+                                                      const char *ptr,
+                                                      size_t len) {
+    return yyjson_mut_ptr_getx(val, ptr, len, NULL, NULL);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_getx(yyjson_mut_val *val,
+                                                      const char *ptr,
+                                                      size_t len,
+                                                      yyjson_ptr_ctx *ctx,
+                                                      yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!val || !ptr)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        return val;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return NULL;
+    }
+    return unsafe_yyjson_mut_ptr_getx(val, ptr, len, ctx, err);
+}
+
+yyjson_api_inline bool yyjson_mut_doc_ptr_add(yyjson_mut_doc *doc,
+                                              const char *ptr,
+                                              yyjson_mut_val *new_val) {
+    if (yyjson_unlikely(!ptr)) return false;
+    return yyjson_mut_doc_ptr_addn(doc, ptr, strlen(ptr), new_val);
+}
+
+yyjson_api_inline bool yyjson_mut_doc_ptr_addn(yyjson_mut_doc *doc,
+                                               const char *ptr,
+                                               size_t len,
+                                               yyjson_mut_val *new_val) {
+    return yyjson_mut_doc_ptr_addx(doc, ptr, len, new_val, true, NULL, NULL);
+}
+
+yyjson_api_inline bool yyjson_mut_doc_ptr_addx(yyjson_mut_doc *doc,
+                                               const char *ptr, size_t len,
+                                               yyjson_mut_val *new_val,
+                                               bool create_parent,
+                                               yyjson_ptr_ctx *ctx,
+                                               yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!doc || !ptr || !new_val)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return false;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        if (doc->root) {
+            yyjson_ptr_set_err(SET_ROOT, "cannot set document's root");
+            return false;
+        } else {
+            doc->root = new_val;
+            return true;
+        }
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return false;
+    }
+    if (yyjson_unlikely(!doc->root && !create_parent)) {
+        yyjson_ptr_set_err(NULL_ROOT, "document's root is NULL");
+        return false;
+    }
+    if (yyjson_unlikely(!doc->root)) {
+        yyjson_mut_val *root = yyjson_mut_obj(doc);
+        if (yyjson_unlikely(!root)) {
+            yyjson_ptr_set_err(MEMORY_ALLOCATION, "failed to create value");
+            return false;
+        }
+        if (unsafe_yyjson_mut_ptr_putx(root, ptr, len, new_val, doc,
+                                       create_parent, true, ctx, err)) {
+            doc->root = root;
+            return true;
+        }
+        return false;
+    }
+    return unsafe_yyjson_mut_ptr_putx(doc->root, ptr, len, new_val, doc,
+                                      create_parent, true, ctx, err);
+}
+
+yyjson_api_inline bool yyjson_mut_ptr_add(yyjson_mut_val *val,
+                                          const char *ptr,
+                                          yyjson_mut_val *new_val,
+                                          yyjson_mut_doc *doc) {
+    if (yyjson_unlikely(!ptr)) return false;
+    return yyjson_mut_ptr_addn(val, ptr, strlen(ptr), new_val, doc);
+}
+
+yyjson_api_inline bool yyjson_mut_ptr_addn(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc) {
+    return yyjson_mut_ptr_addx(val, ptr, len, new_val, doc, true, NULL, NULL);
+}
+
+yyjson_api_inline bool yyjson_mut_ptr_addx(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc,
+                                           bool create_parent,
+                                           yyjson_ptr_ctx *ctx,
+                                           yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!val || !ptr || !new_val || !doc)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return false;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        yyjson_ptr_set_err(SET_ROOT, "cannot set root");
+        return false;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return false;
+    }
+    return unsafe_yyjson_mut_ptr_putx(val, ptr, len, new_val,
+                                       doc, create_parent, true, ctx, err);
+}
+
+yyjson_api_inline bool yyjson_mut_doc_ptr_set(yyjson_mut_doc *doc,
+                                              const char *ptr,
+                                              yyjson_mut_val *new_val) {
+    if (yyjson_unlikely(!ptr)) return false;
+    return yyjson_mut_doc_ptr_setn(doc, ptr, strlen(ptr), new_val);
+}
+
+yyjson_api_inline bool yyjson_mut_doc_ptr_setn(yyjson_mut_doc *doc,
+                                               const char *ptr, size_t len,
+                                               yyjson_mut_val *new_val) {
+    return yyjson_mut_doc_ptr_setx(doc, ptr, len, new_val, true, NULL, NULL);
+}
+
+yyjson_api_inline bool yyjson_mut_doc_ptr_setx(yyjson_mut_doc *doc,
+                                               const char *ptr, size_t len,
+                                               yyjson_mut_val *new_val,
+                                               bool create_parent,
+                                               yyjson_ptr_ctx *ctx,
+                                               yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!doc || !ptr)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return false;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        if (ctx) ctx->old = doc->root;
+        doc->root = new_val;
+        return true;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return false;
+    }
+    if (!new_val) {
+        if (!doc->root) {
+            yyjson_ptr_set_err(RESOLVE, "JSON pointer cannot be resolved");
+            return false;
+        }
+        return !!unsafe_yyjson_mut_ptr_removex(doc->root, ptr, len, ctx, err);
+    }
+    if (yyjson_unlikely(!doc->root && !create_parent)) {
+        yyjson_ptr_set_err(NULL_ROOT, "document's root is NULL");
+        return false;
+    }
+    if (yyjson_unlikely(!doc->root)) {
+        yyjson_mut_val *root = yyjson_mut_obj(doc);
+        if (yyjson_unlikely(!root)) {
+            yyjson_ptr_set_err(MEMORY_ALLOCATION, "failed to create value");
+            return false;
+        }
+        if (unsafe_yyjson_mut_ptr_putx(root, ptr, len, new_val, doc,
+                                       create_parent, false, ctx, err)) {
+            doc->root = root;
+            return true;
+        }
+        return false;
+    }
+    return unsafe_yyjson_mut_ptr_putx(doc->root, ptr, len, new_val, doc,
+                                      create_parent, false, ctx, err);
+}
+
+yyjson_api_inline bool yyjson_mut_ptr_set(yyjson_mut_val *val,
+                                          const char *ptr,
+                                          yyjson_mut_val *new_val,
+                                          yyjson_mut_doc *doc) {
+    if (yyjson_unlikely(!ptr)) return false;
+    return yyjson_mut_ptr_setn(val, ptr, strlen(ptr), new_val, doc);
+}
+
+yyjson_api_inline bool yyjson_mut_ptr_setn(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc) {
+    return yyjson_mut_ptr_setx(val, ptr, len, new_val, doc, true, NULL, NULL);
+}
+
+yyjson_api_inline bool yyjson_mut_ptr_setx(yyjson_mut_val *val,
+                                           const char *ptr, size_t len,
+                                           yyjson_mut_val *new_val,
+                                           yyjson_mut_doc *doc,
+                                           bool create_parent,
+                                           yyjson_ptr_ctx *ctx,
+                                           yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!val || !ptr || !doc)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return false;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        yyjson_ptr_set_err(SET_ROOT, "cannot set root");
+        return false;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return false;
+    }
+    if (!new_val) {
+        return !!unsafe_yyjson_mut_ptr_removex(val, ptr, len, ctx, err);
+    }
+    return unsafe_yyjson_mut_ptr_putx(val, ptr, len, new_val, doc,
+                                      create_parent, false, ctx, err);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_replace(
+    yyjson_mut_doc *doc, const char *ptr, yyjson_mut_val *new_val) {
+    if (!ptr) return NULL;
+    return yyjson_mut_doc_ptr_replacen(doc, ptr, strlen(ptr), new_val);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_replacen(
+    yyjson_mut_doc *doc, const char *ptr, size_t len, yyjson_mut_val *new_val) {
+    return yyjson_mut_doc_ptr_replacex(doc, ptr, len, new_val, NULL, NULL);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_replacex(
+    yyjson_mut_doc *doc, const char *ptr, size_t len, yyjson_mut_val *new_val,
+    yyjson_ptr_ctx *ctx, yyjson_ptr_err *err) {
+    
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!doc || !ptr || !new_val)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        yyjson_mut_val *root = doc->root;
+        if (yyjson_unlikely(!root)) {
+            yyjson_ptr_set_err(RESOLVE, "JSON pointer cannot be resolved");
+            return NULL;
+        }
+        if (ctx) ctx->old = root;
+        doc->root = new_val;
+        return root;
+    }
+    if (yyjson_unlikely(!doc->root)) {
+        yyjson_ptr_set_err(NULL_ROOT, "document's root is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return NULL;
+    }
+    return unsafe_yyjson_mut_ptr_replacex(doc->root, ptr, len, new_val,
+                                          ctx, err);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_replace(
+    yyjson_mut_val *val, const char *ptr, yyjson_mut_val *new_val) {
+    if (!ptr) return NULL;
+    return yyjson_mut_ptr_replacen(val, ptr, strlen(ptr), new_val);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_replacen(
+    yyjson_mut_val *val, const char *ptr, size_t len, yyjson_mut_val *new_val) {
+    return yyjson_mut_ptr_replacex(val, ptr, len, new_val, NULL, NULL);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_replacex(
+    yyjson_mut_val *val, const char *ptr, size_t len, yyjson_mut_val *new_val,
+    yyjson_ptr_ctx *ctx, yyjson_ptr_err *err) {
+    
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!val || !ptr || !new_val)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        yyjson_ptr_set_err(SET_ROOT, "cannot set root");
+        return NULL;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return NULL;
+    }
+    return unsafe_yyjson_mut_ptr_replacex(val, ptr, len, new_val, ctx, err);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_remove(
+    yyjson_mut_doc *doc, const char *ptr) {
+    if (!ptr) return NULL;
+    return yyjson_mut_doc_ptr_removen(doc, ptr, strlen(ptr));
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_removen(
+    yyjson_mut_doc *doc, const char *ptr, size_t len) {
+    return yyjson_mut_doc_ptr_removex(doc, ptr, len, NULL, NULL);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_ptr_removex(
+    yyjson_mut_doc *doc, const char *ptr, size_t len,
+    yyjson_ptr_ctx *ctx, yyjson_ptr_err *err) {
+    
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!doc || !ptr)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(!doc->root)) {
+        yyjson_ptr_set_err(NULL_ROOT, "document's root is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        yyjson_mut_val *root = doc->root;
+        if (ctx) ctx->old = root;
+        doc->root = NULL;
+        return root;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return NULL;
+    }
+    return unsafe_yyjson_mut_ptr_removex(doc->root, ptr, len, ctx, err);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_remove(yyjson_mut_val *val,
+                                                        const char *ptr) {
+    if (!ptr) return NULL;
+    return yyjson_mut_ptr_removen(val, ptr, strlen(ptr));
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_removen(yyjson_mut_val *val,
+                                                         const char *ptr,
+                                                         size_t len) {
+    return yyjson_mut_ptr_removex(val, ptr, len, NULL, NULL);
+}
+
+yyjson_api_inline yyjson_mut_val *yyjson_mut_ptr_removex(yyjson_mut_val *val,
+                                                         const char *ptr,
+                                                         size_t len,
+                                                         yyjson_ptr_ctx *ctx,
+                                                         yyjson_ptr_err *err) {
+    yyjson_ptr_set_err(NONE, NULL);
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+    
+    if (yyjson_unlikely(!val || !ptr)) {
+        yyjson_ptr_set_err(PARAMETER, "input parameter is NULL");
+        return NULL;
+    }
+    if (yyjson_unlikely(len == 0)) {
+        yyjson_ptr_set_err(SET_ROOT, "cannot set root");
+        return NULL;
+    }
+    if (yyjson_unlikely(*ptr != '/')) {
+        yyjson_ptr_set_err(SYNTAX, "no prefix '/'");
+        return NULL;
+    }
+    return unsafe_yyjson_mut_ptr_removex(val, ptr, len, ctx, err);
+}
+
+yyjson_api_inline bool yyjson_ptr_ctx_append(yyjson_ptr_ctx *ctx,
+                                             yyjson_mut_val *key,
+                                             yyjson_mut_val *val) {
+    yyjson_mut_val *ctn, *pre_key, *pre_val, *cur_key, *cur_val;
+    if (!ctx || !ctx->ctn || !val) return false;
+    ctn = ctx->ctn;
+    
+    if (yyjson_mut_is_obj(ctn)) {
+        if (!key) return false;
+        key->next = val;
+        pre_key = ctx->pre;
+        if (unsafe_yyjson_get_len(ctn) == 0) {
+            val->next = key;
+            ctn->uni.ptr = key;
+            ctx->pre = key;
+        } else if (!pre_key) {
+            pre_key = (yyjson_mut_val *)ctn->uni.ptr;
+            pre_val = pre_key->next;
+            val->next = pre_val->next;
+            pre_val->next = key;
+            ctn->uni.ptr = key;
+            ctx->pre = pre_key;
+        } else {
+            cur_key = pre_key->next->next;
+            cur_val = cur_key->next;
+            val->next = cur_val->next;
+            cur_val->next = key;
+            if (ctn->uni.ptr == cur_key) ctn->uni.ptr = key;
+            ctx->pre = cur_key;
+        }
+    } else {
+        pre_val = ctx->pre;
+        if (unsafe_yyjson_get_len(ctn) == 0) {
+            val->next = val;
+            ctn->uni.ptr = val;
+            ctx->pre = val;
+        } else if (!pre_val) {
+            pre_val = (yyjson_mut_val *)ctn->uni.ptr;
+            val->next = pre_val->next;
+            pre_val->next = val;
+            ctn->uni.ptr = val;
+            ctx->pre = pre_val;
+        } else {
+            cur_val = pre_val->next;
+            val->next = cur_val->next;
+            cur_val->next = val;
+            if (ctn->uni.ptr == cur_val) ctn->uni.ptr = val;
+            ctx->pre = cur_val;
+        }
+    }
+    unsafe_yyjson_inc_len(ctn);
+    return true;
+}
+
+yyjson_api_inline bool yyjson_ptr_ctx_replace(yyjson_ptr_ctx *ctx,
+                                              yyjson_mut_val *val) {
+    yyjson_mut_val *ctn, *pre_key, *cur_key, *pre_val, *cur_val;
+    if (!ctx || !ctx->ctn || !ctx->pre || !val) return false;
+    ctn = ctx->ctn;
+    if (yyjson_mut_is_obj(ctn)) {
+        pre_key = ctx->pre;
+        pre_val = pre_key->next;
+        cur_key = pre_val->next;
+        cur_val = cur_key->next;
+        /* replace current value */
+        cur_key->next = val;
+        val->next = cur_val->next;
+        ctx->old = cur_val;
+    } else {
+        pre_val = ctx->pre;
+        cur_val = pre_val->next;
+        /* replace current value */
+        if (pre_val != cur_val) {
+            val->next = cur_val->next;
+            pre_val->next = val;
+            if (ctn->uni.ptr == cur_val) ctn->uni.ptr = val;
+        } else {
+            val->next = val;
+            ctn->uni.ptr = val;
+            ctx->pre = val;
+        }
+        ctx->old = cur_val;
+    }
+    return true;
+}
+
+yyjson_api_inline bool yyjson_ptr_ctx_remove(yyjson_ptr_ctx *ctx) {
+    yyjson_mut_val *ctn, *pre_key, *pre_val, *cur_key, *cur_val;
+    size_t len;
+    if (!ctx || !ctx->ctn || !ctx->pre) return false;
+    ctn = ctx->ctn;
+    if (yyjson_mut_is_obj(ctn)) {
+        pre_key = ctx->pre;
+        pre_val = pre_key->next;
+        cur_key = pre_val->next;
+        cur_val = cur_key->next;
+        /* remove current key-value */
+        pre_val->next = cur_val->next;
+        if (ctn->uni.ptr == cur_key) ctn->uni.ptr = pre_key;
+        ctx->pre = NULL;
+        ctx->old = cur_val;
+    } else {
+        pre_val = ctx->pre;
+        cur_val = pre_val->next;
+        /* remove current key-value */
+        pre_val->next = cur_val->next;
+        if (ctn->uni.ptr == cur_val) ctn->uni.ptr = pre_val;
+        ctx->pre = NULL;
+        ctx->old = cur_val;
+    }
+    len = unsafe_yyjson_get_len(ctn) - 1;
+    if (len == 0) ctn->uni.ptr = NULL;
+    unsafe_yyjson_set_len(ctn, len);
+    return true;
+}
+
+#undef yyjson_ptr_set_err
+
+
+
+/*==============================================================================
+ * JSON Value at Pointer API (Implementation)
+ *============================================================================*/
+
+/**
+ Set provided `value` if the JSON Pointer (RFC 6901) exists and is type bool.
+ Returns true if value at `ptr` exists and is the correct type, otherwise false.
+ */
+yyjson_api_inline bool yyjson_ptr_get_bool(
+    yyjson_val *root, const char *ptr, bool *value) {
+    yyjson_val *val = yyjson_ptr_get(root, ptr);
+    if (value && yyjson_is_bool(val)) {
+        *value = unsafe_yyjson_get_bool(val);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ Set provided `value` if the JSON Pointer (RFC 6901) exists and is an integer
+ that fits in `uint64_t`. Returns true if successful, otherwise false.
+ */
+yyjson_api_inline bool yyjson_ptr_get_uint(
+    yyjson_val *root, const char *ptr, uint64_t *value) {
+    yyjson_val *val = yyjson_ptr_get(root, ptr);
+    if (value && val) {
+        uint64_t ret = val->uni.u64;
+        if (unsafe_yyjson_is_uint(val) ||
+            (unsafe_yyjson_is_sint(val) && !(ret >> 63))) {
+            *value = ret;
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ Set provided `value` if the JSON Pointer (RFC 6901) exists and is an integer
+ that fits in `int64_t`. Returns true if successful, otherwise false.
+ */
+yyjson_api_inline bool yyjson_ptr_get_sint(
+    yyjson_val *root, const char *ptr, int64_t *value) {
+    yyjson_val *val = yyjson_ptr_get(root, ptr);
+    if (value && val) {
+        int64_t ret = val->uni.i64;
+        if (unsafe_yyjson_is_sint(val) ||
+            (unsafe_yyjson_is_uint(val) && ret >= 0)) {
+            *value = ret;
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ Set provided `value` if the JSON Pointer (RFC 6901) exists and is type real.
+ Returns true if value at `ptr` exists and is the correct type, otherwise false.
+ */
+yyjson_api_inline bool yyjson_ptr_get_real(
+    yyjson_val *root, const char *ptr, double *value) {
+    yyjson_val *val = yyjson_ptr_get(root, ptr);
+    if (value && yyjson_is_real(val)) {
+        *value = unsafe_yyjson_get_real(val);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ Set provided `value` if the JSON Pointer (RFC 6901) exists and is type sint,
+ uint or real.
+ Returns true if value at `ptr` exists and is the correct type, otherwise false.
+ */
+yyjson_api_inline bool yyjson_ptr_get_num(
+    yyjson_val *root, const char *ptr, double *value) {
+    yyjson_val *val = yyjson_ptr_get(root, ptr);
+    if (value && yyjson_is_num(val)) {
+        *value = unsafe_yyjson_get_num(val);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ Set provided `value` if the JSON Pointer (RFC 6901) exists and is type string.
+ Returns true if value at `ptr` exists and is the correct type, otherwise false.
+ */
+yyjson_api_inline bool yyjson_ptr_get_str(
+    yyjson_val *root, const char *ptr, const char **value) {
+    yyjson_val *val = yyjson_ptr_get(root, ptr);
+    if (value && yyjson_is_str(val)) {
+        *value = unsafe_yyjson_get_str(val);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+
+
+/*==============================================================================
+ * Deprecated
+ *============================================================================*/
+
+/** @deprecated renamed to `yyjson_doc_ptr_get` */
+yyjson_deprecated("renamed to yyjson_doc_ptr_get")
+yyjson_api_inline yyjson_val *yyjson_doc_get_pointer(yyjson_doc *doc,
+                                                     const char *ptr) {
+    return yyjson_doc_ptr_get(doc, ptr);
+}
+
+/** @deprecated renamed to `yyjson_doc_ptr_getn` */
+yyjson_deprecated("renamed to yyjson_doc_ptr_getn")
+yyjson_api_inline yyjson_val *yyjson_doc_get_pointern(yyjson_doc *doc,
+                                                      const char *ptr,
+                                                      size_t len) {
+    return yyjson_doc_ptr_getn(doc, ptr, len);
+}
+
+/** @deprecated renamed to `yyjson_mut_doc_ptr_get` */
+yyjson_deprecated("renamed to yyjson_mut_doc_ptr_get")
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointer(
+    yyjson_mut_doc *doc, const char *ptr) {
+    return yyjson_mut_doc_ptr_get(doc, ptr);
+}
+
+/** @deprecated renamed to `yyjson_mut_doc_ptr_getn` */
+yyjson_deprecated("renamed to yyjson_mut_doc_ptr_getn")
+yyjson_api_inline yyjson_mut_val *yyjson_mut_doc_get_pointern(
+    yyjson_mut_doc *doc, const char *ptr, size_t len) {
+    return yyjson_mut_doc_ptr_getn(doc, ptr, len);
+}
+
+/** @deprecated renamed to `yyjson_ptr_get` */
+yyjson_deprecated("renamed to yyjson_ptr_get")
+yyjson_api_inline yyjson_val *yyjson_get_pointer(yyjson_val *val,
+                                                 const char *ptr) {
+    return yyjson_ptr_get(val, ptr);
+}
+
+/** @deprecated renamed to `yyjson_ptr_getn` */
+yyjson_deprecated("renamed to yyjson_ptr_getn")
+yyjson_api_inline yyjson_val *yyjson_get_pointern(yyjson_val *val,
+                                                  const char *ptr,
+                                                  size_t len) {
+    return yyjson_ptr_getn(val, ptr, len);
+}
+
+/** @deprecated renamed to `yyjson_mut_ptr_get` */
+yyjson_deprecated("renamed to yyjson_mut_ptr_get")
+yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointer(yyjson_mut_val *val,
+                                                         const char *ptr) {
+    return yyjson_mut_ptr_get(val, ptr);
+}
+
+/** @deprecated renamed to `yyjson_mut_ptr_getn` */
+yyjson_deprecated("renamed to yyjson_mut_ptr_getn")
+yyjson_api_inline yyjson_mut_val *yyjson_mut_get_pointern(yyjson_mut_val *val,
+                                                          const char *ptr,
+                                                          size_t len) {
+    return yyjson_mut_ptr_getn(val, ptr, len);
+}
+
+/** @deprecated renamed to `yyjson_mut_ptr_getn` */
+yyjson_deprecated("renamed to unsafe_yyjson_ptr_getn")
+yyjson_api_inline yyjson_val *unsafe_yyjson_get_pointer(yyjson_val *val,
+                                                        const char *ptr,
+                                                        size_t len) {
+    yyjson_ptr_err err;
+    return unsafe_yyjson_ptr_getx(val, ptr, len, &err);
+}
+
+/** @deprecated renamed to `unsafe_yyjson_mut_ptr_getx` */
+yyjson_deprecated("renamed to unsafe_yyjson_mut_ptr_getx")
+yyjson_api_inline yyjson_mut_val *unsafe_yyjson_mut_get_pointer(
+    yyjson_mut_val *val, const char *ptr, size_t len) {
+    yyjson_ptr_err err;
+    return unsafe_yyjson_mut_ptr_getx(val, ptr, len, NULL, &err);
+}
+
+
 
 /*==============================================================================
  * Compiler Hint End
  *============================================================================*/
 
 #if defined(__clang__)
-#pragma clang diagnostic pop
+#   pragma clang diagnostic pop
 #elif defined(__GNUC__)
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#pragma GCC diagnostic pop
-#endif
+#   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#   pragma GCC diagnostic pop
+#   endif
 #elif defined(_MSC_VER)
-#pragma warning(pop)
+#   pragma warning(pop)
 #endif /* warning suppress end */
 
 #ifdef __cplusplus

--- a/src/yyjson/yyjson.cpp
+++ b/src/yyjson/yyjson.cpp
@@ -1,134 +1,130 @@
 /*==============================================================================
- * Created by Yaoyuan on 2019/3/9.
- * Copyright (C) 2019 Yaoyuan <ibireme@gmail.com>.
- *
- * Released under the MIT License:
- * https://github.com/ibireme/yyjson/blob/master/LICENSE
+ Copyright (c) 2020 YaoYuan <ibireme@gmail.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
  *============================================================================*/
 
 #include "yyjson.hpp"
-#include <stdio.h>
 #include <math.h>
 
+
+
 /*==============================================================================
- * Compile Hint Begin
+ * Warning Suppress
  *============================================================================*/
 
-/* warning suppress begin */
 #if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wunused-label"
-#pragma clang diagnostic ignored "-Wunused-macros"
+#   pragma clang diagnostic ignored "-Wunused-function"
+#   pragma clang diagnostic ignored "-Wunused-parameter"
+#   pragma clang diagnostic ignored "-Wunused-label"
+#   pragma clang diagnostic ignored "-Wunused-macros"
+#   pragma clang diagnostic ignored "-Wunused-variable"
 #elif defined(__GNUC__)
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#pragma GCC diagnostic push
-#endif
-#pragma GCC diagnostic ignored "-Wunused-function"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-label"
-#pragma GCC diagnostic ignored "-Wunused-macros"
+#   pragma GCC diagnostic ignored "-Wunused-function"
+#   pragma GCC diagnostic ignored "-Wunused-parameter"
+#   pragma GCC diagnostic ignored "-Wunused-label"
+#   pragma GCC diagnostic ignored "-Wunused-macros"
+#   pragma GCC diagnostic ignored "-Wunused-variable"
 #elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4100) /* unreferenced formal parameter */
-#pragma warning(disable : 4102) /* unreferenced label */
-#pragma warning(disable : 4127) /* conditional expression is constant */
-#pragma warning(disable : 4706) /* assignment within conditional expression */
+#   pragma warning(disable:4100) /* unreferenced formal parameter */
+#   pragma warning(disable:4101) /* unreferenced variable */
+#   pragma warning(disable:4102) /* unreferenced label */
+#   pragma warning(disable:4127) /* conditional expression is constant */
+#   pragma warning(disable:4706) /* assignment within conditional expression */
 #endif
+
+
 
 /*==============================================================================
  * Version
  *============================================================================*/
 
-yyjson_api uint32_t yyjson_version(void) {
-	return YYJSON_VERSION_HEX;
+uint32_t yyjson_version(void) {
+    return YYJSON_VERSION_HEX;
 }
+
+
 
 /*==============================================================================
  * Flags
  *============================================================================*/
 
-/* gcc version check */
-#if defined(__GNUC__)
-#if defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#define yyjson_gcc_available(major, minor, patch)                                                                      \
-	((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= (major * 10000 + minor * 100 + patch))
-#elif defined(__GNUC_MINOR__)
-#define yyjson_gcc_available(major, minor, patch)                                                                      \
-	((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) >= (major * 10000 + minor * 100 + patch))
-#else
-#define yyjson_gcc_available(major, minor, patch) ((__GNUC__ * 10000) >= (major * 10000 + minor * 100 + patch))
-#endif
-#else
-#define yyjson_gcc_available(major, minor, patch) 0
-#endif
-
-/* real gcc check */
-#if !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__ICC) && defined(__GNUC__) && defined(__GNUC_MINOR__)
-#define YYJSON_IS_REAL_GCC 1
-#else
-#define YYJSON_IS_REAL_GCC 0
-#endif
-
 /* msvc intrinsic */
 #if YYJSON_MSC_VER >= 1400
-#include <intrin.h>
-#if defined(_M_AMD64) || defined(_M_ARM64)
-#define MSC_HAS_BIT_SCAN_64 1
-#pragma intrinsic(_BitScanForward64)
-#pragma intrinsic(_BitScanReverse64)
+#   include <intrin.h>
+#   if defined(_M_AMD64) || defined(_M_ARM64)
+#       define MSC_HAS_BIT_SCAN_64 1
+#       pragma intrinsic(_BitScanForward64)
+#       pragma intrinsic(_BitScanReverse64)
+#   else
+#       define MSC_HAS_BIT_SCAN_64 0
+#   endif
+#   if defined(_M_AMD64) || defined(_M_ARM64) || \
+        defined(_M_IX86) || defined(_M_ARM)
+#       define MSC_HAS_BIT_SCAN 1
+#       pragma intrinsic(_BitScanForward)
+#       pragma intrinsic(_BitScanReverse)
+#   else
+#       define MSC_HAS_BIT_SCAN 0
+#   endif
+#   if defined(_M_AMD64)
+#       define MSC_HAS_UMUL128 1
+#       pragma intrinsic(_umul128)
+#   else
+#       define MSC_HAS_UMUL128 0
+#   endif
 #else
-#define MSC_HAS_BIT_SCAN_64 0
-#endif
-#if defined(_M_AMD64) || defined(_M_ARM64) || defined(_M_IX86) || defined(_M_ARM)
-#define MSC_HAS_BIT_SCAN 1
-#pragma intrinsic(_BitScanForward)
-#pragma intrinsic(_BitScanReverse)
-#else
-#define MSC_HAS_BIT_SCAN 0
-#endif
-#if defined(_M_AMD64)
-#define MSC_HAS_UMUL128 1
-#pragma intrinsic(_umul128)
-#else
-#define MSC_HAS_UMUL128 0
-#endif
-#else
-#define MSC_HAS_BIT_SCAN_64 0
-#define MSC_HAS_BIT_SCAN    0
-#define MSC_HAS_UMUL128     0
+#   define MSC_HAS_BIT_SCAN_64 0
+#   define MSC_HAS_BIT_SCAN 0
+#   define MSC_HAS_UMUL128 0
 #endif
 
 /* gcc builtin */
 #if yyjson_has_builtin(__builtin_clzll) || yyjson_gcc_available(3, 4, 0)
-#define GCC_HAS_CLZLL 1
+#   define GCC_HAS_CLZLL 1
 #else
-#define GCC_HAS_CLZLL 0
+#   define GCC_HAS_CLZLL 0
 #endif
 
 #if yyjson_has_builtin(__builtin_ctzll) || yyjson_gcc_available(3, 4, 0)
-#define GCC_HAS_CTZLL 1
+#   define GCC_HAS_CTZLL 1
 #else
-#define GCC_HAS_CTZLL 0
+#   define GCC_HAS_CTZLL 0
 #endif
 
 /* int128 type */
-#if defined(__SIZEOF_INT128__) && (__SIZEOF_INT128__ == 16) &&                                                         \
+#if defined(__SIZEOF_INT128__) && (__SIZEOF_INT128__ == 16) && \
     (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER))
-#define YYJSON_HAS_INT128 1
+#    define YYJSON_HAS_INT128 1
 #else
-#define YYJSON_HAS_INT128 0
+#    define YYJSON_HAS_INT128 0
 #endif
 
 /* IEEE 754 floating-point binary representation */
 #if defined(__STDC_IEC_559__) || defined(__STDC_IEC_60559_BFP__)
-#define YYJSON_HAS_IEEE_754 1
-#elif (FLT_RADIX == 2) && (DBL_MANT_DIG == 53) && (DBL_DIG == 15) && (DBL_MIN_EXP == -1021) &&                         \
-    (DBL_MAX_EXP == 1024) && (DBL_MIN_10_EXP == -307) && (DBL_MAX_10_EXP == 308)
-#define YYJSON_HAS_IEEE_754 1
+#   define YYJSON_HAS_IEEE_754 1
+#elif (FLT_RADIX == 2) && (DBL_MANT_DIG == 53) && (DBL_DIG == 15) && \
+     (DBL_MIN_EXP == -1021) && (DBL_MAX_EXP == 1024) && \
+     (DBL_MIN_10_EXP == -307) && (DBL_MAX_10_EXP == 308)
+#   define YYJSON_HAS_IEEE_754 1
 #else
-#define YYJSON_HAS_IEEE_754 0
+#   define YYJSON_HAS_IEEE_754 0
 #endif
 
 /*
@@ -165,139 +161,123 @@ yyjson_api uint32_t yyjson_version(void) {
  See also: utils.h in https://github.com/google/double-conversion/
  */
 #if !defined(FLT_EVAL_METHOD) && defined(__FLT_EVAL_METHOD__)
-#define FLT_EVAL_METHOD __FLT_EVAL_METHOD__
+#    define FLT_EVAL_METHOD __FLT_EVAL_METHOD__
 #endif
 
 #if defined(FLT_EVAL_METHOD) && FLT_EVAL_METHOD != 0 && FLT_EVAL_METHOD != 1
-#define YYJSON_DOUBLE_MATH_CORRECT 0
-#elif defined(i386) || defined(__i386) || defined(__i386__) || defined(_X86_) || defined(__X86__) ||                   \
-    defined(_M_IX86) || defined(__I86__) || defined(__IA32__) || defined(__THW_INTEL)
-#if (defined(_MSC_VER) && defined(_M_IX86_FP) && _M_IX86_FP == 2) || (defined(__SSE2_MATH__) && __SSE2_MATH__)
-#define YYJSON_DOUBLE_MATH_CORRECT 1
-#else
-#define YYJSON_DOUBLE_MATH_CORRECT 0
-#endif
+#    define YYJSON_DOUBLE_MATH_CORRECT 0
+#elif defined(i386) || defined(__i386) || defined(__i386__) || \
+    defined(_X86_) || defined(__X86__) || defined(_M_IX86) || \
+    defined(__I86__) || defined(__IA32__) || defined(__THW_INTEL)
+#   if (defined(_MSC_VER) && defined(_M_IX86_FP) && _M_IX86_FP == 2) || \
+        (defined(__SSE2_MATH__) && __SSE2_MATH__)
+#       define YYJSON_DOUBLE_MATH_CORRECT 1
+#   else
+#       define YYJSON_DOUBLE_MATH_CORRECT 0
+#   endif
 #elif defined(__mc68000__) || defined(__pnacl__) || defined(__native_client__)
-#define YYJSON_DOUBLE_MATH_CORRECT 0
+#   define YYJSON_DOUBLE_MATH_CORRECT 0
 #else
-#define YYJSON_DOUBLE_MATH_CORRECT 1
-#endif
-
-/*
- Microsoft Visual C++ 6.0 doesn't support converting number from u64 to f64:
- error C2520: conversion from unsigned __int64 to double not implemented.
- */
-#ifndef YYJSON_U64_TO_F64_NO_IMPL
-#if (0 < YYJSON_MSC_VER) && (YYJSON_MSC_VER <= 1200)
-#define YYJSON_U64_TO_F64_NO_IMPL 1
-#else
-#define YYJSON_U64_TO_F64_NO_IMPL 0
-#endif
+#   define YYJSON_DOUBLE_MATH_CORRECT 1
 #endif
 
 /* endian */
-#if yyjson_has_include(<sys / types.h>)
-#include <sys/types.h>
+#if yyjson_has_include(<sys/types.h>)
+#    include <sys/types.h> /* POSIX */
 #endif
-
 #if yyjson_has_include(<endian.h>)
-#include <endian.h>
-#elif yyjson_has_include(<machine / endian.h>)
-#include <machine/endian.h>
-#elif yyjson_has_include(<sys / endian.h>)
-#include <sys/endian.h>
+#    include <endian.h> /* Linux */
+#elif yyjson_has_include(<sys/endian.h>)
+#    include <sys/endian.h> /* BSD, Android */
+#elif yyjson_has_include(<machine/endian.h>)
+#    include <machine/endian.h> /* BSD, Darwin */
 #endif
 
-#define YYJSON_BIG_ENDIAN    4321
-#define YYJSON_LITTLE_ENDIAN 1234
+#define YYJSON_BIG_ENDIAN       4321
+#define YYJSON_LITTLE_ENDIAN    1234
 
-#if defined(__BYTE_ORDER__) && __BYTE_ORDER__
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
-#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
-#endif
+#if defined(BYTE_ORDER) && BYTE_ORDER
+#   if defined(BIG_ENDIAN) && (BYTE_ORDER == BIG_ENDIAN)
+#       define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
+#   elif defined(LITTLE_ENDIAN) && (BYTE_ORDER == LITTLE_ENDIAN)
+#       define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
+#   endif
 
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER
-#if __BYTE_ORDER == __BIG_ENDIAN
-#define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
-#elif __BYTE_ORDER == __LITTLE_ENDIAN
-#define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
-#endif
+#   if defined(__BIG_ENDIAN) && (__BYTE_ORDER == __BIG_ENDIAN)
+#       define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
+#   elif defined(__LITTLE_ENDIAN) && (__BYTE_ORDER == __LITTLE_ENDIAN)
+#       define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
+#   endif
 
-#elif defined(BYTE_ORDER) && BYTE_ORDER
-#if BYTE_ORDER == BIG_ENDIAN
-#define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
-#elif BYTE_ORDER == LITTLE_ENDIAN
-#define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
-#endif
+#elif defined(__BYTE_ORDER__) && __BYTE_ORDER__
+#   if defined(__ORDER_BIG_ENDIAN__) && \
+        (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#       define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
+#   elif defined(__ORDER_LITTLE_ENDIAN__) && \
+        (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#       define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
+#   endif
 
-#elif (defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__ == 1) || defined(__i386) || defined(__i386__) ||                \
-    defined(_X86_) || defined(__X86__) || defined(_M_IX86) || defined(__THW_INTEL__) || defined(__x86_64) ||           \
-    defined(__x86_64__) || defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) || defined(_M_X64) ||           \
-    defined(__ia64) || defined(_IA64) || defined(__IA64__) || defined(__ia64__) || defined(_M_IA64) ||                 \
-    defined(__itanium__) || defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) ||                    \
-    defined(__alpha) || defined(__alpha__) || defined(_M_ALPHA) || defined(__riscv) || defined(__riscv__) ||           \
-    defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) || defined(__EMSCRIPTEN__) || defined(__wasm__)
-#define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
+#elif (defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__ == 1) || \
+    defined(__i386) || defined(__i386__) || \
+    defined(_X86_) || defined(__X86__) || \
+    defined(_M_IX86) || defined(__THW_INTEL__) || \
+    defined(__x86_64) || defined(__x86_64__) || \
+    defined(__amd64) || defined(__amd64__) || \
+    defined(_M_AMD64) || defined(_M_X64) || \
+    defined(_M_ARM) || defined(_M_ARM64) || \
+    defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || \
+    defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) || \
+    defined(__EMSCRIPTEN__) || defined(__wasm__) || \
+    defined(__loongarch__)
+#   define YYJSON_ENDIAN YYJSON_LITTLE_ENDIAN
 
-#elif (defined(__BIG_ENDIAN__) && __BIG_ENDIAN__ == 1) || defined(__ARMEB__) || defined(__THUMBEB__) ||                \
-    defined(__AARCH64EB__) || defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__) || defined(_ARCH_PPC) ||    \
-    defined(_ARCH_PPC64) || defined(__ppc) || defined(__ppc__) || defined(__sparc) || defined(__sparc__) ||            \
-    defined(__sparc64__) || defined(__or1k__) || defined(__OR1K__)
-#define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
+#elif (defined(__BIG_ENDIAN__) && __BIG_ENDIAN__ == 1) || \
+    defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__) || \
+    defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__) || \
+    defined(__or1k__) || defined(__OR1K__)
+#   define YYJSON_ENDIAN YYJSON_BIG_ENDIAN
 
 #else
-#define YYJSON_ENDIAN 0 /* unknown endian, detect at run-time */
+#   define YYJSON_ENDIAN 0 /* unknown endian, detect at run-time */
 #endif
 
 /*
- Unaligned memory access detection.
+ This macro controls how yyjson handles unaligned memory accesses.
 
- Some architectures cannot perform unaligned memory access, or unaligned memory
- accesses can have a large performance penalty. Modern compilers can make some
- optimizations for unaligned access. For example: https://godbolt.org/z/Ejo3Pa
+ By default, yyjson uses `memcpy()` for memory copying. This takes advantage of
+ the compiler's automatic optimizations to generate unaligned memory access
+ instructions when the target architecture supports it.
 
-    typedef struct { char c[2] } vec2;
-    void copy_vec2(vec2 *dst, vec2 *src) {
-        *dst = *src;
-    }
+ However, for some older compilers or architectures where `memcpy()` isn't
+ optimized well and may generate unnecessary function calls, consider defining
+ this macro as 1. In such cases, yyjson switches to manual byte-by-byte access,
+ potentially improving performance. An example of the generated assembly code on
+ the ARM platform can be found here: https://godbolt.org/z/334jjhxPT
 
- Compiler may generate `load/store` or `move` instruction if target architecture
- supports unaligned access, otherwise it may generate `call memcpy` instruction.
-
- We want to avoid `memcpy` calls, so we should disable unaligned access by
- define `YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS` as 1 on these architectures.
+ As this flag has already been enabled for some common architectures in the
+ following code, users typically don't need to manually specify it. If users are
+ unsure about it, please review the generated assembly code or perform actual
+ benchmark to make an informed decision.
  */
 #ifndef YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-#if defined(i386) || defined(__i386) || defined(__i386__) || defined(__i486__) || defined(__i586__) ||                 \
-    defined(__i686__) || defined(_X86_) || defined(__X86__) || defined(_M_IX86) || defined(__I86__) ||                 \
-    defined(__IA32__) || defined(__THW_INTEL) || defined(__THW_INTEL__) || defined(__x86_64) || defined(__x86_64__) || \
-    defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) || defined(_M_X64)
-#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* x86 */
-
-#elif defined(__ia64) || defined(_IA64) || defined(__IA64__) || defined(__ia64__) || defined(_M_IA64) ||               \
-    defined(__itanium__)
-#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* Itanium */
-
-#elif defined(__arm64) || defined(__arm64__) || defined(__AARCH64EL__) || defined(__AARCH64EB__) ||                    \
-    defined(__aarch64__) || defined(_M_ARM64)
-#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* ARM64 */
-
-#elif defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__) || defined(__ARM_ARCH_5TEJ__) ||                             \
-    defined(__ARM_ARCH_5TE__) || defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_6KZ__) || defined(__ARM_ARCH_6Z__) || \
-    defined(__ARM_ARCH_6K__)
-#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* ARM */
-
-#elif defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__) || defined(_ARCH_PPC64) || defined(__ppc) ||  \
-    defined(__ppc__) || defined(__PPC__) || defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__) ||      \
-    defined(_ARCH_PPC) || defined(_M_PPC) || defined(__PPCGECKO__) || defined(__PPCBROADWAY__) || defined(_XENON)
-#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* PowerPC */
-
-#else
-#define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0 /* Unknown */
-#endif
-
+#   if defined(__ia64) || defined(_IA64) || defined(__IA64__) ||  \
+        defined(__ia64__) || defined(_M_IA64) || defined(__itanium__)
+#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* Itanium */
+#   elif (defined(__arm__) || defined(__arm64__) || defined(__aarch64__)) && \
+        (defined(__GNUC__) || defined(__clang__)) && \
+        (!defined(__ARM_FEATURE_UNALIGNED) || !__ARM_FEATURE_UNALIGNED)
+#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* ARM */
+#   elif defined(__sparc) || defined(__sparc__)
+#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* SPARC */
+#   elif defined(__mips) || defined(__mips__) || defined(__MIPS__)
+#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* MIPS */
+#   elif defined(__m68k__) || defined(M68000)
+#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 1 /* M68K */
+#   else
+#       define YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS 0
+#   endif
 #endif
 
 /*
@@ -321,6 +301,15 @@ yyjson_api uint32_t yyjson_version(void) {
 #define YYJSON_WRITER_ESTIMATED_PRETTY_RATIO 32
 #define YYJSON_WRITER_ESTIMATED_MINIFY_RATIO 18
 
+/* The initial and maximum size of the memory pool's chunk in yyjson_mut_doc. */
+#define YYJSON_MUT_DOC_STR_POOL_INIT_SIZE   0x100
+#define YYJSON_MUT_DOC_STR_POOL_MAX_SIZE    0x10000000
+#define YYJSON_MUT_DOC_VAL_POOL_INIT_SIZE   (0x10 * sizeof(yyjson_mut_val))
+#define YYJSON_MUT_DOC_VAL_POOL_MAX_SIZE    (0x1000000 * sizeof(yyjson_mut_val))
+
+/* The minimum size of the dynamic allocator's chunk. */
+#define YYJSON_ALC_DYN_MIN_SIZE             0x1000
+
 /* Default value for compile-time options. */
 #ifndef YYJSON_DISABLE_READER
 #define YYJSON_DISABLE_READER 0
@@ -328,77 +317,114 @@ yyjson_api uint32_t yyjson_version(void) {
 #ifndef YYJSON_DISABLE_WRITER
 #define YYJSON_DISABLE_WRITER 0
 #endif
+#ifndef YYJSON_DISABLE_UTILS
+#define YYJSON_DISABLE_UTILS 0
+#endif
 #ifndef YYJSON_DISABLE_FAST_FP_CONV
 #define YYJSON_DISABLE_FAST_FP_CONV 0
 #endif
 #ifndef YYJSON_DISABLE_NON_STANDARD
 #define YYJSON_DISABLE_NON_STANDARD 0
 #endif
+#ifndef YYJSON_DISABLE_UTF8_VALIDATION
+#define YYJSON_DISABLE_UTF8_VALIDATION 0
+#endif
+
+
 
 /*==============================================================================
  * Macros
  *============================================================================*/
 
 /* Macros used for loop unrolling and other purpose. */
-#define repeat2(x)                                                                                                     \
-	{ x x }
-#define repeat3(x)                                                                                                     \
-	{ x x x }
-#define repeat4(x)                                                                                                     \
-	{ x x x x }
-#define repeat8(x)                                                                                                     \
-	{ x x x x x x x x }
-#define repeat16(x)                                                                                                    \
-	{ x x x x x x x x x x x x x x x x }
+#define repeat2(x)  { x x }
+#define repeat3(x)  { x x x }
+#define repeat4(x)  { x x x x }
+#define repeat8(x)  { x x x x x x x x }
+#define repeat16(x) { x x x x x x x x x x x x x x x x }
 
-#define repeat2_incr(x)                                                                                                \
-	{ x(0) x(1) }
-#define repeat4_incr(x)                                                                                                \
-	{ x(0) x(1) x(2) x(3) }
-#define repeat8_incr(x)                                                                                                \
-	{ x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7) }
-#define repeat16_incr(x)                                                                                               \
-	{ x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7) x(8) x(9) x(10) x(11) x(12) x(13) x(14) x(15) }
-#define repeat_in_1_18(x)                                                                                              \
-	{ x(1) x(2) x(3) x(4) x(5) x(6) x(7) x(8) x(9) x(10) x(11) x(12) x(13) x(14) x(15) x(16) x(17) x(18) }
+#define repeat2_incr(x)   { x(0)  x(1) }
+#define repeat4_incr(x)   { x(0)  x(1)  x(2)  x(3) }
+#define repeat8_incr(x)   { x(0)  x(1)  x(2)  x(3)  x(4)  x(5)  x(6)  x(7)  }
+#define repeat16_incr(x)  { x(0)  x(1)  x(2)  x(3)  x(4)  x(5)  x(6)  x(7)  \
+                            x(8)  x(9)  x(10) x(11) x(12) x(13) x(14) x(15) }
+
+#define repeat_in_1_18(x) { x(1)  x(2)  x(3)  x(4)  x(5)  x(6)  x(7)  x(8)  \
+                            x(9)  x(10) x(11) x(12) x(13) x(14) x(15) x(16) \
+                            x(17) x(18) }
 
 /* Macros used to provide branch prediction information for compiler. */
-#undef likely
-#define likely(x) yyjson_likely(x)
-#undef unlikely
-#define unlikely(x) yyjson_unlikely(x)
+#undef  likely
+#define likely(x)       yyjson_likely(x)
+#undef  unlikely
+#define unlikely(x)     yyjson_unlikely(x)
 
 /* Macros used to provide inline information for compiler. */
-#undef static_inline
-#define static_inline static yyjson_inline
-#undef static_noinline
+#undef  static_inline
+#define static_inline   static yyjson_inline
+#undef  static_noinline
 #define static_noinline static yyjson_noinline
 
 /* Macros for min and max. */
-#undef yyjson_min
+#undef  yyjson_min
 #define yyjson_min(x, y) ((x) < (y) ? (x) : (y))
-#undef yyjson_max
+#undef  yyjson_max
 #define yyjson_max(x, y) ((x) > (y) ? (x) : (y))
 
 /* Used to write u64 literal for C89 which doesn't support "ULL" suffix. */
-#undef U64
+#undef  U64
 #define U64(hi, lo) ((((u64)hi##UL) << 32U) + lo##UL)
+
+/* Used to cast away (remove) const qualifier. */
+#define constcast(type) (type)(void *)(size_t)(const void *)
+
+/* flag test */
+#define has_read_flag(_flag) unlikely(read_flag_eq(flg, YYJSON_READ_##_flag))
+#define has_write_flag(_flag) unlikely(write_flag_eq(flg, YYJSON_WRITE_##_flag))
+
+static_inline bool read_flag_eq(yyjson_read_flag flg, yyjson_read_flag chk) {
+#if YYJSON_DISABLE_NON_STANDARD
+    if (chk == YYJSON_READ_ALLOW_INF_AND_NAN ||
+        chk == YYJSON_READ_ALLOW_COMMENTS ||
+        chk == YYJSON_READ_ALLOW_TRAILING_COMMAS ||
+        chk == YYJSON_READ_ALLOW_INVALID_UNICODE)
+        return false; /* this should be evaluated at compile-time */
+#endif
+    return (flg & chk) != 0;
+}
+
+static_inline bool write_flag_eq(yyjson_write_flag flg, yyjson_write_flag chk) {
+#if YYJSON_DISABLE_NON_STANDARD
+    if (chk == YYJSON_WRITE_ALLOW_INF_AND_NAN ||
+        chk == YYJSON_WRITE_ALLOW_INVALID_UNICODE)
+        return false; /* this should be evaluated at compile-time */
+#endif
+    return (flg & chk) != 0;
+}
+
+
 
 /*==============================================================================
  * Integer Constants
  *============================================================================*/
 
 /* U64 constant values */
-#undef U64_MAX
-#define U64_MAX U64(0xFFFFFFFF, 0xFFFFFFFF)
-#undef I64_MAX
-#define I64_MAX U64(0x7FFFFFFF, 0xFFFFFFFF)
-#undef USIZE_MAX
-#define USIZE_MAX ((usize)(~(usize)0))
+#undef  U64_MAX
+#define U64_MAX         U64(0xFFFFFFFF, 0xFFFFFFFF)
+#undef  I64_MAX
+#define I64_MAX         U64(0x7FFFFFFF, 0xFFFFFFFF)
+#undef  USIZE_MAX
+#define USIZE_MAX       ((usize)(~(usize)0))
 
-/* Maximum number of digits for reading u64 safety. */
-#undef U64_SAFE_DIG
-#define U64_SAFE_DIG 19
+/* Maximum number of digits for reading u32/u64/usize safety (not overflow). */
+#undef  U32_SAFE_DIG
+#define U32_SAFE_DIG    9   /* u32 max is 4294967295, 10 digits */
+#undef  U64_SAFE_DIG
+#define U64_SAFE_DIG    19  /* u64 max is 18446744073709551615, 20 digits */
+#undef  USIZE_SAFE_DIG
+#define USIZE_SAFE_DIG  (sizeof(usize) == 8 ? U64_SAFE_DIG : U32_SAFE_DIG)
+
+
 
 /*==============================================================================
  * IEEE-754 Double Number Constants
@@ -453,229 +479,248 @@ yyjson_api uint32_t yyjson_version(void) {
 /* minimum binary power of double number */
 #define F64_MIN_BIN_EXP (-1021)
 
+
+
 /*==============================================================================
  * Types
  *============================================================================*/
 
 /** Type define for primitive types. */
-typedef float f32;
-typedef double f64;
-typedef int8_t i8;
-typedef uint8_t u8;
-typedef int16_t i16;
-typedef uint16_t u16;
-typedef int32_t i32;
-typedef uint32_t u32;
-typedef int64_t i64;
-typedef uint64_t u64;
-typedef size_t usize;
+typedef float       f32;
+typedef double      f64;
+typedef int8_t      i8;
+typedef uint8_t     u8;
+typedef int16_t     i16;
+typedef uint16_t    u16;
+typedef int32_t     i32;
+typedef uint32_t    u32;
+typedef int64_t     i64;
+typedef uint64_t    u64;
+typedef size_t      usize;
 
 /** 128-bit integer, used by floating-point number reader and writer. */
 #if YYJSON_HAS_INT128
-__extension__ typedef __int128 i128;
+__extension__ typedef __int128          i128;
 __extension__ typedef unsigned __int128 u128;
 #endif
 
 /** 16/32/64-bit vector */
-typedef struct v16 {
-	char c1, c2;
-} v16;
-typedef struct v32 {
-	char c1, c2, c3, c4;
-} v32;
-typedef struct v64 {
-	char c1, c2, c3, c4, c5, c6, c7, c8;
-} v64;
+typedef struct v16 { char c[2]; } v16;
+typedef struct v32 { char c[4]; } v32;
+typedef struct v64 { char c[8]; } v64;
 
-/** 16/32/64-bit vector union, used for unaligned memory access on modern CPU */
-typedef union v16_uni {
-	v16 v;
-	u16 u;
-} v16_uni;
-typedef union v32_uni {
-	v32 v;
-	u32 u;
-} v32_uni;
-typedef union v64_uni {
-	v64 v;
-	u64 u;
-} v64_uni;
+/** 16/32/64-bit vector union */
+typedef union v16_uni { v16 v; u16 u; } v16_uni;
+typedef union v32_uni { v32 v; u32 u; } v32_uni;
+typedef union v64_uni { v64 v; u64 u; } v64_uni;
+
+
 
 /*==============================================================================
  * Load/Store Utils
  *============================================================================*/
 
-#define byte_move_idx(x) ((u8 *)dst)[x] = ((u8 *)src)[x];
-
-static_inline void byte_move_2(void *dst, const void *src) {
 #if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	repeat2_incr(byte_move_idx);
-#else
-	memmove(dst, src, 2);
-#endif
-}
 
-static_inline void byte_move_4(void *dst, const void *src) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	repeat4_incr(byte_move_idx);
-#else
-	memmove(dst, src, 4);
-#endif
-}
-
-static_inline void byte_move_8(void *dst, const void *src) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	repeat8_incr(byte_move_idx);
-#else
-	memmove(dst, src, 8);
-#endif
-}
-
-static_inline void byte_move_16(void *dst, const void *src) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	repeat16_incr(byte_move_idx);
-#else
-	memmove(dst, src, 16);
-#endif
-}
+#define byte_move_idx(x) ((char *)dst)[x] = ((const char *)src)[x];
 
 static_inline void byte_copy_2(void *dst, const void *src) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	repeat2_incr(byte_move_idx);
-#else
-	memcpy(dst, src, 2);
-#endif
+    repeat2_incr(byte_move_idx)
 }
 
 static_inline void byte_copy_4(void *dst, const void *src) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	repeat4_incr(byte_move_idx);
-#else
-	memcpy(dst, src, 4);
-#endif
+    repeat4_incr(byte_move_idx)
 }
 
 static_inline void byte_copy_8(void *dst, const void *src) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	repeat8_incr(byte_move_idx);
-#else
-	memcpy(dst, src, 8);
-#endif
+    repeat8_incr(byte_move_idx)
 }
 
 static_inline void byte_copy_16(void *dst, const void *src) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	repeat16_incr(byte_move_idx);
-#else
-	memcpy(dst, src, 16);
-#endif
+    repeat16_incr(byte_move_idx)
+}
+
+static_inline void byte_move_2(void *dst, const void *src) {
+    repeat2_incr(byte_move_idx)
+}
+
+static_inline void byte_move_4(void *dst, const void *src) {
+    repeat4_incr(byte_move_idx)
+}
+
+static_inline void byte_move_8(void *dst, const void *src) {
+    repeat8_incr(byte_move_idx)
+}
+
+static_inline void byte_move_16(void *dst, const void *src) {
+    repeat16_incr(byte_move_idx)
 }
 
 static_inline bool byte_match_2(void *buf, const char *pat) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	return ((u8 *)buf)[0] == ((const u8 *)pat)[0] && ((u8 *)buf)[1] == ((const u8 *)pat)[1];
-#else
-	v16_uni u1, u2;
-	u1.v = *(const v16 *)pat;
-	u2.v = *(const v16 *)buf;
-	return u1.u == u2.u;
-#endif
+    return
+    ((char *)buf)[0] == ((const char *)pat)[0] &&
+    ((char *)buf)[1] == ((const char *)pat)[1];
 }
 
 static_inline bool byte_match_4(void *buf, const char *pat) {
-#if YYJSON_DISABLE_UNALIGNED_MEMORY_ACCESS
-	return ((u8 *)buf)[0] == ((const u8 *)pat)[0] && ((u8 *)buf)[1] == ((const u8 *)pat)[1] &&
-	       ((u8 *)buf)[2] == ((const u8 *)pat)[2] && ((u8 *)buf)[3] == ((const u8 *)pat)[3];
-#else
-	v32_uni u1, u2;
-	u1.v = *(const v32 *)pat;
-	u2.v = *(const v32 *)buf;
-	return u1.u == u2.u;
-#endif
+    return
+    ((char *)buf)[0] == ((const char *)pat)[0] &&
+    ((char *)buf)[1] == ((const char *)pat)[1] &&
+    ((char *)buf)[2] == ((const char *)pat)[2] &&
+    ((char *)buf)[3] == ((const char *)pat)[3];
 }
 
 static_inline u16 byte_load_2(const void *src) {
-	v16_uni uni;
-	uni.v = *(v16 *)src;
-	return uni.u;
+    v16_uni uni;
+    uni.v.c[0] = ((const char *)src)[0];
+    uni.v.c[1] = ((const char *)src)[1];
+    return uni.u;
 }
 
 static_inline u32 byte_load_3(const void *src) {
-	v32_uni uni;
-	((v16_uni *)&uni)->v = *(v16 *)src;
-	uni.v.c3 = ((char *)src)[2];
-	uni.v.c4 = 0;
-	return uni.u;
+    v32_uni uni;
+    uni.v.c[0] = ((const char *)src)[0];
+    uni.v.c[1] = ((const char *)src)[1];
+    uni.v.c[2] = ((const char *)src)[2];
+    uni.v.c[3] = 0;
+    return uni.u;
 }
 
 static_inline u32 byte_load_4(const void *src) {
-	v32_uni uni;
-	uni.v = *(v32 *)src;
-	return uni.u;
+    v32_uni uni;
+    uni.v.c[0] = ((const char *)src)[0];
+    uni.v.c[1] = ((const char *)src)[1];
+    uni.v.c[2] = ((const char *)src)[2];
+    uni.v.c[3] = ((const char *)src)[3];
+    return uni.u;
 }
 
 #undef byte_move_expr
+
+#else
+
+static_inline void byte_copy_2(void *dst, const void *src) {
+    memcpy(dst, src, 2);
+}
+
+static_inline void byte_copy_4(void *dst, const void *src) {
+    memcpy(dst, src, 4);
+}
+
+static_inline void byte_copy_8(void *dst, const void *src) {
+    memcpy(dst, src, 8);
+}
+
+static_inline void byte_copy_16(void *dst, const void *src) {
+    memcpy(dst, src, 16);
+}
+
+static_inline void byte_move_2(void *dst, const void *src) {
+    u16 tmp;
+    memcpy(&tmp, src, 2);
+    memcpy(dst, &tmp, 2);
+}
+
+static_inline void byte_move_4(void *dst, const void *src) {
+    u32 tmp;
+    memcpy(&tmp, src, 4);
+    memcpy(dst, &tmp, 4);
+}
+
+static_inline void byte_move_8(void *dst, const void *src) {
+    u64 tmp;
+    memcpy(&tmp, src, 8);
+    memcpy(dst, &tmp, 8);
+}
+
+static_inline void byte_move_16(void *dst, const void *src) {
+    char *pdst = (char *)dst;
+    const char *psrc = (const char *)src;
+    u64 tmp1, tmp2;
+    memcpy(&tmp1, psrc, 8);
+    memcpy(&tmp2, psrc + 8, 8);
+    memcpy(pdst, &tmp1, 8);
+    memcpy(pdst + 8, &tmp2, 8);
+}
+
+static_inline bool byte_match_2(void *buf, const char *pat) {
+    v16_uni u1, u2;
+    memcpy(&u1, buf, 2);
+    memcpy(&u2, pat, 2);
+    return u1.u == u2.u;
+}
+
+static_inline bool byte_match_4(void *buf, const char *pat) {
+    v32_uni u1, u2;
+    memcpy(&u1, buf, 4);
+    memcpy(&u2, pat, 4);
+    return u1.u == u2.u;
+}
+
+static_inline u16 byte_load_2(const void *src) {
+    v16_uni uni;
+    memcpy(&uni, src, 2);
+    return uni.u;
+}
+
+static_inline u32 byte_load_3(const void *src) {
+    v32_uni uni;
+    memcpy(&uni, src, 2);
+    uni.v.c[2] = ((const char *)src)[2];
+    uni.v.c[3] = 0;
+    return uni.u;
+}
+
+static_inline u32 byte_load_4(const void *src) {
+    v32_uni uni;
+    memcpy(&uni, src, 4);
+    return uni.u;
+}
+
+#endif
+
+
 
 /*==============================================================================
  * Number Utils
  * These functions are used to detect and convert NaN and Inf numbers.
  *============================================================================*/
 
-/**
- This union is used to avoid violating the strict aliasing rule in C.
- `memcpy` can be used in both C and C++, but it may reduce performance without
- compiler optimization.
- */
-typedef union {
-	u64 u;
-	f64 f;
-} f64_uni;
-
 /** Convert raw binary to double. */
 static_inline f64 f64_from_raw(u64 u) {
-#ifndef __cplusplus
-	f64_uni uni;
-	uni.u = u;
-	return uni.f;
-#else
-	f64 f;
-	memcpy(&f, &u, 8);
-	return f;
-#endif
+    /* use memcpy to avoid violating the strict aliasing rule */
+    f64 f;
+    memcpy(&f, &u, 8);
+    return f;
 }
 
 /** Convert double to raw binary. */
 static_inline u64 f64_to_raw(f64 f) {
-#ifndef __cplusplus
-	f64_uni uni;
-	uni.f = f;
-	return uni.u;
-#else
-	u64 u;
-	memcpy(&u, &f, 8);
-	return u;
-#endif
+    /* use memcpy to avoid violating the strict aliasing rule */
+    u64 u;
+    memcpy(&u, &f, 8);
+    return u;
 }
 
 /** Get raw 'infinity' with sign. */
 static_inline u64 f64_raw_get_inf(bool sign) {
 #if YYJSON_HAS_IEEE_754
-	return F64_RAW_INF | ((u64)sign << 63);
+    return F64_RAW_INF | ((u64)sign << 63);
 #elif defined(INFINITY)
-	return f64_to_raw(sign ? -INFINITY : INFINITY);
+    return f64_to_raw(sign ? -INFINITY : INFINITY);
 #else
-	return f64_to_raw(sign ? -HUGE_VAL : HUGE_VAL);
+    return f64_to_raw(sign ? -HUGE_VAL : HUGE_VAL);
 #endif
 }
 
 /** Get raw 'nan' with sign. */
 static_inline u64 f64_raw_get_nan(bool sign) {
 #if YYJSON_HAS_IEEE_754
-	return F64_RAW_NAN | ((u64)sign << 63);
+    return F64_RAW_NAN | ((u64)sign << 63);
 #elif defined(NAN)
-	return f64_to_raw(sign ? (f64)-NAN : (f64)NAN);
+    return f64_to_raw(sign ? (f64)-NAN : (f64)NAN);
 #else
-	return f64_to_raw((sign ? -0.0 : 0.0) / 0.0);
+    return f64_to_raw((sign ? -0.0 : 0.0) / 0.0);
 #endif
 }
 
@@ -688,12 +733,14 @@ static_inline u64 f64_raw_get_nan(bool sign) {
  */
 static_inline f64 normalized_u64_to_f64(u64 val) {
 #if YYJSON_U64_TO_F64_NO_IMPL
-	i64 sig = (i64)((val >> 1) | (val & 1));
-	return ((f64)sig) * (f64)2.0;
+    i64 sig = (i64)((val >> 1) | (val & 1));
+    return ((f64)sig) * (f64)2.0;
 #else
-	return (f64)val;
+    return (f64)val;
 #endif
 }
+
+
 
 /*==============================================================================
  * Size Utils
@@ -702,50 +749,42 @@ static_inline f64 normalized_u64_to_f64(u64 val) {
 
 /** Returns whether the size is overflow after increment. */
 static_inline bool size_add_is_overflow(usize size, usize add) {
-	usize val = size + add;
-	return (val < size) | (val < add);
+    return size > (size + add);
 }
 
 /** Returns whether the size is power of 2 (size should not be 0). */
 static_inline bool size_is_pow2(usize size) {
-	return (size & (size - 1)) == 0;
+    return (size & (size - 1)) == 0;
 }
 
 /** Align size upwards (may overflow). */
 static_inline usize size_align_up(usize size, usize align) {
-	if (size_is_pow2(align)) {
-		return (size + (align - 1)) & ~(align - 1);
-	} else {
-		return size + align - (size + align - 1) % align - 1;
-	}
+    if (size_is_pow2(align)) {
+        return (size + (align - 1)) & ~(align - 1);
+    } else {
+        return size + align - (size + align - 1) % align - 1;
+    }
 }
 
 /** Align size downwards. */
 static_inline usize size_align_down(usize size, usize align) {
-	if (size_is_pow2(align)) {
-		return size & ~(align - 1);
-	} else {
-		return size - (size % align);
-	}
+    if (size_is_pow2(align)) {
+        return size & ~(align - 1);
+    } else {
+        return size - (size % align);
+    }
 }
 
 /** Align address upwards (may overflow). */
 static_inline void *mem_align_up(void *mem, usize align) {
-	usize size;
-	memcpy(&size, &mem, sizeof(usize));
-	size = size_align_up(size, align);
-	memcpy(&mem, &size, sizeof(usize));
-	return mem;
+    usize size;
+    memcpy(&size, &mem, sizeof(usize));
+    size = size_align_up(size, align);
+    memcpy(&mem, &size, sizeof(usize));
+    return mem;
 }
 
-/** Align address downwards. */
-static_inline void *mem_align_down(void *mem, usize align) {
-	usize size;
-	memcpy(&size, &mem, sizeof(usize));
-	size = size_align_down(size, align);
-	memcpy(&mem, &size, sizeof(usize));
-	return mem;
-}
+
 
 /*==============================================================================
  * Bits Utils
@@ -755,60 +794,68 @@ static_inline void *mem_align_down(void *mem, usize align) {
 /** Returns the number of leading 0-bits in value (input should not be 0). */
 static_inline u32 u64_lz_bits(u64 v) {
 #if GCC_HAS_CLZLL
-	return (u32)__builtin_clzll(v);
+    return (u32)__builtin_clzll(v);
 #elif MSC_HAS_BIT_SCAN_64
-	unsigned long r;
-	_BitScanReverse64(&r, v);
-	return (u32)63 - (u32)r;
+    unsigned long r;
+    _BitScanReverse64(&r, v);
+    return (u32)63 - (u32)r;
 #elif MSC_HAS_BIT_SCAN
-	unsigned long hi, lo;
-	bool hi_set = _BitScanReverse(&hi, (u32)(v >> 32)) != 0;
-	_BitScanReverse(&lo, (u32)v);
-	hi |= 32;
-	return (u32)63 - (u32)(hi_set ? hi : lo);
+    unsigned long hi, lo;
+    bool hi_set = _BitScanReverse(&hi, (u32)(v >> 32)) != 0;
+    _BitScanReverse(&lo, (u32)v);
+    hi |= 32;
+    return (u32)63 - (u32)(hi_set ? hi : lo);
 #else
-	/*
-	 branchless, use de Bruijn sequences
-	 see: https://www.chessprogramming.org/BitScan
-	 */
-	const u8 table[64] = {63, 16, 62, 7,  15, 36, 61, 3,  6,  14, 22, 26, 35, 47, 60, 2,  9,  5,  28, 11, 13, 21,
-	                      42, 19, 25, 31, 34, 40, 46, 52, 59, 1,  17, 8,  37, 4,  23, 27, 48, 10, 29, 12, 43, 20,
-	                      32, 41, 53, 18, 38, 24, 49, 30, 44, 33, 54, 39, 50, 45, 55, 51, 56, 57, 58, 0};
-	v |= v >> 1;
-	v |= v >> 2;
-	v |= v >> 4;
-	v |= v >> 8;
-	v |= v >> 16;
-	v |= v >> 32;
-	return table[(v * U64(0x03F79D71, 0xB4CB0A89)) >> 58];
+    /*
+     branchless, use de Bruijn sequences
+     see: https://www.chessprogramming.org/BitScan
+     */
+    const u8 table[64] = {
+        63, 16, 62,  7, 15, 36, 61,  3,  6, 14, 22, 26, 35, 47, 60,  2,
+         9,  5, 28, 11, 13, 21, 42, 19, 25, 31, 34, 40, 46, 52, 59,  1,
+        17,  8, 37,  4, 23, 27, 48, 10, 29, 12, 43, 20, 32, 41, 53, 18,
+        38, 24, 49, 30, 44, 33, 54, 39, 50, 45, 55, 51, 56, 57, 58,  0
+    };
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v |= v >> 32;
+    return table[(v * U64(0x03F79D71, 0xB4CB0A89)) >> 58];
 #endif
 }
 
 /** Returns the number of trailing 0-bits in value (input should not be 0). */
 static_inline u32 u64_tz_bits(u64 v) {
 #if GCC_HAS_CTZLL
-	return (u32)__builtin_ctzll(v);
+    return (u32)__builtin_ctzll(v);
 #elif MSC_HAS_BIT_SCAN_64
-	unsigned long r;
-	_BitScanForward64(&r, v);
-	return (u32)r;
+    unsigned long r;
+    _BitScanForward64(&r, v);
+    return (u32)r;
 #elif MSC_HAS_BIT_SCAN
-	unsigned long lo, hi;
-	bool lo_set = _BitScanForward(&lo, (u32)(v)) != 0;
-	_BitScanForward(&hi, (u32)(v >> 32));
-	hi += 32;
-	return lo_set ? lo : hi;
+    unsigned long lo, hi;
+    bool lo_set = _BitScanForward(&lo, (u32)(v)) != 0;
+    _BitScanForward(&hi, (u32)(v >> 32));
+    hi += 32;
+    return lo_set ? lo : hi;
 #else
-	/*
-	 branchless, use de Bruijn sequences
-	 see: https://www.chessprogramming.org/BitScan
-	 */
-	const u8 table[64] = {0,  1,  2,  53, 3,  7,  54, 27, 4,  38, 41, 8,  34, 55, 48, 28, 62, 5,  39, 46, 44, 42,
-	                      22, 9,  24, 35, 59, 56, 49, 18, 29, 11, 63, 52, 6,  26, 37, 40, 33, 47, 61, 45, 43, 21,
-	                      23, 58, 17, 10, 51, 25, 36, 32, 60, 20, 57, 16, 50, 31, 19, 15, 30, 14, 13, 12};
-	return table[((v & (~v + 1)) * U64(0x022FDD63, 0xCC95386D)) >> 58];
+    /*
+     branchless, use de Bruijn sequences
+     see: https://www.chessprogramming.org/BitScan
+     */
+    const u8 table[64] = {
+         0,  1,  2, 53,  3,  7, 54, 27,  4, 38, 41,  8, 34, 55, 48, 28,
+        62,  5, 39, 46, 44, 42, 22,  9, 24, 35, 59, 56, 49, 18, 29, 11,
+        63, 52,  6, 26, 37, 40, 33, 47, 61, 45, 43, 21, 23, 58, 17, 10,
+        51, 25, 36, 32, 60, 20, 57, 16, 50, 31, 19, 15, 30, 14, 13, 12
+    };
+    return table[((v & (~v + 1)) * U64(0x022FDD63, 0xCC95386D)) >> 58];
 #endif
 }
+
+
 
 /*==============================================================================
  * 128-bit Integer Utils
@@ -819,22 +866,22 @@ static_inline u32 u64_tz_bits(u64 v) {
     returns the 128-bit result as 'hi' and 'lo'. */
 static_inline void u128_mul(u64 a, u64 b, u64 *hi, u64 *lo) {
 #if YYJSON_HAS_INT128
-	u128 m = (u128)a * b;
-	*hi = (u64)(m >> 64);
-	*lo = (u64)(m);
+    u128 m = (u128)a * b;
+    *hi = (u64)(m >> 64);
+    *lo = (u64)(m);
 #elif MSC_HAS_UMUL128
-	*lo = _umul128(a, b, hi);
+    *lo = _umul128(a, b, hi);
 #else
-	u32 a0 = (u32)(a), a1 = (u32)(a >> 32);
-	u32 b0 = (u32)(b), b1 = (u32)(b >> 32);
-	u64 p00 = (u64)a0 * b0, p01 = (u64)a0 * b1;
-	u64 p10 = (u64)a1 * b0, p11 = (u64)a1 * b1;
-	u64 m0 = p01 + (p00 >> 32);
-	u32 m00 = (u32)(m0), m01 = (u32)(m0 >> 32);
-	u64 m1 = p10 + m00;
-	u32 m10 = (u32)(m1), m11 = (u32)(m1 >> 32);
-	*hi = p11 + m01 + m11;
-	*lo = ((u64)m10 << 32) | (u32)p00;
+    u32 a0 = (u32)(a), a1 = (u32)(a >> 32);
+    u32 b0 = (u32)(b), b1 = (u32)(b >> 32);
+    u64 p00 = (u64)a0 * b0, p01 = (u64)a0 * b1;
+    u64 p10 = (u64)a1 * b0, p11 = (u64)a1 * b1;
+    u64 m0 = p01 + (p00 >> 32);
+    u32 m00 = (u32)(m0), m01 = (u32)(m0 >> 32);
+    u64 m1 = p10 + m00;
+    u32 m10 = (u32)(m1), m11 = (u32)(m1 >> 32);
+    *hi = p11 + m01 + m11;
+    *lo = ((u64)m10 << 32) | (u32)p00;
 #endif
 }
 
@@ -842,18 +889,20 @@ static_inline void u128_mul(u64 a, u64 b, u64 *hi, u64 *lo) {
     returns the 128-bit result as 'hi' and 'lo'. */
 static_inline void u128_mul_add(u64 a, u64 b, u64 c, u64 *hi, u64 *lo) {
 #if YYJSON_HAS_INT128
-	u128 m = (u128)a * b + c;
-	*hi = (u64)(m >> 64);
-	*lo = (u64)(m);
+    u128 m = (u128)a * b + c;
+    *hi = (u64)(m >> 64);
+    *lo = (u64)(m);
 #else
-	u64 h, l, t;
-	u128_mul(a, b, &h, &l);
-	t = l + c;
-	h += (u64)(((t < l) | (t < c)));
-	*hi = h;
-	*lo = t;
+    u64 h, l, t;
+    u128_mul(a, b, &h, &l);
+    t = l + c;
+    h += (u64)(((t < l) | (t < c)));
+    *hi = h;
+    *lo = t;
 #endif
 }
+
+
 
 /*==============================================================================
  * File Utils
@@ -862,38 +911,39 @@ static_inline void u128_mul_add(u64 a, u64 b, u64 c, u64 *hi, u64 *lo) {
 
 #define YYJSON_FOPEN_EXT
 #if !defined(_MSC_VER) && defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 7)
-#undef YYJSON_FOPEN_EXT
-#define YYJSON_FOPEN_EXT "e" /* glibc extension to enable O_CLOEXEC */
-#endif
+#   if __GLIBC_PREREQ(2, 7)
+#       undef YYJSON_FOPEN_EXT
+#       define YYJSON_FOPEN_EXT "e" /* glibc extension to enable O_CLOEXEC */
+#   endif
 #endif
 
 static_inline FILE *fopen_safe(const char *path, const char *mode) {
 #if YYJSON_MSC_VER >= 1400
-	FILE *file = NULL;
-	if (fopen_s(&file, path, mode) != 0)
-		return NULL;
-	return file;
+    FILE *file = NULL;
+    if (fopen_s(&file, path, mode) != 0) return NULL;
+    return file;
 #else
-	return fopen(path, mode);
+    return fopen(path, mode);
 #endif
 }
 
 static_inline FILE *fopen_readonly(const char *path) {
-	return fopen_safe(path, "rb" YYJSON_FOPEN_EXT);
+    return fopen_safe(path, "rb" YYJSON_FOPEN_EXT);
 }
 
 static_inline FILE *fopen_writeonly(const char *path) {
-	return fopen_safe(path, "wb" YYJSON_FOPEN_EXT);
+    return fopen_safe(path, "wb" YYJSON_FOPEN_EXT);
 }
 
 static_inline usize fread_safe(void *buf, usize size, FILE *file) {
 #if YYJSON_MSC_VER >= 1400
-	return fread_s(buf, size, 1, size, file);
+    return fread_s(buf, size, 1, size, file);
 #else
-	return fread(buf, 1, size, file);
+    return fread(buf, 1, size, file);
 #endif
 }
+
+
 
 /*==============================================================================
  * Default Memory Allocator
@@ -901,980 +951,1827 @@ static_inline usize fread_safe(void *buf, usize size, FILE *file) {
  *============================================================================*/
 
 static void *default_malloc(void *ctx, usize size) {
-	return malloc(size);
+    return malloc(size);
 }
 
 static void *default_realloc(void *ctx, void *ptr, usize old_size, usize size) {
-	return realloc(ptr, size);
+    return realloc(ptr, size);
 }
 
 static void default_free(void *ctx, void *ptr) {
-	free(ptr);
+    free(ptr);
 }
 
-static const yyjson_alc YYJSON_DEFAULT_ALC = {default_malloc, default_realloc, default_free, NULL};
+static const yyjson_alc YYJSON_DEFAULT_ALC = {
+    default_malloc,
+    default_realloc,
+    default_free,
+    NULL
+};
+
+
+
+/*==============================================================================
+ * Null Memory Allocator
+ *
+ * This allocator is just a placeholder to ensure that the internal
+ * malloc/realloc/free function pointers are not null.
+ *============================================================================*/
 
 static void *null_malloc(void *ctx, usize size) {
-	return NULL;
+    return NULL;
 }
 
 static void *null_realloc(void *ctx, void *ptr, usize old_size, usize size) {
-	return NULL;
+    return NULL;
 }
 
 static void null_free(void *ctx, void *ptr) {
-	return;
+    return;
 }
 
-static const yyjson_alc YYJSON_NULL_ALC = {null_malloc, null_realloc, null_free, NULL};
+static const yyjson_alc YYJSON_NULL_ALC = {
+    null_malloc,
+    null_realloc,
+    null_free,
+    NULL
+};
+
+
 
 /*==============================================================================
  * Pool Memory Allocator
- * This is a simple memory allocator that uses linked list memory chunk.
- * The following code will be executed only when the library user creates
- * this allocator manually.
+ *
+ * This allocator is initialized with a fixed-size buffer.
+ * The buffer is split into multiple memory chunks for memory allocation.
  *============================================================================*/
 
-/** chunk header */
+/** memory chunk header */
 typedef struct pool_chunk {
-	usize size; /* chunk memory size (include chunk header) */
-	struct pool_chunk *next;
+    usize size; /* chunk memory size, include chunk header */
+    struct pool_chunk *next; /* linked list, nullable */
+    /* char mem[]; flexible array member */
 } pool_chunk;
 
-/** ctx header */
+/** allocator ctx header */
 typedef struct pool_ctx {
-	usize size; /* total memory size (include ctx header) */
-	pool_chunk *free_list;
+    usize size; /* total memory size, include ctx header */
+    pool_chunk *free_list; /* linked list, nullable */
+    /* pool_chunk chunks[]; flexible array member */
 } pool_ctx;
 
+/** align up the input size to chunk size */
+static_inline void pool_size_align(usize *size) {
+    *size = size_align_up(*size, sizeof(pool_chunk)) + sizeof(pool_chunk);
+}
+
 static void *pool_malloc(void *ctx_ptr, usize size) {
-	pool_ctx *ctx = (pool_ctx *)ctx_ptr;
-	pool_chunk *next, *prev = NULL, *cur = ctx->free_list;
+    /* assert(size != 0) */
+    pool_ctx *ctx = (pool_ctx *)ctx_ptr;
+    pool_chunk *next, *prev = NULL, *cur = ctx->free_list;
 
-	if (unlikely(size == 0 || size >= ctx->size))
-		return NULL;
-	size = size_align_up(size, sizeof(pool_chunk)) + sizeof(pool_chunk);
+    if (unlikely(size >= ctx->size)) return NULL;
+    pool_size_align(&size);
 
-	while (cur) {
-		if (cur->size < size) {
-			/* not enough space, try next chunk */
-			prev = cur;
-			cur = cur->next;
-			continue;
-		}
-		if (cur->size >= size + sizeof(pool_chunk) * 2) {
-			/* too much space, split this chunk */
-			next = (pool_chunk *)(void *)((u8 *)cur + size);
-			next->size = cur->size - size;
-			next->next = cur->next;
-			cur->size = size;
-		} else {
-			/* just enough space, use whole chunk */
-			next = cur->next;
-		}
-		if (prev)
-			prev->next = next;
-		else
-			ctx->free_list = next;
-		return (void *)(cur + 1);
-	}
-	return NULL;
+    while (cur) {
+        if (cur->size < size) {
+            /* not enough space, try next chunk */
+            prev = cur;
+            cur = cur->next;
+            continue;
+        }
+        if (cur->size >= size + sizeof(pool_chunk) * 2) {
+            /* too much space, split this chunk */
+            next = (pool_chunk *)(void *)((u8 *)cur + size);
+            next->size = cur->size - size;
+            next->next = cur->next;
+            cur->size = size;
+        } else {
+            /* just enough space, use whole chunk */
+            next = cur->next;
+        }
+        if (prev) prev->next = next;
+        else ctx->free_list = next;
+        return (void *)(cur + 1);
+    }
+    return NULL;
 }
 
 static void pool_free(void *ctx_ptr, void *ptr) {
-	pool_ctx *ctx = (pool_ctx *)ctx_ptr;
-	pool_chunk *cur = ((pool_chunk *)ptr) - 1;
-	pool_chunk *prev = NULL, *next = ctx->free_list;
+    /* assert(ptr != NULL) */
+    pool_ctx *ctx = (pool_ctx *)ctx_ptr;
+    pool_chunk *cur = ((pool_chunk *)ptr) - 1;
+    pool_chunk *prev = NULL, *next = ctx->free_list;
 
-	while (next && next < cur) {
-		prev = next;
-		next = next->next;
-	}
-	if (prev)
-		prev->next = cur;
-	else
-		ctx->free_list = cur;
-	cur->next = next;
+    while (next && next < cur) {
+        prev = next;
+        next = next->next;
+    }
+    if (prev) prev->next = cur;
+    else ctx->free_list = cur;
+    cur->next = next;
 
-	if (next && ((u8 *)cur + cur->size) == (u8 *)next) {
-		/* merge cur to higher chunk */
-		cur->size += next->size;
-		cur->next = next->next;
-	}
-	if (prev && ((u8 *)prev + prev->size) == (u8 *)cur) {
-		/* merge cur to lower chunk */
-		prev->size += cur->size;
-		prev->next = cur->next;
-	}
+    if (next && ((u8 *)cur + cur->size) == (u8 *)next) {
+        /* merge cur to higher chunk */
+        cur->size += next->size;
+        cur->next = next->next;
+    }
+    if (prev && ((u8 *)prev + prev->size) == (u8 *)cur) {
+        /* merge cur to lower chunk */
+        prev->size += cur->size;
+        prev->next = cur->next;
+    }
 }
 
-static void *pool_realloc(void *ctx_ptr, void *ptr, usize old_size, usize size) {
-	pool_ctx *ctx = (pool_ctx *)ctx_ptr;
-	pool_chunk *cur = ((pool_chunk *)ptr) - 1, *prev, *next, *tmp;
-	usize free_size;
-	void *new_ptr;
+static void *pool_realloc(void *ctx_ptr, void *ptr,
+                          usize old_size, usize size) {
+    /* assert(ptr != NULL && size != 0 && old_size < size) */
+    pool_ctx *ctx = (pool_ctx *)ctx_ptr;
+    pool_chunk *cur = ((pool_chunk *)ptr) - 1, *prev, *next, *tmp;
 
-	if (unlikely(size == 0 || size >= ctx->size))
-		return NULL;
-	size = size_align_up(size, sizeof(pool_chunk)) + sizeof(pool_chunk);
+    /* check size */
+    if (unlikely(size >= ctx->size)) return NULL;
+    pool_size_align(&old_size);
+    pool_size_align(&size);
+    if (unlikely(old_size == size)) return ptr;
 
-	/* reduce size */
-	if (unlikely(size <= cur->size)) {
-		free_size = cur->size - size;
-		if (free_size >= sizeof(pool_chunk) * 2) {
-			tmp = (pool_chunk *)(void *)((u8 *)cur + cur->size - free_size);
-			tmp->size = free_size;
-			pool_free(ctx_ptr, (void *)(tmp + 1));
-			cur->size -= free_size;
-		}
-		return ptr;
-	}
+    /* find next and prev chunk */
+    prev = NULL;
+    next = ctx->free_list;
+    while (next && next < cur) {
+        prev = next;
+        next = next->next;
+    }
 
-	/* find next and prev chunk */
-	prev = NULL;
-	next = ctx->free_list;
-	while (next && next < cur) {
-		prev = next;
-		next = next->next;
-	}
-
-	/* merge to higher chunk if they are contiguous */
-	if ((u8 *)cur + cur->size == (u8 *)next && cur->size + next->size >= size) {
-		free_size = cur->size + next->size - size;
-		if (free_size > sizeof(pool_chunk) * 2) {
-			tmp = (pool_chunk *)(void *)((u8 *)cur + size);
-			if (prev)
-				prev->next = tmp;
-			else
-				ctx->free_list = tmp;
-			tmp->next = next->next;
-			tmp->size = free_size;
-			cur->size = size;
-		} else {
-			if (prev)
-				prev->next = next->next;
-			else
-				ctx->free_list = next->next;
-			cur->size += next->size;
-		}
-		return ptr;
-	}
-
-	/* fallback to malloc and memcpy */
-	new_ptr = pool_malloc(ctx_ptr, size - sizeof(pool_chunk));
-	if (new_ptr) {
-		memcpy(new_ptr, ptr, cur->size - sizeof(pool_chunk));
-		pool_free(ctx_ptr, ptr);
-	}
-	return new_ptr;
+    if ((u8 *)cur + cur->size == (u8 *)next && cur->size + next->size >= size) {
+        /* merge to higher chunk if they are contiguous */
+        usize free_size = cur->size + next->size - size;
+        if (free_size > sizeof(pool_chunk) * 2) {
+            tmp = (pool_chunk *)(void *)((u8 *)cur + size);
+            if (prev) prev->next = tmp;
+            else ctx->free_list = tmp;
+            tmp->next = next->next;
+            tmp->size = free_size;
+            cur->size = size;
+        } else {
+            if (prev) prev->next = next->next;
+            else ctx->free_list = next->next;
+            cur->size += next->size;
+        }
+        return ptr;
+    } else {
+        /* fallback to malloc and memcpy */
+        void *new_ptr = pool_malloc(ctx_ptr, size - sizeof(pool_chunk));
+        if (new_ptr) {
+            memcpy(new_ptr, ptr, cur->size - sizeof(pool_chunk));
+            pool_free(ctx_ptr, ptr);
+        }
+        return new_ptr;
+    }
 }
 
 bool yyjson_alc_pool_init(yyjson_alc *alc, void *buf, usize size) {
-	pool_chunk *chunk;
-	pool_ctx *ctx;
+    pool_chunk *chunk;
+    pool_ctx *ctx;
 
-	if (unlikely(!alc))
-		return false;
-	*alc = YYJSON_NULL_ALC;
-	if (size < sizeof(pool_ctx) * 4)
-		return false;
-	ctx = (pool_ctx *)mem_align_up(buf, sizeof(pool_ctx));
-	if (unlikely(!ctx))
-		return false;
-	size -= (usize)((u8 *)ctx - (u8 *)buf);
-	size = size_align_down(size, sizeof(pool_ctx));
+    if (unlikely(!alc)) return false;
+    *alc = YYJSON_NULL_ALC;
+    if (size < sizeof(pool_ctx) * 4) return false;
+    ctx = (pool_ctx *)mem_align_up(buf, sizeof(pool_ctx));
+    if (unlikely(!ctx)) return false;
+    size -= (usize)((u8 *)ctx - (u8 *)buf);
+    size = size_align_down(size, sizeof(pool_ctx));
 
-	chunk = (pool_chunk *)(ctx + 1);
-	chunk->size = size - sizeof(pool_ctx);
-	chunk->next = NULL;
-	ctx->size = size;
-	ctx->free_list = chunk;
+    chunk = (pool_chunk *)(ctx + 1);
+    chunk->size = size - sizeof(pool_ctx);
+    chunk->next = NULL;
+    ctx->size = size;
+    ctx->free_list = chunk;
 
-	alc->malloc = pool_malloc;
-	alc->realloc = pool_realloc;
-	alc->free = pool_free;
-	alc->ctx = (void *)ctx;
-	return true;
+    alc->malloc = pool_malloc;
+    alc->realloc = pool_realloc;
+    alc->free = pool_free;
+    alc->ctx = (void *)ctx;
+    return true;
 }
+
+
+
+/*==============================================================================
+ * Dynamic Memory Allocator
+ *
+ * This allocator allocates memory on demand and does not immediately release
+ * unused memory. Instead, it places the unused memory into a freelist for
+ * potential reuse in the future. It is only when the entire allocator is
+ * destroyed that all previously allocated memory is released at once.
+ *============================================================================*/
+
+/** memory chunk header */
+typedef struct dyn_chunk {
+    usize size; /* chunk size, include header */
+    struct dyn_chunk *next;
+    /* char mem[]; flexible array member */
+} dyn_chunk;
+
+/** allocator ctx header */
+typedef struct {
+    dyn_chunk free_list; /* dummy header, sorted from small to large */
+    dyn_chunk used_list; /* dummy header */
+} dyn_ctx;
+
+/** align up the input size to chunk size */
+static_inline bool dyn_size_align(usize *size) {
+    usize alc_size = *size + sizeof(dyn_chunk);
+    alc_size = size_align_up(alc_size, YYJSON_ALC_DYN_MIN_SIZE);
+    if (unlikely(alc_size < *size)) return false; /* overflow */
+    *size = alc_size;
+    return true;
+}
+
+/** remove a chunk from list (the chunk must already be in the list) */
+static_inline void dyn_chunk_list_remove(dyn_chunk *list, dyn_chunk *chunk) {
+    dyn_chunk *prev = list, *cur;
+    for (cur = prev->next; cur; cur = cur->next) {
+        if (cur == chunk) {
+            prev->next = cur->next;
+            cur->next = NULL;
+            return;
+        }
+        prev = cur;
+    }
+}
+
+/** add a chunk to list header (the chunk must not be in the list) */
+static_inline void dyn_chunk_list_add(dyn_chunk *list, dyn_chunk *chunk) {
+    chunk->next = list->next;
+    list->next = chunk;
+}
+
+static void *dyn_malloc(void *ctx_ptr, usize size) {
+    /* assert(size != 0) */
+    const yyjson_alc def = YYJSON_DEFAULT_ALC;
+    dyn_ctx *ctx = (dyn_ctx *)ctx_ptr;
+    dyn_chunk *chunk, *prev, *next;
+    if (unlikely(!dyn_size_align(&size))) return NULL;
+
+    /* freelist is empty, create new chunk */
+    if (!ctx->free_list.next) {
+        chunk = (dyn_chunk *)def.malloc(def.ctx, size);
+        if (unlikely(!chunk)) return NULL;
+        chunk->size = size;
+        chunk->next = NULL;
+        dyn_chunk_list_add(&ctx->used_list, chunk);
+        return (void *)(chunk + 1);
+    }
+
+    /* find a large enough chunk, or resize the largest chunk */
+    prev = &ctx->free_list;
+    while (true) {
+        chunk = prev->next;
+        if (chunk->size >= size) { /* enough size, reuse this chunk */
+            prev->next = chunk->next;
+            dyn_chunk_list_add(&ctx->used_list, chunk);
+            return (void *)(chunk + 1);
+        }
+        if (!chunk->next) { /* resize the largest chunk */
+            chunk = (dyn_chunk *)def.realloc(def.ctx, chunk, chunk->size, size);
+            if (unlikely(!chunk)) return NULL;
+            prev->next = NULL;
+            chunk->size = size;
+            dyn_chunk_list_add(&ctx->used_list, chunk);
+            return (void *)(chunk + 1);
+        }
+        prev = chunk;
+    }
+}
+
+static void *dyn_realloc(void *ctx_ptr, void *ptr,
+                          usize old_size, usize size) {
+    /* assert(ptr != NULL && size != 0 && old_size < size) */
+    const yyjson_alc def = YYJSON_DEFAULT_ALC;
+    dyn_ctx *ctx = (dyn_ctx *)ctx_ptr;
+    dyn_chunk *prev, *next, *new_chunk;
+    dyn_chunk *chunk = (dyn_chunk *)ptr - 1;
+    if (unlikely(!dyn_size_align(&size))) return NULL;
+    if (chunk->size >= size) return ptr;
+
+    dyn_chunk_list_remove(&ctx->used_list, chunk);
+    new_chunk = (dyn_chunk *)def.realloc(def.ctx, chunk, chunk->size, size);
+    if (likely(new_chunk)) {
+        new_chunk->size = size;
+        chunk = new_chunk;
+    }
+    dyn_chunk_list_add(&ctx->used_list, chunk);
+    return new_chunk ? (void *)(new_chunk + 1) : NULL;
+}
+
+static void dyn_free(void *ctx_ptr, void *ptr) {
+    /* assert(ptr != NULL) */
+    dyn_ctx *ctx = (dyn_ctx *)ctx_ptr;
+    dyn_chunk *chunk = (dyn_chunk *)ptr - 1, *prev;
+
+    dyn_chunk_list_remove(&ctx->used_list, chunk);
+    for (prev = &ctx->free_list; prev; prev = prev->next) {
+        if (!prev->next || prev->next->size >= chunk->size) {
+            chunk->next = prev->next;
+            prev->next = chunk;
+            break;
+        }
+    }
+}
+
+yyjson_alc *yyjson_alc_dyn_new(void) {
+    const yyjson_alc def = YYJSON_DEFAULT_ALC;
+    usize hdr_len = sizeof(yyjson_alc) + sizeof(dyn_ctx);
+    yyjson_alc *alc = (yyjson_alc *)def.malloc(def.ctx, hdr_len);
+    dyn_ctx *ctx = (dyn_ctx *)(void *)(alc + 1);
+    if (unlikely(!alc)) return NULL;
+    alc->malloc = dyn_malloc;
+    alc->realloc = dyn_realloc;
+    alc->free = dyn_free;
+    alc->ctx = alc + 1;
+    memset(ctx, 0, sizeof(*ctx));
+    return alc;
+}
+
+void yyjson_alc_dyn_free(yyjson_alc *alc) {
+    const yyjson_alc def = YYJSON_DEFAULT_ALC;
+    dyn_ctx *ctx = (dyn_ctx *)(void *)(alc + 1);
+    dyn_chunk *chunk, *next;
+    if (unlikely(!alc)) return;
+    for (chunk = ctx->free_list.next; chunk; chunk = next) {
+        next = chunk->next;
+        def.free(def.ctx, chunk);
+    }
+    for (chunk = ctx->used_list.next; chunk; chunk = next) {
+        next = chunk->next;
+        def.free(def.ctx, chunk);
+    }
+    def.free(def.ctx, alc);
+}
+
+
 
 /*==============================================================================
  * JSON document and value
  *============================================================================*/
 
-static_inline void unsafe_yyjson_str_pool_release(yyjson_str_pool *pool, yyjson_alc *alc) {
-	yyjson_str_chunk *chunk = pool->chunks, *next;
-	while (chunk) {
-		next = chunk->next;
-		alc->free(alc->ctx, chunk);
-		chunk = next;
-	}
+static_inline void unsafe_yyjson_str_pool_release(yyjson_str_pool *pool,
+                                                  yyjson_alc *alc) {
+    yyjson_str_chunk *chunk = pool->chunks, *next;
+    while (chunk) {
+        next = chunk->next;
+        alc->free(alc->ctx, chunk);
+        chunk = next;
+    }
 }
 
-static_inline void unsafe_yyjson_val_pool_release(yyjson_val_pool *pool, yyjson_alc *alc) {
-	yyjson_val_chunk *chunk = pool->chunks, *next;
-	while (chunk) {
-		next = chunk->next;
-		alc->free(alc->ctx, chunk);
-		chunk = next;
-	}
+static_inline void unsafe_yyjson_val_pool_release(yyjson_val_pool *pool,
+                                                  yyjson_alc *alc) {
+    yyjson_val_chunk *chunk = pool->chunks, *next;
+    while (chunk) {
+        next = chunk->next;
+        alc->free(alc->ctx, chunk);
+        chunk = next;
+    }
 }
 
-bool unsafe_yyjson_str_pool_grow(yyjson_str_pool *pool, const yyjson_alc *alc, usize len) {
-	yyjson_str_chunk *chunk;
-	usize size = len + sizeof(yyjson_str_chunk);
-	size = yyjson_max(pool->chunk_size, size);
-	chunk = (yyjson_str_chunk *)alc->malloc(alc->ctx, size);
-	if (yyjson_unlikely(!chunk))
-		return false;
+bool unsafe_yyjson_str_pool_grow(yyjson_str_pool *pool,
+                                 const yyjson_alc *alc, usize len) {
+    yyjson_str_chunk *chunk;
+    usize size, max_len;
 
-	chunk->next = pool->chunks;
-	pool->chunks = chunk;
-	pool->cur = (char *)chunk + sizeof(yyjson_str_chunk);
-	pool->end = (char *)chunk + size;
+    /* create a new chunk */
+    max_len = USIZE_MAX - sizeof(yyjson_str_chunk);
+    if (unlikely(len > max_len)) return false;
+    size = len + sizeof(yyjson_str_chunk);
+    size = yyjson_max(pool->chunk_size, size);
+    chunk = (yyjson_str_chunk *)alc->malloc(alc->ctx, size);
+    if (unlikely(!chunk)) return false;
 
-	size = yyjson_min(pool->chunk_size * 2, pool->chunk_size_max);
-	pool->chunk_size = size;
-	return true;
+    /* insert the new chunk as the head of the linked list */
+    chunk->next = pool->chunks;
+    chunk->chunk_size = size;
+    pool->chunks = chunk;
+    pool->cur = (char *)chunk + sizeof(yyjson_str_chunk);
+    pool->end = (char *)chunk + size;
+
+    /* the next chunk is twice the size of the current one */
+    size = yyjson_min(pool->chunk_size * 2, pool->chunk_size_max);
+    if (size < pool->chunk_size) size = pool->chunk_size_max; /* overflow */
+    pool->chunk_size = size;
+    return true;
 }
 
-bool unsafe_yyjson_val_pool_grow(yyjson_val_pool *pool, const yyjson_alc *alc, usize count) {
-	yyjson_val_chunk *chunk;
-	usize size;
+bool unsafe_yyjson_val_pool_grow(yyjson_val_pool *pool,
+                                 const yyjson_alc *alc, usize count) {
+    yyjson_val_chunk *chunk;
+    usize size, max_count;
 
-	if (count >= USIZE_MAX / sizeof(yyjson_mut_val) - 16)
-		return false;
-	size = (count + 1) * sizeof(yyjson_mut_val);
-	size = yyjson_max(pool->chunk_size, size);
-	chunk = (yyjson_val_chunk *)alc->malloc(alc->ctx, size);
-	if (yyjson_unlikely(!chunk))
-		return false;
+    /* create a new chunk */
+    max_count = USIZE_MAX / sizeof(yyjson_mut_val) - 1;
+    if (unlikely(count > max_count)) return false;
+    size = (count + 1) * sizeof(yyjson_mut_val);
+    size = yyjson_max(pool->chunk_size, size);
+    chunk = (yyjson_val_chunk *)alc->malloc(alc->ctx, size);
+    if (unlikely(!chunk)) return false;
 
-	chunk->next = pool->chunks;
-	pool->chunks = chunk;
-	pool->cur = (yyjson_mut_val *)(void *)((u8 *)chunk + sizeof(yyjson_mut_val));
-	pool->end = (yyjson_mut_val *)(void *)((u8 *)chunk + size);
+    /* insert the new chunk as the head of the linked list */
+    chunk->next = pool->chunks;
+    chunk->chunk_size = size;
+    pool->chunks = chunk;
+    pool->cur = (yyjson_mut_val *)(void *)((u8 *)chunk) + 1;
+    pool->end = (yyjson_mut_val *)(void *)((u8 *)chunk + size);
 
-	size = yyjson_min(pool->chunk_size * 2, pool->chunk_size_max);
-	pool->chunk_size = size;
-	return true;
+    /* the next chunk is twice the size of the current one */
+    size = yyjson_min(pool->chunk_size * 2, pool->chunk_size_max);
+    if (size < pool->chunk_size) size = pool->chunk_size_max; /* overflow */
+    pool->chunk_size = size;
+    return true;
+}
+
+bool yyjson_mut_doc_set_str_pool_size(yyjson_mut_doc *doc, size_t len) {
+    usize max_size = USIZE_MAX - sizeof(yyjson_str_chunk);
+    if (!doc || !len || len > max_size) return false;
+    doc->str_pool.chunk_size = len + sizeof(yyjson_str_chunk);
+    return true;
+}
+
+bool yyjson_mut_doc_set_val_pool_size(yyjson_mut_doc *doc, size_t count) {
+    usize max_count = USIZE_MAX / sizeof(yyjson_mut_val) - 1;
+    if (!doc || !count || count > max_count) return false;
+    doc->val_pool.chunk_size = (count + 1) * sizeof(yyjson_mut_val);
+    return true;
 }
 
 void yyjson_mut_doc_free(yyjson_mut_doc *doc) {
-	if (doc) {
-		yyjson_alc alc = doc->alc;
-		unsafe_yyjson_str_pool_release(&doc->str_pool, &alc);
-		unsafe_yyjson_val_pool_release(&doc->val_pool, &alc);
-		alc.free(alc.ctx, doc);
-	}
+    if (doc) {
+        yyjson_alc alc = doc->alc;
+        memset(&doc->alc, 0, sizeof(alc));
+        unsafe_yyjson_str_pool_release(&doc->str_pool, &alc);
+        unsafe_yyjson_val_pool_release(&doc->val_pool, &alc);
+        alc.free(alc.ctx, doc);
+    }
 }
 
 yyjson_mut_doc *yyjson_mut_doc_new(const yyjson_alc *alc) {
-	yyjson_mut_doc *doc;
-	if (!alc)
-		alc = &YYJSON_DEFAULT_ALC;
-	doc = (yyjson_mut_doc *)alc->malloc(alc->ctx, sizeof(yyjson_mut_doc));
-	if (!doc)
-		return NULL;
-	memset(doc, 0, sizeof(yyjson_mut_doc));
+    yyjson_mut_doc *doc;
+    if (!alc) alc = &YYJSON_DEFAULT_ALC;
+    doc = (yyjson_mut_doc *)alc->malloc(alc->ctx, sizeof(yyjson_mut_doc));
+    if (!doc) return NULL;
+    memset(doc, 0, sizeof(yyjson_mut_doc));
 
-	doc->alc = *alc;
-	doc->str_pool.chunk_size = 0x100;
-	doc->str_pool.chunk_size_max = 0x10000000;
-	doc->val_pool.chunk_size = 0x10 * sizeof(yyjson_mut_val);
-	doc->val_pool.chunk_size_max = 0x1000000 * sizeof(yyjson_mut_val);
-	return doc;
+    doc->alc = *alc;
+    doc->str_pool.chunk_size = YYJSON_MUT_DOC_STR_POOL_INIT_SIZE;
+    doc->str_pool.chunk_size_max = YYJSON_MUT_DOC_STR_POOL_MAX_SIZE;
+    doc->val_pool.chunk_size = YYJSON_MUT_DOC_VAL_POOL_INIT_SIZE;
+    doc->val_pool.chunk_size_max = YYJSON_MUT_DOC_VAL_POOL_MAX_SIZE;
+    return doc;
 }
 
-yyjson_api yyjson_mut_doc *yyjson_doc_mut_copy(yyjson_doc *doc, const yyjson_alc *alc) {
-	yyjson_mut_doc *m_doc;
-	yyjson_mut_val *m_val;
+yyjson_mut_doc *yyjson_doc_mut_copy(yyjson_doc *doc, const yyjson_alc *alc) {
+    yyjson_mut_doc *m_doc;
+    yyjson_mut_val *m_val;
 
-	if (!doc || !doc->root)
-		return NULL;
-	m_doc = yyjson_mut_doc_new(alc);
-	if (!m_doc)
-		return NULL;
-	m_val = yyjson_val_mut_copy(m_doc, doc->root);
-	if (!m_val) {
-		yyjson_mut_doc_free(m_doc);
-		return NULL;
-	}
-	yyjson_mut_doc_set_root(m_doc, m_val);
-	return m_doc;
+    if (!doc || !doc->root) return NULL;
+    m_doc = yyjson_mut_doc_new(alc);
+    if (!m_doc) return NULL;
+    m_val = yyjson_val_mut_copy(m_doc, doc->root);
+    if (!m_val) {
+        yyjson_mut_doc_free(m_doc);
+        return NULL;
+    }
+    yyjson_mut_doc_set_root(m_doc, m_val);
+    return m_doc;
 }
 
-yyjson_api yyjson_mut_doc *yyjson_mut_doc_mut_copy(yyjson_mut_doc *doc, const yyjson_alc *alc) {
-	yyjson_mut_doc *m_doc;
-	yyjson_mut_val *m_val;
+yyjson_mut_doc *yyjson_mut_doc_mut_copy(yyjson_mut_doc *doc,
+                                        const yyjson_alc *alc) {
+    yyjson_mut_doc *m_doc;
+    yyjson_mut_val *m_val;
 
-	if (!doc || !doc->root)
-		return NULL;
-	m_doc = yyjson_mut_doc_new(alc);
-	if (!m_doc)
-		return NULL;
-	m_val = yyjson_mut_val_mut_copy(m_doc, doc->root);
-	if (!m_val) {
-		yyjson_mut_doc_free(m_doc);
-		return NULL;
-	}
-	yyjson_mut_doc_set_root(m_doc, m_val);
-	return m_doc;
+    if (!doc) return NULL;
+    if (!doc->root) return yyjson_mut_doc_new(alc);
+
+    m_doc = yyjson_mut_doc_new(alc);
+    if (!m_doc) return NULL;
+    m_val = yyjson_mut_val_mut_copy(m_doc, doc->root);
+    if (!m_val) {
+        yyjson_mut_doc_free(m_doc);
+        return NULL;
+    }
+    yyjson_mut_doc_set_root(m_doc, m_val);
+    return m_doc;
 }
 
-yyjson_api yyjson_mut_val *yyjson_val_mut_copy(yyjson_mut_doc *m_doc, yyjson_val *i_vals) {
-	/*
-	 The immutable object or array stores all sub-values in a contiguous memory,
-	 We copy them to another contiguous memory as mutable values,
-	 then reconnect the mutable values with the original relationship.
-	 */
+yyjson_mut_val *yyjson_val_mut_copy(yyjson_mut_doc *m_doc,
+                                    yyjson_val *i_vals) {
+    /*
+     The immutable object or array stores all sub-values in a contiguous memory,
+     We copy them to another contiguous memory as mutable values,
+     then reconnect the mutable values with the original relationship.
+     */
+    usize i_vals_len;
+    yyjson_mut_val *m_vals, *m_val;
+    yyjson_val *i_val, *i_end;
 
-	usize i_vals_len;
-	yyjson_mut_val *m_vals, *m_val;
-	yyjson_val *i_val, *i_end;
+    if (!m_doc || !i_vals) return NULL;
+    i_end = unsafe_yyjson_get_next(i_vals);
+    i_vals_len = (usize)(unsafe_yyjson_get_next(i_vals) - i_vals);
+    m_vals = unsafe_yyjson_mut_val(m_doc, i_vals_len);
+    if (!m_vals) return NULL;
+    i_val = i_vals;
+    m_val = m_vals;
 
-	if (!m_doc || !i_vals)
-		return NULL;
-	i_end = unsafe_yyjson_get_next(i_vals);
-	i_vals_len = (usize)(unsafe_yyjson_get_next(i_vals) - i_vals);
-	m_vals = unsafe_yyjson_mut_val(m_doc, i_vals_len);
-	if (!m_vals)
-		return NULL;
-	i_val = i_vals;
-	m_val = m_vals;
+    for (; i_val < i_end; i_val++, m_val++) {
+        yyjson_type type = unsafe_yyjson_get_type(i_val);
+        m_val->tag = i_val->tag;
+        m_val->uni.u64 = i_val->uni.u64;
+        if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
+            const char *str = i_val->uni.str;
+            usize str_len = unsafe_yyjson_get_len(i_val);
+            m_val->uni.str = unsafe_yyjson_mut_strncpy(m_doc, str, str_len);
+            if (!m_val->uni.str) return NULL;
+        } else if (type == YYJSON_TYPE_ARR) {
+            usize len = unsafe_yyjson_get_len(i_val);
+            if (len > 0) {
+                yyjson_val *ii_val = i_val + 1, *ii_next;
+                yyjson_mut_val *mm_val = m_val + 1, *mm_ctn = m_val, *mm_next;
+                while (len-- > 1) {
+                    ii_next = unsafe_yyjson_get_next(ii_val);
+                    mm_next = mm_val + (ii_next - ii_val);
+                    mm_val->next = mm_next;
+                    ii_val = ii_next;
+                    mm_val = mm_next;
+                }
+                mm_val->next = mm_ctn + 1;
+                mm_ctn->uni.ptr = mm_val;
+            }
+        } else if (type == YYJSON_TYPE_OBJ) {
+            usize len = unsafe_yyjson_get_len(i_val);
+            if (len > 0) {
+                yyjson_val *ii_key = i_val + 1, *ii_nextkey;
+                yyjson_mut_val *mm_key = m_val + 1, *mm_ctn = m_val;
+                yyjson_mut_val *mm_nextkey;
+                while (len-- > 1) {
+                    ii_nextkey = unsafe_yyjson_get_next(ii_key + 1);
+                    mm_nextkey = mm_key + (ii_nextkey - ii_key);
+                    mm_key->next = mm_key + 1;
+                    mm_key->next->next = mm_nextkey;
+                    ii_key = ii_nextkey;
+                    mm_key = mm_nextkey;
+                }
+                mm_key->next = mm_key + 1;
+                mm_key->next->next = mm_ctn + 1;
+                mm_ctn->uni.ptr = mm_key;
+            }
+        }
+    }
 
-	for (; i_val < i_end; i_val++, m_val++) {
-		yyjson_type type = unsafe_yyjson_get_type(i_val);
-		m_val->tag = i_val->tag;
-		m_val->uni.u64 = i_val->uni.u64;
-		if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
-			const char *str = i_val->uni.str;
-			usize str_len = unsafe_yyjson_get_len(i_val);
-			m_val->uni.str = unsafe_yyjson_mut_strncpy(m_doc, str, str_len);
-			if (!m_val->uni.str)
-				return NULL;
-		} else if (type == YYJSON_TYPE_ARR) {
-			usize len = unsafe_yyjson_get_len(i_val);
-			if (len > 0) {
-				yyjson_val *ii_val = i_val + 1, *ii_next;
-				yyjson_mut_val *mm_val = m_val + 1, *mm_ctn = m_val, *mm_next;
-				while (len-- > 1) {
-					ii_next = unsafe_yyjson_get_next(ii_val);
-					mm_next = mm_val + (ii_next - ii_val);
-					mm_val->next = mm_next;
-					ii_val = ii_next;
-					mm_val = mm_next;
-				}
-				mm_val->next = mm_ctn + 1;
-				mm_ctn->uni.ptr = mm_val;
-			}
-		} else if (type == YYJSON_TYPE_OBJ) {
-			usize len = unsafe_yyjson_get_len(i_val);
-			if (len > 0) {
-				yyjson_val *ii_key = i_val + 1, *ii_nextkey;
-				yyjson_mut_val *mm_key = m_val + 1, *mm_ctn = m_val;
-				yyjson_mut_val *mm_nextkey;
-				while (len-- > 1) {
-					ii_nextkey = unsafe_yyjson_get_next(ii_key + 1);
-					mm_nextkey = mm_key + (ii_nextkey - ii_key);
-					mm_key->next = mm_key + 1;
-					mm_key->next->next = mm_nextkey;
-					ii_key = ii_nextkey;
-					mm_key = mm_nextkey;
-				}
-				mm_key->next = mm_key + 1;
-				mm_key->next->next = mm_ctn + 1;
-				mm_ctn->uni.ptr = mm_key;
-			}
-		}
-	}
-
-	return m_vals;
+    return m_vals;
 }
 
-static yyjson_mut_val *unsafe_yyjson_mut_val_mut_copy(yyjson_mut_doc *m_doc, yyjson_mut_val *m_vals) {
-	/*
-	 The mutable object or array stores all sub-values in a circular linked
-	 list, so we can traverse them in the same loop. The traversal starts from
-	 the last item, continues with the first item in a list, and ends with the
-	 second to last item, which needs to be linked to the last item to close the
-	 circle.
-	 */
+static yyjson_mut_val *unsafe_yyjson_mut_val_mut_copy(yyjson_mut_doc *m_doc,
+                                                      yyjson_mut_val *m_vals) {
+    /*
+     The mutable object or array stores all sub-values in a circular linked
+     list, so we can traverse them in the same loop. The traversal starts from
+     the last item, continues with the first item in a list, and ends with the
+     second to last item, which needs to be linked to the last item to close the
+     circle.
+     */
+    yyjson_mut_val *m_val = unsafe_yyjson_mut_val(m_doc, 1);
+    if (unlikely(!m_val)) return NULL;
+    m_val->tag = m_vals->tag;
 
-	yyjson_mut_val *m_val = unsafe_yyjson_mut_val(m_doc, 1);
-	if (unlikely(!m_val))
-		return NULL;
-	m_val->tag = m_vals->tag;
+    switch (unsafe_yyjson_get_type(m_vals)) {
+        case YYJSON_TYPE_OBJ:
+        case YYJSON_TYPE_ARR:
+            if (unsafe_yyjson_get_len(m_vals) > 0) {
+                yyjson_mut_val *last = (yyjson_mut_val *)m_vals->uni.ptr;
+                yyjson_mut_val *next = last->next, *prev;
+                prev = unsafe_yyjson_mut_val_mut_copy(m_doc, last);
+                if (!prev) return NULL;
+                m_val->uni.ptr = (void *)prev;
+                while (next != last) {
+                    prev->next = unsafe_yyjson_mut_val_mut_copy(m_doc, next);
+                    if (!prev->next) return NULL;
+                    prev = prev->next;
+                    next = next->next;
+                }
+                prev->next = (yyjson_mut_val *)m_val->uni.ptr;
+            }
+            break;
 
-	switch (unsafe_yyjson_get_type(m_vals)) {
-	case YYJSON_TYPE_OBJ:
-	case YYJSON_TYPE_ARR:
-		if (unsafe_yyjson_get_len(m_vals) > 0) {
-			yyjson_mut_val *last = (yyjson_mut_val *)m_vals->uni.ptr;
-			yyjson_mut_val *next = last->next, *prev;
-			prev = unsafe_yyjson_mut_val_mut_copy(m_doc, last);
-			if (!prev)
-				return NULL;
-			m_val->uni.ptr = (void *)prev;
-			while (next != last) {
-				prev->next = unsafe_yyjson_mut_val_mut_copy(m_doc, next);
-				if (!prev->next)
-					return NULL;
-				prev = prev->next;
-				next = next->next;
-			}
-			prev->next = (yyjson_mut_val *)m_val->uni.ptr;
-		}
-		break;
+        case YYJSON_TYPE_RAW:
+        case YYJSON_TYPE_STR: {
+            const char *str = m_vals->uni.str;
+            usize str_len = unsafe_yyjson_get_len(m_vals);
+            m_val->uni.str = unsafe_yyjson_mut_strncpy(m_doc, str, str_len);
+            if (!m_val->uni.str) return NULL;
+            break;
+        }
 
-	case YYJSON_TYPE_RAW:
-	case YYJSON_TYPE_STR: {
-		const char *str = m_vals->uni.str;
-		usize str_len = unsafe_yyjson_get_len(m_vals);
-		m_val->uni.str = unsafe_yyjson_mut_strncpy(m_doc, str, str_len);
-		if (!m_val->uni.str)
-			return NULL;
-		break;
-	}
+        default:
+            m_val->uni = m_vals->uni;
+            break;
+    }
 
-	default:
-		m_val->uni = m_vals->uni;
-		break;
-	}
-
-	return m_val;
+    return m_val;
 }
 
-yyjson_api yyjson_mut_val *yyjson_mut_val_mut_copy(yyjson_mut_doc *doc, yyjson_mut_val *val) {
-	if (doc && val)
-		return unsafe_yyjson_mut_val_mut_copy(doc, val);
-	return NULL;
+yyjson_mut_val *yyjson_mut_val_mut_copy(yyjson_mut_doc *doc,
+                                        yyjson_mut_val *val) {
+    if (doc && val) return unsafe_yyjson_mut_val_mut_copy(doc, val);
+    return NULL;
 }
 
 /* Count the number of values and the total length of the strings. */
-static void yyjson_mut_stat(yyjson_mut_val *val, usize *val_sum, usize *str_sum) {
-	yyjson_type type = unsafe_yyjson_get_type(val);
-	*val_sum += 1;
-	if (type == YYJSON_TYPE_ARR || type == YYJSON_TYPE_OBJ) {
-		yyjson_mut_val *child = (yyjson_mut_val *)val->uni.ptr;
-		usize len = unsafe_yyjson_get_len(val), i;
-		len <<= (u8)(type == YYJSON_TYPE_OBJ);
-		*val_sum += len;
-		for (i = 0; i < len; i++) {
-			yyjson_type stype = unsafe_yyjson_get_type(child);
-			if (stype == YYJSON_TYPE_STR || stype == YYJSON_TYPE_RAW) {
-				*str_sum += unsafe_yyjson_get_len(child) + 1;
-			} else if (stype == YYJSON_TYPE_ARR || stype == YYJSON_TYPE_OBJ) {
-				yyjson_mut_stat(child, val_sum, str_sum);
-				*val_sum -= 1;
-			}
-			child = child->next;
-		}
-	} else if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
-		*str_sum += unsafe_yyjson_get_len(val) + 1;
-	}
+static void yyjson_mut_stat(yyjson_mut_val *val,
+                            usize *val_sum, usize *str_sum) {
+    yyjson_type type = unsafe_yyjson_get_type(val);
+    *val_sum += 1;
+    if (type == YYJSON_TYPE_ARR || type == YYJSON_TYPE_OBJ) {
+        yyjson_mut_val *child = (yyjson_mut_val *)val->uni.ptr;
+        usize len = unsafe_yyjson_get_len(val), i;
+        len <<= (u8)(type == YYJSON_TYPE_OBJ);
+        *val_sum += len;
+        for (i = 0; i < len; i++) {
+            yyjson_type stype = unsafe_yyjson_get_type(child);
+            if (stype == YYJSON_TYPE_STR || stype == YYJSON_TYPE_RAW) {
+                *str_sum += unsafe_yyjson_get_len(child) + 1;
+            } else if (stype == YYJSON_TYPE_ARR || stype == YYJSON_TYPE_OBJ) {
+                yyjson_mut_stat(child, val_sum, str_sum);
+                *val_sum -= 1;
+            }
+            child = child->next;
+        }
+    } else if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
+        *str_sum += unsafe_yyjson_get_len(val) + 1;
+    }
 }
 
 /* Copy mutable values to immutable value pool. */
-static usize yyjson_imut_copy(yyjson_val **val_ptr, char **buf_ptr, yyjson_mut_val *mval) {
-	yyjson_val *val = *val_ptr;
-	yyjson_type type = unsafe_yyjson_get_type(mval);
-	if (type == YYJSON_TYPE_ARR || type == YYJSON_TYPE_OBJ) {
-		yyjson_mut_val *child = (yyjson_mut_val *)mval->uni.ptr;
-		usize len = unsafe_yyjson_get_len(mval), i;
-		usize val_sum = 1;
-		if (type == YYJSON_TYPE_OBJ) {
-			if (len)
-				child = child->next->next;
-			len <<= 1;
-		} else {
-			if (len)
-				child = child->next;
-		}
-		*val_ptr = val + 1;
-		for (i = 0; i < len; i++) {
-			val_sum += yyjson_imut_copy(val_ptr, buf_ptr, child);
-			child = child->next;
-		}
-		val->tag = mval->tag;
-		val->uni.ofs = val_sum * sizeof(yyjson_val);
-		return val_sum;
-	} else if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
-		char *buf = *buf_ptr;
-		usize len = unsafe_yyjson_get_len(mval);
-		memcpy((void *)buf, (void *)mval->uni.str, len);
-		buf[len] = '\0';
-		val->tag = mval->tag;
-		val->uni.str = buf;
-		*val_ptr = val + 1;
-		*buf_ptr = buf + len + 1;
-		return 1;
-	} else {
-		val->tag = mval->tag;
-		val->uni = mval->uni;
-		*val_ptr = val + 1;
-		return 1;
-	}
+static usize yyjson_imut_copy(yyjson_val **val_ptr, char **buf_ptr,
+                              yyjson_mut_val *mval) {
+    yyjson_val *val = *val_ptr;
+    yyjson_type type = unsafe_yyjson_get_type(mval);
+    if (type == YYJSON_TYPE_ARR || type == YYJSON_TYPE_OBJ) {
+        yyjson_mut_val *child = (yyjson_mut_val *)mval->uni.ptr;
+        usize len = unsafe_yyjson_get_len(mval), i;
+        usize val_sum = 1;
+        if (type == YYJSON_TYPE_OBJ) {
+            if (len) child = child->next->next;
+            len <<= 1;
+        } else {
+            if (len) child = child->next;
+        }
+        *val_ptr = val + 1;
+        for (i = 0; i < len; i++) {
+            val_sum += yyjson_imut_copy(val_ptr, buf_ptr, child);
+            child = child->next;
+        }
+        val->tag = mval->tag;
+        val->uni.ofs = val_sum * sizeof(yyjson_val);
+        return val_sum;
+    } else if (type == YYJSON_TYPE_STR || type == YYJSON_TYPE_RAW) {
+        char *buf = *buf_ptr;
+        usize len = unsafe_yyjson_get_len(mval);
+        memcpy((void *)buf, (const void *)mval->uni.str, len);
+        buf[len] = '\0';
+        val->tag = mval->tag;
+        val->uni.str = buf;
+        *val_ptr = val + 1;
+        *buf_ptr = buf + len + 1;
+        return 1;
+    } else {
+        val->tag = mval->tag;
+        val->uni = mval->uni;
+        *val_ptr = val + 1;
+        return 1;
+    }
 }
 
-yyjson_api yyjson_doc *yyjson_mut_doc_imut_copy(yyjson_mut_doc *mdoc, const yyjson_alc *alc) {
-	if (!mdoc)
-		return NULL;
-	return yyjson_mut_val_imut_copy(mdoc->root, alc);
+yyjson_doc *yyjson_mut_doc_imut_copy(yyjson_mut_doc *mdoc,
+                                     const yyjson_alc *alc) {
+    if (!mdoc) return NULL;
+    return yyjson_mut_val_imut_copy(mdoc->root, alc);
 }
 
-yyjson_api yyjson_doc *yyjson_mut_val_imut_copy(yyjson_mut_val *mval, const yyjson_alc *alc) {
-	usize val_num = 0, str_sum = 0, hdr_size, buf_size;
-	yyjson_doc *doc = NULL;
-	yyjson_val *val_hdr = NULL;
+yyjson_doc *yyjson_mut_val_imut_copy(yyjson_mut_val *mval,
+                                     const yyjson_alc *alc) {
+    usize val_num = 0, str_sum = 0, hdr_size, buf_size;
+    yyjson_doc *doc = NULL;
+    yyjson_val *val_hdr = NULL;
 
-	/* This value should be NULL here. Setting a non-null value suppresses
-	   warning from the clang analyzer. */
-	char *str_hdr = (char *)(void *)&str_sum;
-	if (!mval)
-		return NULL;
-	if (!alc)
-		alc = &YYJSON_DEFAULT_ALC;
+    /* This value should be NULL here. Setting a non-null value suppresses
+       warning from the clang analyzer. */
+    char *str_hdr = (char *)(void *)&str_sum;
+    if (!mval) return NULL;
+    if (!alc) alc = &YYJSON_DEFAULT_ALC;
 
-	/* traverse the input value to get pool size */
-	yyjson_mut_stat(mval, &val_num, &str_sum);
+    /* traverse the input value to get pool size */
+    yyjson_mut_stat(mval, &val_num, &str_sum);
 
-	/* create doc and val pool */
-	hdr_size = size_align_up(sizeof(yyjson_doc), sizeof(yyjson_val));
-	buf_size = hdr_size + val_num * sizeof(yyjson_val);
-	doc = (yyjson_doc *)alc->malloc(alc->ctx, buf_size);
-	if (!doc)
-		return NULL;
-	memset(doc, 0, sizeof(yyjson_doc));
-	val_hdr = (yyjson_val *)((char *)(void *)doc + hdr_size);
-	doc->root = val_hdr;
-	doc->alc = *alc;
+    /* create doc and val pool */
+    hdr_size = size_align_up(sizeof(yyjson_doc), sizeof(yyjson_val));
+    buf_size = hdr_size + val_num * sizeof(yyjson_val);
+    doc = (yyjson_doc *)alc->malloc(alc->ctx, buf_size);
+    if (!doc) return NULL;
+    memset(doc, 0, sizeof(yyjson_doc));
+    val_hdr = (yyjson_val *)(void *)((char *)(void *)doc + hdr_size);
+    doc->root = val_hdr;
+    doc->alc = *alc;
 
-	/* create str pool */
-	if (str_sum > 0) {
-		str_hdr = (char *)alc->malloc(alc->ctx, str_sum);
-		doc->str_pool = str_hdr;
-		if (!str_hdr) {
-			alc->free(alc->ctx, (void *)doc);
-			return NULL;
-		}
-	}
+    /* create str pool */
+    if (str_sum > 0) {
+        str_hdr = (char *)alc->malloc(alc->ctx, str_sum);
+        doc->str_pool = str_hdr;
+        if (!str_hdr) {
+            alc->free(alc->ctx, (void *)doc);
+            return NULL;
+        }
+    }
 
-	/* copy vals and strs */
-	doc->val_read = yyjson_imut_copy(&val_hdr, &str_hdr, mval);
-	doc->dat_read = str_sum + 1;
-	return doc;
+    /* copy vals and strs */
+    doc->val_read = yyjson_imut_copy(&val_hdr, &str_hdr, mval);
+    doc->dat_read = str_sum + 1;
+    return doc;
 }
 
 static_inline bool unsafe_yyjson_num_equals(void *lhs, void *rhs) {
-	yyjson_val_uni *luni = &((yyjson_val *)lhs)->uni;
-	yyjson_val_uni *runi = &((yyjson_val *)rhs)->uni;
-	yyjson_subtype lt = unsafe_yyjson_get_subtype(lhs);
-	yyjson_subtype rt = unsafe_yyjson_get_subtype(rhs);
-	if (lt == rt)
-		return luni->u64 == runi->u64;
-	if (lt == YYJSON_SUBTYPE_SINT && rt == YYJSON_SUBTYPE_UINT)
-		return luni->i64 >= 0 && luni->u64 == runi->u64;
-	if (lt == YYJSON_SUBTYPE_UINT && rt == YYJSON_SUBTYPE_SINT)
-		return runi->i64 >= 0 && luni->u64 == runi->u64;
-	return false;
+    yyjson_val_uni *luni = &((yyjson_val *)lhs)->uni;
+    yyjson_val_uni *runi = &((yyjson_val *)rhs)->uni;
+    yyjson_subtype lt = unsafe_yyjson_get_subtype(lhs);
+    yyjson_subtype rt = unsafe_yyjson_get_subtype(rhs);
+    if (lt == rt) return luni->u64 == runi->u64;
+    if (lt == YYJSON_SUBTYPE_SINT && rt == YYJSON_SUBTYPE_UINT) {
+        return luni->i64 >= 0 && luni->u64 == runi->u64;
+    }
+    if (lt == YYJSON_SUBTYPE_UINT && rt == YYJSON_SUBTYPE_SINT) {
+        return runi->i64 >= 0 && luni->u64 == runi->u64;
+    }
+    return false;
 }
 
 static_inline bool unsafe_yyjson_str_equals(void *lhs, void *rhs) {
-	usize len = unsafe_yyjson_get_len(lhs);
-	if (len != unsafe_yyjson_get_len(rhs))
-		return false;
-	return 0 == len || 0 == memcmp(unsafe_yyjson_get_str(lhs), unsafe_yyjson_get_str(rhs), len);
+    usize len = unsafe_yyjson_get_len(lhs);
+    if (len != unsafe_yyjson_get_len(rhs)) return false;
+    return !memcmp(unsafe_yyjson_get_str(lhs),
+                   unsafe_yyjson_get_str(rhs), len);
 }
 
-yyjson_api bool unsafe_yyjson_equals(yyjson_val *lhs, yyjson_val *rhs) {
-	yyjson_type type = unsafe_yyjson_get_type(lhs);
-	if (type != unsafe_yyjson_get_type(rhs))
-		return false;
+bool unsafe_yyjson_equals(yyjson_val *lhs, yyjson_val *rhs) {
+    yyjson_type type = unsafe_yyjson_get_type(lhs);
+    if (type != unsafe_yyjson_get_type(rhs)) return false;
 
-	switch (type) {
-	case YYJSON_TYPE_OBJ: {
-		usize len = unsafe_yyjson_get_len(lhs);
-		if (len != unsafe_yyjson_get_len(rhs))
-			return false;
-		if (len > 0) {
-			yyjson_obj_iter iter;
-			yyjson_obj_iter_init(rhs, &iter);
-			lhs = unsafe_yyjson_get_first(lhs);
-			while (len-- > 0) {
-				rhs = yyjson_obj_iter_getn(&iter, lhs->uni.str, unsafe_yyjson_get_len(lhs));
-				if (!rhs || !unsafe_yyjson_equals(lhs + 1, rhs))
-					return false;
-				lhs = unsafe_yyjson_get_next(lhs + 1);
-			}
-		}
-		/* yyjson allows duplicate keys, so the check may be inaccurate */
-		return true;
-	}
+    switch (type) {
+        case YYJSON_TYPE_OBJ: {
+            usize len = unsafe_yyjson_get_len(lhs);
+            if (len != unsafe_yyjson_get_len(rhs)) return false;
+            if (len > 0) {
+                yyjson_obj_iter iter;
+                yyjson_obj_iter_init(rhs, &iter);
+                lhs = unsafe_yyjson_get_first(lhs);
+                while (len-- > 0) {
+                    rhs = yyjson_obj_iter_getn(&iter, lhs->uni.str,
+                                               unsafe_yyjson_get_len(lhs));
+                    if (!rhs) return false;
+                    if (!unsafe_yyjson_equals(lhs + 1, rhs)) return false;
+                    lhs = unsafe_yyjson_get_next(lhs + 1);
+                }
+            }
+            /* yyjson allows duplicate keys, so the check may be inaccurate */
+            return true;
+        }
 
-	case YYJSON_TYPE_ARR: {
-		usize len = unsafe_yyjson_get_len(lhs);
-		if (len != unsafe_yyjson_get_len(rhs))
-			return false;
-		if (len > 0) {
-			lhs = unsafe_yyjson_get_first(lhs);
-			rhs = unsafe_yyjson_get_first(rhs);
-			while (len-- > 0) {
-				if (!unsafe_yyjson_equals(lhs, rhs))
-					return false;
-				lhs = unsafe_yyjson_get_next(lhs);
-				rhs = unsafe_yyjson_get_next(rhs);
-			}
-		}
-		return true;
-	}
+        case YYJSON_TYPE_ARR: {
+            usize len = unsafe_yyjson_get_len(lhs);
+            if (len != unsafe_yyjson_get_len(rhs)) return false;
+            if (len > 0) {
+                lhs = unsafe_yyjson_get_first(lhs);
+                rhs = unsafe_yyjson_get_first(rhs);
+                while (len-- > 0) {
+                    if (!unsafe_yyjson_equals(lhs, rhs)) return false;
+                    lhs = unsafe_yyjson_get_next(lhs);
+                    rhs = unsafe_yyjson_get_next(rhs);
+                }
+            }
+            return true;
+        }
 
-	case YYJSON_TYPE_NUM:
-		return unsafe_yyjson_num_equals(lhs, rhs);
+        case YYJSON_TYPE_NUM:
+            return unsafe_yyjson_num_equals(lhs, rhs);
 
-	case YYJSON_TYPE_RAW:
-	case YYJSON_TYPE_STR:
-		return unsafe_yyjson_str_equals(lhs, rhs);
+        case YYJSON_TYPE_RAW:
+        case YYJSON_TYPE_STR:
+            return unsafe_yyjson_str_equals(lhs, rhs);
 
-	case YYJSON_TYPE_NULL:
-	case YYJSON_TYPE_BOOL:
-		return lhs->tag == rhs->tag;
+        case YYJSON_TYPE_NULL:
+        case YYJSON_TYPE_BOOL:
+            return lhs->tag == rhs->tag;
 
-	default:
-		return false;
-	}
+        default:
+            return false;
+    }
 }
 
 bool unsafe_yyjson_mut_equals(yyjson_mut_val *lhs, yyjson_mut_val *rhs) {
-	yyjson_type type = unsafe_yyjson_get_type(lhs);
-	if (type != unsafe_yyjson_get_type(rhs))
-		return false;
+    yyjson_type type = unsafe_yyjson_get_type(lhs);
+    if (type != unsafe_yyjson_get_type(rhs)) return false;
 
-	switch (type) {
-	case YYJSON_TYPE_OBJ: {
-		usize len = unsafe_yyjson_get_len(lhs);
-		if (len != unsafe_yyjson_get_len(rhs))
-			return false;
-		if (len > 0) {
-			yyjson_mut_obj_iter iter;
-			yyjson_mut_obj_iter_init(rhs, &iter);
-			lhs = (yyjson_mut_val *)lhs->uni.ptr;
-			while (len-- > 0) {
-				rhs = yyjson_mut_obj_iter_getn(&iter, lhs->uni.str, unsafe_yyjson_get_len(lhs));
-				if (!rhs || !unsafe_yyjson_mut_equals(lhs->next, rhs))
-					return false;
-				lhs = lhs->next->next;
-			}
-		}
-		/* yyjson allows duplicate keys, so the check may be inaccurate */
-		return true;
-	}
+    switch (type) {
+        case YYJSON_TYPE_OBJ: {
+            usize len = unsafe_yyjson_get_len(lhs);
+            if (len != unsafe_yyjson_get_len(rhs)) return false;
+            if (len > 0) {
+                yyjson_mut_obj_iter iter;
+                yyjson_mut_obj_iter_init(rhs, &iter);
+                lhs = (yyjson_mut_val *)lhs->uni.ptr;
+                while (len-- > 0) {
+                    rhs = yyjson_mut_obj_iter_getn(&iter, lhs->uni.str,
+                                                   unsafe_yyjson_get_len(lhs));
+                    if (!rhs) return false;
+                    if (!unsafe_yyjson_mut_equals(lhs->next, rhs)) return false;
+                    lhs = lhs->next->next;
+                }
+            }
+            /* yyjson allows duplicate keys, so the check may be inaccurate */
+            return true;
+        }
 
-	case YYJSON_TYPE_ARR: {
-		usize len = unsafe_yyjson_get_len(lhs);
-		if (len != unsafe_yyjson_get_len(rhs))
-			return false;
-		if (len > 0) {
-			lhs = (yyjson_mut_val *)lhs->uni.ptr;
-			rhs = (yyjson_mut_val *)rhs->uni.ptr;
-			while (len-- > 0) {
-				if (!unsafe_yyjson_mut_equals(lhs, rhs))
-					return false;
-				lhs = lhs->next;
-				rhs = rhs->next;
-			}
-		}
-		return true;
-	}
+        case YYJSON_TYPE_ARR: {
+            usize len = unsafe_yyjson_get_len(lhs);
+            if (len != unsafe_yyjson_get_len(rhs)) return false;
+            if (len > 0) {
+                lhs = (yyjson_mut_val *)lhs->uni.ptr;
+                rhs = (yyjson_mut_val *)rhs->uni.ptr;
+                while (len-- > 0) {
+                    if (!unsafe_yyjson_mut_equals(lhs, rhs)) return false;
+                    lhs = lhs->next;
+                    rhs = rhs->next;
+                }
+            }
+            return true;
+        }
 
-	case YYJSON_TYPE_NUM:
-		return unsafe_yyjson_num_equals(lhs, rhs);
+        case YYJSON_TYPE_NUM:
+            return unsafe_yyjson_num_equals(lhs, rhs);
 
-	case YYJSON_TYPE_RAW:
-	case YYJSON_TYPE_STR:
-		return unsafe_yyjson_str_equals(lhs, rhs);
+        case YYJSON_TYPE_RAW:
+        case YYJSON_TYPE_STR:
+            return unsafe_yyjson_str_equals(lhs, rhs);
 
-	case YYJSON_TYPE_NULL:
-	case YYJSON_TYPE_BOOL:
-		return lhs->tag == rhs->tag;
+        case YYJSON_TYPE_NULL:
+        case YYJSON_TYPE_BOOL:
+            return lhs->tag == rhs->tag;
 
-	default:
-		return false;
-	}
+        default:
+            return false;
+    }
 }
 
+
+
+#if !YYJSON_DISABLE_UTILS
+
 /*==============================================================================
- * JSON Pointer
+ * JSON Pointer API (RFC 6901)
  *============================================================================*/
 
 /**
- Get value from JSON array with a path segment (array index).
- @param ptr Input the segment after `/`, output the end of segment.
- @param end The end of entire JSON pointer.
- @param arr JSON array (yyjson_val/yyjson_mut_val, based on `mut`).
- @param mut Whether `arr` is mutable.
- @return The matched value, or NULL if not matched.
+ Get a token from JSON pointer string.
+ @param ptr [in,out]
+                in:  string that points to current token prefix `/`
+                out: string that points to next token prefix `/`, or string end
+ @param end [in] end of the entire JSON Pointer string
+ @param len [out] unescaped token length
+ @param esc [out] number of escaped characters in this token
+ @return head of the token, or NULL if syntax error
  */
-static_inline void *pointer_read_arr(const char **ptr, const char *end, void *arr, bool mut) {
-	const char *hdr = *ptr;
-	const char *cur = hdr;
-	yyjson_val *i_arr = (yyjson_val *)arr;
-	yyjson_mut_val *m_arr = (yyjson_mut_val *)arr;
-	u64 idx = 0;
-	u8 add;
-
-	/* start with 0 */
-	if (cur < end && *cur == '0') {
-		*ptr = cur + 1;
-		return mut ? (void *)yyjson_mut_arr_get_first(m_arr) : (void *)yyjson_arr_get_first(i_arr);
-	}
-
-	/* read whole number */
-	if (cur + U64_SAFE_DIG < end)
-		end = cur + U64_SAFE_DIG;
-	while (cur < end && (add = (u8)((u8)*cur - (u8)'0')) <= 9) {
-		cur++;
-		idx = idx * 10 + add;
-	}
-	if (cur == hdr || idx >= (u64)USIZE_MAX)
-		return NULL;
-	*ptr = cur;
-	return mut ? (void *)yyjson_mut_arr_get(m_arr, (usize)idx) : (void *)yyjson_arr_get(i_arr, (usize)idx);
+static_inline const char *ptr_next_token(const char **ptr, const char *end,
+                                         usize *len, usize *esc) {
+    const char *hdr = *ptr + 1;
+    const char *cur = hdr;
+    /* skip unescaped characters */
+    while (cur < end && *cur != '/' && *cur != '~') cur++;
+    if (likely(cur == end || *cur != '~')) {
+        /* no escaped characters, return */
+        *ptr = cur;
+        *len = (usize)(cur - hdr);
+        *esc = 0;
+        return hdr;
+    } else {
+        /* handle escaped characters */
+        usize esc_num = 0;
+        while (cur < end && *cur != '/') {
+            if (*cur++ == '~') {
+                if (cur == end || (*cur != '0' && *cur != '1')) {
+                    *ptr = cur - 1;
+                    return NULL;
+                }
+                esc_num++;
+            }
+        }
+        *ptr = cur;
+        *len = (usize)(cur - hdr) - esc_num;
+        *esc = esc_num;
+        return hdr;
+    }
 }
 
 /**
- Get value from JSON object with a path segment (object key).
- @param ptr Input the segment after `/`, output the end of segment.
- @param end The end of entire JSON pointer.
- @param obj JSON object (yyjson_val/yyjson_mut_val, based on `mut`).
- @param mut `obj` is mutable.
- @return The matched value, or NULL if not matched.
+ Convert token string to index.
+ @param cur [in]  token head
+ @param len [in]  token length
+ @param idx [out] the index number, or USIZE_MAX if token is '-'
+ @return true if token is a valid array index
  */
-static_inline void *pointer_read_obj(const char **ptr, const char *end, void *obj, bool mut) {
-#define BUF_SIZE          512
-#define is_escaped(cur)   ((cur) < end && (*(cur) == '0' || *(cur) == '1'))
-#define is_unescaped(cur) ((cur) < end && *(cur) != '/' && *(cur) != '~')
-#define is_completed(cur) ((cur) == end || *(cur) == '/')
-
-	const char *hdr = *ptr;
-	const char *cur = hdr;
-	yyjson_val *i_obj = (yyjson_val *)obj;
-	yyjson_mut_val *m_obj = (yyjson_mut_val *)obj;
-	yyjson_obj_iter i_iter;
-	yyjson_mut_obj_iter m_iter;
-	void *key;
-
-	/* skip unescaped characters */
-	while (is_unescaped(cur))
-		cur++;
-	if (likely(is_completed(cur))) {
-		usize len = (usize)(cur - hdr);
-		*ptr = cur;
-		return mut ? (void *)yyjson_mut_obj_getn(m_obj, hdr, len) : (void *)yyjson_obj_getn(i_obj, hdr, len);
-	}
-
-	/* copy escaped characters to buffer */
-	if (likely(end - hdr <= BUF_SIZE)) {
-		char buf[BUF_SIZE];
-		char *dst = buf + (usize)(cur - hdr);
-		memcpy(buf, hdr, (usize)(cur - hdr));
-		while (true) {
-			if (is_unescaped(cur)) {
-				*dst++ = *cur++;
-			} else if (is_completed(cur)) {
-				usize len = (usize)(dst - buf);
-				*ptr = cur;
-				return mut ? (void *)yyjson_mut_obj_getn(m_obj, buf, len) : (void *)yyjson_obj_getn(i_obj, buf, len);
-			} else {
-				cur++; /* skip '~' */
-				if (unlikely(!is_escaped(cur)))
-					return NULL;
-				*dst++ = (char)(*cur++ == '0' ? '~' : '/');
-			}
-		}
-	}
-
-	/* compare byte by byte */
-	cur = hdr;
-	if (!mut)
-		yyjson_obj_iter_init(i_obj, &i_iter);
-	else
-		yyjson_mut_obj_iter_init(m_obj, &m_iter);
-	while ((key = mut ? (void *)yyjson_mut_obj_iter_next(&m_iter) : (void *)yyjson_obj_iter_next(&i_iter))) {
-		const char *k_str = unsafe_yyjson_get_str(key);
-		const char *k_end = k_str + unsafe_yyjson_get_len(key);
-		while (k_str < k_end) {
-			if (is_unescaped(cur) && *k_str == *cur) {
-				k_str += 1;
-				cur += 1;
-			} else if (cur < end && *cur == '~' && is_escaped(cur + 1) && *k_str == (*(cur + 1) == '0' ? '~' : '/')) {
-				k_str += 1;
-				cur += 2;
-			} else {
-				break;
-			}
-		}
-		if (k_str == k_end && is_completed(cur)) {
-			*ptr = cur;
-			return mut ? (void *)yyjson_mut_obj_iter_get_val((yyjson_mut_val *)key)
-			           : (void *)yyjson_obj_iter_get_val((yyjson_val *)key);
-		}
-	}
-	return NULL;
-
-#undef BUF_SIZE
-#undef is_escaped
-#undef is_unescaped
-#undef is_completed
+static_inline bool ptr_token_to_idx(const char *cur, usize len, usize *idx) {
+    const char *end = cur + len;
+    usize num = 0, add;
+    if (unlikely(len == 0 || len > USIZE_SAFE_DIG)) return false;
+    if (*cur == '0') {
+        if (unlikely(len > 1)) return false;
+        *idx = 0;
+        return true;
+    }
+    if (*cur == '-') {
+        if (unlikely(len > 1)) return false;
+        *idx = USIZE_MAX;
+        return true;
+    }
+    for (; cur < end && (add = (usize)((u8)*cur - (u8)'0')) <= 9; cur++) {
+        num = num * 10 + add;
+    }
+    if (unlikely(num == 0 || cur < end)) return false;
+    *idx = num;
+    return true;
 }
 
-yyjson_api yyjson_val *unsafe_yyjson_get_pointer(yyjson_val *val, const char *ptr, usize len) {
-	const char *end = ptr + len;
-	ptr++; /* skip '/' */
-	while (true) {
-		if (yyjson_is_obj(val)) {
-			val = (yyjson_val *)pointer_read_obj(&ptr, end, val, false);
-		} else if (yyjson_is_arr(val)) {
-			val = (yyjson_val *)pointer_read_arr(&ptr, end, val, false);
-		} else {
-			val = NULL;
-		}
-		if (!val || ptr == end)
-			return val;
-		if (*ptr++ != '/')
-			return NULL;
-	}
+/**
+ Compare JSON key with token.
+ @param key a string key (yyjson_val or yyjson_mut_val)
+ @param token a JSON pointer token
+ @param len unescaped token length
+ @param esc number of escaped characters in this token
+ @return true if `str` is equals to `token`
+ */
+static_inline bool ptr_token_eq(void *key,
+                                const char *token, usize len, usize esc) {
+    yyjson_val *val = (yyjson_val *)key;
+    if (unsafe_yyjson_get_len(val) != len) return false;
+    if (likely(!esc)) {
+        return memcmp(val->uni.str, token, len) == 0;
+    } else {
+        const char *str = val->uni.str;
+        for (; len-- > 0; token++, str++) {
+            if (*token == '~') {
+                if (*str != (*++token == '0' ? '~' : '/')) return false;
+            } else {
+                if (*str != *token) return false;
+            }
+        }
+        return true;
+    }
 }
 
-yyjson_api yyjson_mut_val *unsafe_yyjson_mut_get_pointer(yyjson_mut_val *val, const char *ptr, usize len) {
-	const char *end = ptr + len;
-	ptr++; /* skip '/' */
-	while (true) {
-		if (yyjson_mut_is_obj(val)) {
-			val = (yyjson_mut_val *)pointer_read_obj(&ptr, end, val, true);
-		} else if (yyjson_mut_is_arr(val)) {
-			val = (yyjson_mut_val *)pointer_read_arr(&ptr, end, val, true);
-		} else {
-			val = NULL;
-		}
-		if (!val || ptr == end)
-			return val;
-		if (*ptr++ != '/')
-			return NULL;
-	}
+/**
+ Get a value from array by token.
+ @param arr   an array, should not be NULL or non-array type
+ @param token a JSON pointer token
+ @param len   unescaped token length
+ @param esc   number of escaped characters in this token
+ @return value at index, or NULL if token is not index or index is out of range
+ */
+static_inline yyjson_val *ptr_arr_get(yyjson_val *arr, const char *token,
+                                      usize len, usize esc) {
+    yyjson_val *val = unsafe_yyjson_get_first(arr);
+    usize num = unsafe_yyjson_get_len(arr), idx = 0;
+    if (unlikely(num == 0)) return NULL;
+    if (unlikely(!ptr_token_to_idx(token, len, &idx))) return NULL;
+    if (unlikely(idx >= num)) return NULL;
+    if (unsafe_yyjson_arr_is_flat(arr)) {
+        return val + idx;
+    } else {
+        while (idx-- > 0) val = unsafe_yyjson_get_next(val);
+        return val;
+    }
 }
+
+/**
+ Get a value from object by token.
+ @param obj   [in] an object, should not be NULL or non-object type
+ @param token [in] a JSON pointer token
+ @param len   [in] unescaped token length
+ @param esc   [in] number of escaped characters in this token
+ @return value associated with the token, or NULL if no value
+ */
+static_inline yyjson_val *ptr_obj_get(yyjson_val *obj, const char *token,
+                                      usize len, usize esc) {
+    yyjson_val *key = unsafe_yyjson_get_first(obj);
+    usize num = unsafe_yyjson_get_len(obj);
+    if (unlikely(num == 0)) return NULL;
+    for (; num > 0; num--, key = unsafe_yyjson_get_next(key + 1)) {
+        if (ptr_token_eq(key, token, len, esc)) return key + 1;
+    }
+    return NULL;
+}
+
+/**
+ Get a value from array by token.
+ @param arr   [in] an array, should not be NULL or non-array type
+ @param token [in] a JSON pointer token
+ @param len   [in] unescaped token length
+ @param esc   [in] number of escaped characters in this token
+ @param pre   [out] previous (sibling) value of the returned value
+ @param last  [out] whether index is last
+ @return value at index, or NULL if token is not index or index is out of range
+ */
+static_inline yyjson_mut_val *ptr_mut_arr_get(yyjson_mut_val *arr,
+                                              const char *token,
+                                              usize len, usize esc,
+                                              yyjson_mut_val **pre,
+                                              bool *last) {
+    yyjson_mut_val *val = (yyjson_mut_val *)arr->uni.ptr; /* last (tail) */
+    usize num = unsafe_yyjson_get_len(arr), idx;
+    if (last) *last = false;
+    if (pre) *pre = NULL;
+    if (unlikely(num == 0)) {
+        if (last && len == 1 && (*token == '0' || *token == '-')) *last = true;
+        return NULL;
+    }
+    if (unlikely(!ptr_token_to_idx(token, len, &idx))) return NULL;
+    if (last) *last = (idx == num || idx == USIZE_MAX);
+    if (unlikely(idx >= num)) return NULL;
+    while (idx-- > 0) val = val->next;
+    *pre = val;
+    return val->next;
+}
+
+/**
+ Get a value from object by token.
+ @param obj   [in] an object, should not be NULL or non-object type
+ @param token [in] a JSON pointer token
+ @param len   [in] unescaped token length
+ @param esc   [in] number of escaped characters in this token
+ @param pre   [out] previous (sibling) key of the returned value's key
+ @return value associated with the token, or NULL if no value
+ */
+static_inline yyjson_mut_val *ptr_mut_obj_get(yyjson_mut_val *obj,
+                                              const char *token,
+                                              usize len, usize esc,
+                                              yyjson_mut_val **pre) {
+    yyjson_mut_val *pre_key = (yyjson_mut_val *)obj->uni.ptr, *key;
+    usize num = unsafe_yyjson_get_len(obj);
+    if (pre) *pre = NULL;
+    if (unlikely(num == 0)) return NULL;
+    for (; num > 0; num--, pre_key = key) {
+        key = pre_key->next->next;
+        if (ptr_token_eq(key, token, len, esc)) {
+            *pre = pre_key;
+            return key->next;
+        }
+    }
+    return NULL;
+}
+
+/**
+ Create a string value with JSON pointer token.
+ @param token [in] a JSON pointer token
+ @param len   [in] unescaped token length
+ @param esc   [in] number of escaped characters in this token
+ @param doc   [in] used for memory allocation when creating value
+ @return new string value, or NULL if memory allocation failed
+ */
+static_inline yyjson_mut_val *ptr_new_key(const char *token,
+                                          usize len, usize esc,
+                                          yyjson_mut_doc *doc) {
+    const char *src = token;
+    if (likely(!esc)) {
+        return yyjson_mut_strncpy(doc, src, len);
+    } else {
+        const char *end = src + len + esc;
+        char *dst = unsafe_yyjson_mut_str_alc(doc, len + esc);
+        char *str = dst;
+        if (unlikely(!dst)) return NULL;
+        for (; src < end; src++, dst++) {
+            if (*src != '~') *dst = *src;
+            else *dst = (*++src == '0' ? '~' : '/');
+        }
+        *dst = '\0';
+        return yyjson_mut_strn(doc, str, len);
+    }
+}
+
+/* macros for yyjson_ptr */
+#define return_err(_ret, _code, _pos, _msg) do { \
+    if (err) { \
+        err->code = YYJSON_PTR_ERR_##_code; \
+        err->msg = _msg; \
+        err->pos = (usize)(_pos); \
+    } \
+    return _ret; \
+} while (false)
+
+#define return_err_resolve(_ret, _pos) \
+    return_err(_ret, RESOLVE, _pos, "JSON pointer cannot be resolved")
+#define return_err_syntax(_ret, _pos) \
+    return_err(_ret, SYNTAX, _pos, "invalid escaped character")
+#define return_err_alloc(_ret) \
+    return_err(_ret, MEMORY_ALLOCATION, 0, "failed to create value")
+
+yyjson_val *unsafe_yyjson_ptr_getx(yyjson_val *val,
+                                   const char *ptr, size_t ptr_len,
+                                   yyjson_ptr_err *err) {
+
+    const char *hdr = ptr, *end = ptr + ptr_len, *token;
+    usize len, esc;
+    yyjson_type type;
+
+    while (true) {
+        token = ptr_next_token(&ptr, end, &len, &esc);
+        if (unlikely(!token)) return_err_syntax(NULL, ptr - hdr);
+        type = unsafe_yyjson_get_type(val);
+        if (type == YYJSON_TYPE_OBJ) {
+            val = ptr_obj_get(val, token, len, esc);
+        } else if (type == YYJSON_TYPE_ARR) {
+            val = ptr_arr_get(val, token, len, esc);
+        } else {
+            val = NULL;
+        }
+        if (!val) return_err_resolve(NULL, token - hdr);
+        if (ptr == end) return val;
+    }
+}
+
+yyjson_mut_val *unsafe_yyjson_mut_ptr_getx(yyjson_mut_val *val,
+                                           const char *ptr,
+                                           size_t ptr_len,
+                                           yyjson_ptr_ctx *ctx,
+                                           yyjson_ptr_err *err) {
+
+    const char *hdr = ptr, *end = ptr + ptr_len, *token;
+    usize len, esc;
+    yyjson_mut_val *ctn, *pre = NULL;
+    yyjson_type type;
+    bool idx_is_last = false;
+
+    while (true) {
+        token = ptr_next_token(&ptr, end, &len, &esc);
+        if (unlikely(!token)) return_err_syntax(NULL, ptr - hdr);
+        ctn = val;
+        type = unsafe_yyjson_get_type(val);
+        if (type == YYJSON_TYPE_OBJ) {
+            val = ptr_mut_obj_get(val, token, len, esc, &pre);
+        } else if (type == YYJSON_TYPE_ARR) {
+            val = ptr_mut_arr_get(val, token, len, esc, &pre, &idx_is_last);
+        } else {
+            val = NULL;
+        }
+        if (ctx && (ptr == end)) {
+            if (type == YYJSON_TYPE_OBJ ||
+                (type == YYJSON_TYPE_ARR && (val || idx_is_last))) {
+                ctx->ctn = ctn;
+                ctx->pre = pre;
+            }
+        }
+        if (!val) return_err_resolve(NULL, token - hdr);
+        if (ptr == end) return val;
+    }
+}
+
+bool unsafe_yyjson_mut_ptr_putx(yyjson_mut_val *val,
+                                const char *ptr, size_t ptr_len,
+                                yyjson_mut_val *new_val,
+                                yyjson_mut_doc *doc,
+                                bool create_parent, bool insert_new,
+                                yyjson_ptr_ctx *ctx,
+                                yyjson_ptr_err *err) {
+
+    const char *hdr = ptr, *end = ptr + ptr_len, *token;
+    usize token_len, esc, ctn_len;
+    yyjson_mut_val *ctn, *key, *pre = NULL;
+    yyjson_mut_val *sep_ctn = NULL, *sep_key = NULL, *sep_val = NULL;
+    yyjson_type ctn_type;
+    bool idx_is_last = false;
+
+    /* skip exist parent nodes */
+    while (true) {
+        token = ptr_next_token(&ptr, end, &token_len, &esc);
+        if (unlikely(!token)) return_err_syntax(false, ptr - hdr);
+        ctn = val;
+        ctn_type = unsafe_yyjson_get_type(ctn);
+        if (ctn_type == YYJSON_TYPE_OBJ) {
+            val = ptr_mut_obj_get(ctn, token, token_len, esc, &pre);
+        } else if (ctn_type == YYJSON_TYPE_ARR) {
+            val = ptr_mut_arr_get(ctn, token, token_len, esc, &pre,
+                                  &idx_is_last);
+        } else return_err_resolve(false, token - hdr);
+        if (!val) break;
+        if (ptr == end) break; /* is last token */
+    }
+
+    /* create parent nodes if not exist */
+    if (unlikely(ptr != end)) { /* not last token */
+        if (!create_parent) return_err_resolve(false, token - hdr);
+
+        /* add value at last index if container is array */
+        if (ctn_type == YYJSON_TYPE_ARR) {
+            if (!idx_is_last || !insert_new) {
+                return_err_resolve(false, token - hdr);
+            }
+            val = yyjson_mut_obj(doc);
+            if (!val) return_err_alloc(false);
+
+            /* delay attaching until all operations are completed */
+            sep_ctn = ctn;
+            sep_key = NULL;
+            sep_val = val;
+
+            /* move to next token */
+            ctn = val;
+            val = NULL;
+            ctn_type = YYJSON_TYPE_OBJ;
+            token = ptr_next_token(&ptr, end, &token_len, &esc);
+            if (unlikely(!token)) return_err_resolve(false, token - hdr);
+        }
+
+        /* container is object, create parent nodes */
+        while (ptr != end) { /* not last token */
+            key = ptr_new_key(token, token_len, esc, doc);
+            if (!key) return_err_alloc(false);
+            val = yyjson_mut_obj(doc);
+            if (!val) return_err_alloc(false);
+
+            /* delay attaching until all operations are completed */
+            if (!sep_ctn) {
+                sep_ctn = ctn;
+                sep_key = key;
+                sep_val = val;
+            } else {
+                yyjson_mut_obj_add(ctn, key, val);
+            }
+
+            /* move to next token */
+            ctn = val;
+            val = NULL;
+            token = ptr_next_token(&ptr, end, &token_len, &esc);
+            if (unlikely(!token)) return_err_syntax(false, ptr - hdr);
+        }
+    }
+
+    /* JSON pointer is resolved, insert or replace target value */
+    ctn_len = unsafe_yyjson_get_len(ctn);
+    if (ctn_type == YYJSON_TYPE_OBJ) {
+        if (ctx) ctx->ctn = ctn;
+        if (!val || insert_new) {
+            /* insert new key-value pair */
+            key = ptr_new_key(token, token_len, esc, doc);
+            if (unlikely(!key)) return_err_alloc(false);
+            if (ctx) ctx->pre = ctn_len ? (yyjson_mut_val *)ctn->uni.ptr : key;
+            unsafe_yyjson_mut_obj_add(ctn, key, new_val, ctn_len);
+        } else {
+            /* replace exist value */
+            key = pre->next->next;
+            if (ctx) ctx->pre = pre;
+            if (ctx) ctx->old = val;
+            yyjson_mut_obj_put(ctn, key, new_val);
+        }
+    } else {
+        /* array */
+        if (ctx && (val || idx_is_last)) ctx->ctn = ctn;
+        if (insert_new) {
+            /* append new value */
+            if (val) {
+                pre->next = new_val;
+                new_val->next = val;
+                if (ctx) ctx->pre = pre;
+                unsafe_yyjson_set_len(ctn, ctn_len + 1);
+            } else if (idx_is_last) {
+                if (ctx) ctx->pre = ctn_len ?
+                    (yyjson_mut_val *)ctn->uni.ptr : new_val;
+                yyjson_mut_arr_append(ctn, new_val);
+            } else {
+                return_err_resolve(false, token - hdr);
+            }
+        } else {
+            /* replace exist value */
+            if (!val) return_err_resolve(false, token - hdr);
+            if (ctn_len > 1) {
+                new_val->next = val->next;
+                pre->next = new_val;
+                if (ctn->uni.ptr == val) ctn->uni.ptr = new_val;
+            } else {
+                new_val->next = new_val;
+                ctn->uni.ptr = new_val;
+                pre = new_val;
+            }
+            if (ctx) ctx->pre = pre;
+            if (ctx) ctx->old = val;
+        }
+    }
+
+    /* all operations are completed, attach the new components to the target */
+    if (unlikely(sep_ctn)) {
+        if (sep_key) yyjson_mut_obj_add(sep_ctn, sep_key, sep_val);
+        else yyjson_mut_arr_append(sep_ctn, sep_val);
+    }
+    return true;
+}
+
+yyjson_mut_val *unsafe_yyjson_mut_ptr_replacex(
+    yyjson_mut_val *val, const char *ptr, size_t len, yyjson_mut_val *new_val,
+    yyjson_ptr_ctx *ctx, yyjson_ptr_err *err) {
+
+    yyjson_mut_val *cur_val;
+    yyjson_ptr_ctx cur_ctx;
+    memset(&cur_ctx, 0, sizeof(cur_ctx));
+    if (!ctx) ctx = &cur_ctx;
+    cur_val = unsafe_yyjson_mut_ptr_getx(val, ptr, len, ctx, err);
+    if (!cur_val) return NULL;
+
+    if (yyjson_mut_is_obj(ctx->ctn)) {
+        yyjson_mut_val *key = ctx->pre->next->next;
+        yyjson_mut_obj_put(ctx->ctn, key, new_val);
+    } else {
+        yyjson_ptr_ctx_replace(ctx, new_val);
+    }
+    ctx->old = cur_val;
+    return cur_val;
+}
+
+yyjson_mut_val *unsafe_yyjson_mut_ptr_removex(yyjson_mut_val *val,
+                                              const char *ptr,
+                                              size_t len,
+                                              yyjson_ptr_ctx *ctx,
+                                              yyjson_ptr_err *err) {
+    yyjson_mut_val *cur_val;
+    yyjson_ptr_ctx cur_ctx;
+    memset(&cur_ctx, 0, sizeof(cur_ctx));
+    if (!ctx) ctx = &cur_ctx;
+    cur_val = unsafe_yyjson_mut_ptr_getx(val, ptr, len, ctx, err);
+    if (cur_val) {
+        if (yyjson_mut_is_obj(ctx->ctn)) {
+            yyjson_mut_val *key = ctx->pre->next->next;
+            yyjson_mut_obj_put(ctx->ctn, key, NULL);
+        } else {
+            yyjson_ptr_ctx_remove(ctx);
+        }
+        ctx->pre = NULL;
+        ctx->old = cur_val;
+    }
+    return cur_val;
+}
+
+/* macros for yyjson_ptr */
+#undef return_err
+#undef return_err_resolve
+#undef return_err_syntax
+#undef return_err_alloc
+
+
 
 /*==============================================================================
- * JSON Merge-Patch
+ * JSON Patch API (RFC 6902)
  *============================================================================*/
 
-yyjson_api yyjson_mut_val *yyjson_merge_patch(yyjson_mut_doc *doc, yyjson_val *orig, yyjson_val *patch) {
-	usize idx, max;
-	yyjson_val *key, *orig_val, *patch_val, local_orig;
-	yyjson_mut_val *builder, *mut_key, *mut_val, *merged_val;
+/* JSON Patch operation */
+typedef enum patch_op {
+    PATCH_OP_ADD,       /* path, value */
+    PATCH_OP_REMOVE,    /* path */
+    PATCH_OP_REPLACE,   /* path, value */
+    PATCH_OP_MOVE,      /* from, path */
+    PATCH_OP_COPY,      /* from, path */
+    PATCH_OP_TEST,      /* path, value */
+    PATCH_OP_NONE       /* invalid */
+} patch_op;
 
-	if (unlikely(!yyjson_is_obj(patch))) {
-		return yyjson_val_mut_copy(doc, patch);
-	}
-
-	builder = yyjson_mut_obj(doc);
-	if (unlikely(!builder))
-		return NULL;
-
-	if (!yyjson_is_obj(orig)) {
-		orig = &local_orig;
-		orig->tag = builder->tag;
-		orig->uni = builder->uni;
-	}
-
-	/* Merge items modified by the patch. */
-	yyjson_obj_foreach(patch, idx, max, key, patch_val) {
-		/* null indicates the field is removed. */
-		if (unsafe_yyjson_is_null(patch_val)) {
-			continue;
-		}
-		mut_key = yyjson_val_mut_copy(doc, key);
-		orig_val = yyjson_obj_getn(orig, unsafe_yyjson_get_str(key), unsafe_yyjson_get_len(key));
-		merged_val = yyjson_merge_patch(doc, orig_val, patch_val);
-		if (!yyjson_mut_obj_add(builder, mut_key, merged_val))
-			return NULL;
-	}
-
-	/* Exit early, if orig is not contributing to the final result. */
-	if (orig == &local_orig) {
-		return builder;
-	}
-
-	/* Copy over any items that weren't modified by the patch. */
-	yyjson_obj_foreach(orig, idx, max, key, orig_val) {
-		patch_val = yyjson_obj_getn(patch, unsafe_yyjson_get_str(key), unsafe_yyjson_get_len(key));
-		if (!patch_val) {
-			mut_key = yyjson_val_mut_copy(doc, key);
-			mut_val = yyjson_val_mut_copy(doc, orig_val);
-			if (!yyjson_mut_obj_add(builder, mut_key, mut_val))
-				return NULL;
-		}
-	}
-
-	return builder;
+static patch_op patch_op_get(yyjson_val *op) {
+    const char *str = op->uni.str;
+    switch (unsafe_yyjson_get_len(op)) {
+        case 3:
+            if (!memcmp(str, "add", 3)) return PATCH_OP_ADD;
+            return PATCH_OP_NONE;
+        case 4:
+            if (!memcmp(str, "move", 4)) return PATCH_OP_MOVE;
+            if (!memcmp(str, "copy", 4)) return PATCH_OP_COPY;
+            if (!memcmp(str, "test", 4)) return PATCH_OP_TEST;
+            return PATCH_OP_NONE;
+        case 6:
+            if (!memcmp(str, "remove", 6)) return PATCH_OP_REMOVE;
+            return PATCH_OP_NONE;
+        case 7:
+            if (!memcmp(str, "replace", 7)) return PATCH_OP_REPLACE;
+            return PATCH_OP_NONE;
+        default:
+            return PATCH_OP_NONE;
+    }
 }
 
-yyjson_api yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc, yyjson_mut_val *orig, yyjson_mut_val *patch) {
-	usize idx, max;
-	yyjson_mut_val *key, *orig_val, *patch_val, local_orig;
-	yyjson_mut_val *builder, *mut_key, *mut_val, *merged_val;
+/* macros for yyjson_patch */
+#define return_err(_code, _msg) do { \
+    if (err->ptr.code == YYJSON_PTR_ERR_MEMORY_ALLOCATION) { \
+        err->code = YYJSON_PATCH_ERROR_MEMORY_ALLOCATION; \
+        err->msg = _msg; \
+        memset(&err->ptr, 0, sizeof(yyjson_ptr_err)); \
+    } else { \
+        err->code = YYJSON_PATCH_ERROR_##_code; \
+        err->msg = _msg; \
+        err->idx = iter.idx ? iter.idx - 1 : 0; \
+    } \
+    return NULL; \
+} while (false)
 
-	if (unlikely(!yyjson_mut_is_obj(patch))) {
-		return yyjson_mut_val_mut_copy(doc, patch);
-	}
+#define return_err_copy() \
+    return_err(MEMORY_ALLOCATION, "failed to copy value")
+#define return_err_key(_key) \
+    return_err(MISSING_KEY, "missing key " _key)
+#define return_err_val(_key) \
+    return_err(INVALID_MEMBER, "invalid member " _key)
 
-	builder = yyjson_mut_obj(doc);
-	if (unlikely(!builder))
-		return NULL;
+#define ptr_get(_ptr) yyjson_mut_ptr_getx( \
+    root, _ptr->uni.str, _ptr##_len, NULL, &err->ptr)
+#define ptr_add(_ptr, _val) yyjson_mut_ptr_addx( \
+    root, _ptr->uni.str, _ptr##_len, _val, doc, false, NULL, &err->ptr)
+#define ptr_remove(_ptr) yyjson_mut_ptr_removex( \
+    root, _ptr->uni.str, _ptr##_len, NULL, &err->ptr)
+#define ptr_replace(_ptr, _val)yyjson_mut_ptr_replacex( \
+    root, _ptr->uni.str, _ptr##_len, _val, NULL, &err->ptr)
 
-	if (!yyjson_mut_is_obj(orig)) {
-		orig = &local_orig;
-		orig->tag = builder->tag;
-		orig->uni = builder->uni;
-	}
+yyjson_mut_val *yyjson_patch(yyjson_mut_doc *doc,
+                             yyjson_val *orig,
+                             yyjson_val *patch,
+                             yyjson_patch_err *err) {
 
-	/* Merge items modified by the patch. */
-	yyjson_mut_obj_foreach(patch, idx, max, key, patch_val) {
-		/* null indicates the field is removed. */
-		if (unsafe_yyjson_is_null(patch_val)) {
-			continue;
-		}
-		mut_key = yyjson_mut_val_mut_copy(doc, key);
-		orig_val = yyjson_mut_obj_getn(orig, unsafe_yyjson_get_str(key), unsafe_yyjson_get_len(key));
-		merged_val = yyjson_mut_merge_patch(doc, orig_val, patch_val);
-		if (!yyjson_mut_obj_add(builder, mut_key, merged_val))
-			return NULL;
-	}
+    yyjson_mut_val *root;
+    yyjson_val *obj;
+    yyjson_arr_iter iter;
+    yyjson_patch_err err_tmp;
+    if (!err) err = &err_tmp;
+    memset(err, 0, sizeof(*err));
+    memset(&iter, 0, sizeof(iter));
 
-	/* Exit early, if orig is not contributing to the final result. */
-	if (orig == &local_orig) {
-		return builder;
-	}
+    if (unlikely(!doc || !orig || !patch)) {
+        return_err(INVALID_PARAMETER, "input parameter is NULL");
+    }
+    if (unlikely(!yyjson_is_arr(patch))) {
+        return_err(INVALID_PARAMETER, "input patch is not array");
+    }
+    root = yyjson_val_mut_copy(doc, orig);
+    if (unlikely(!root)) return_err_copy();
 
-	/* Copy over any items that weren't modified by the patch. */
-	yyjson_mut_obj_foreach(orig, idx, max, key, orig_val) {
-		patch_val = yyjson_mut_obj_getn(patch, unsafe_yyjson_get_str(key), unsafe_yyjson_get_len(key));
-		if (!patch_val) {
-			mut_key = yyjson_mut_val_mut_copy(doc, key);
-			mut_val = yyjson_mut_val_mut_copy(doc, orig_val);
-			if (!yyjson_mut_obj_add(builder, mut_key, mut_val))
-				return NULL;
-		}
-	}
+    /* iterate through the patch array */
+    yyjson_arr_iter_init(patch, &iter);
+    while ((obj = yyjson_arr_iter_next(&iter))) {
+        patch_op op_enum;
+        yyjson_val *op, *path, *from = NULL, *value;
+        yyjson_mut_val *val = NULL, *test;
+        usize path_len, from_len = 0;
+        if (unlikely(!unsafe_yyjson_is_obj(obj))) {
+            return_err(INVALID_OPERATION, "JSON patch operation is not object");
+        }
 
-	return builder;
+        /* get required member: op */
+        op = yyjson_obj_get(obj, "op");
+        if (unlikely(!op)) return_err_key("`op`");
+        if (unlikely(!yyjson_is_str(op))) return_err_val("`op`");
+        op_enum = patch_op_get(op);
+
+        /* get required member: path */
+        path = yyjson_obj_get(obj, "path");
+        if (unlikely(!path)) return_err_key("`path`");
+        if (unlikely(!yyjson_is_str(path))) return_err_val("`path`");
+        path_len = unsafe_yyjson_get_len(path);
+
+        /* get required member: value, from */
+        switch ((int)op_enum) {
+            case PATCH_OP_ADD: case PATCH_OP_REPLACE: case PATCH_OP_TEST:
+                value = yyjson_obj_get(obj, "value");
+                if (unlikely(!value)) return_err_key("`value`");
+                val = yyjson_val_mut_copy(doc, value);
+                if (unlikely(!val)) return_err_copy();
+                break;
+            case PATCH_OP_MOVE: case PATCH_OP_COPY:
+                from = yyjson_obj_get(obj, "from");
+                if (unlikely(!from)) return_err_key("`from`");
+                if (unlikely(!yyjson_is_str(from))) return_err_val("`from`");
+                from_len = unsafe_yyjson_get_len(from);
+                break;
+            default:
+                break;
+        }
+
+        /* perform an operation */
+        switch ((int)op_enum) {
+            case PATCH_OP_ADD: /* add(path, val) */
+                if (unlikely(path_len == 0)) { root = val; break; }
+                if (unlikely(!ptr_add(path, val))) {
+                    return_err(POINTER, "failed to add `path`");
+                }
+                break;
+            case PATCH_OP_REMOVE: /* remove(path) */
+                if (unlikely(!ptr_remove(path))) {
+                    return_err(POINTER, "failed to remove `path`");
+                }
+                break;
+            case PATCH_OP_REPLACE: /* replace(path, val) */
+                if (unlikely(path_len == 0)) { root = val; break; }
+                if (unlikely(!ptr_replace(path, val))) {
+                    return_err(POINTER, "failed to replace `path`");
+                }
+                break;
+            case PATCH_OP_MOVE: /* val = remove(from), add(path, val) */
+                if (unlikely(from_len == 0 && path_len == 0)) break;
+                val = ptr_remove(from);
+                if (unlikely(!val)) {
+                    return_err(POINTER, "failed to remove `from`");
+                }
+                if (unlikely(path_len == 0)) { root = val; break; }
+                if (unlikely(!ptr_add(path, val))) {
+                    return_err(POINTER, "failed to add `path`");
+                }
+                break;
+            case PATCH_OP_COPY: /* val = get(from).copy, add(path, val) */
+                val = ptr_get(from);
+                if (unlikely(!val)) {
+                    return_err(POINTER, "failed to get `from`");
+                }
+                if (unlikely(path_len == 0)) { root = val; break; }
+                val = yyjson_mut_val_mut_copy(doc, val);
+                if (unlikely(!val)) return_err_copy();
+                if (unlikely(!ptr_add(path, val))) {
+                    return_err(POINTER, "failed to add `path`");
+                }
+                break;
+            case PATCH_OP_TEST: /* test = get(path), test.eq(val) */
+                test = ptr_get(path);
+                if (unlikely(!test)) {
+                    return_err(POINTER, "failed to get `path`");
+                }
+                if (unlikely(!yyjson_mut_equals(val, test))) {
+                    return_err(EQUAL, "failed to test equal");
+                }
+                break;
+            default:
+                return_err(INVALID_MEMBER, "unsupported `op`");
+        }
+    }
+    return root;
 }
+
+yyjson_mut_val *yyjson_mut_patch(yyjson_mut_doc *doc,
+                                 yyjson_mut_val *orig,
+                                 yyjson_mut_val *patch,
+                                 yyjson_patch_err *err) {
+    yyjson_mut_val *root, *obj;
+    yyjson_mut_arr_iter iter;
+    yyjson_patch_err err_tmp;
+    if (!err) err = &err_tmp;
+    memset(err, 0, sizeof(*err));
+    memset(&iter, 0, sizeof(iter));
+
+    if (unlikely(!doc || !orig || !patch)) {
+        return_err(INVALID_PARAMETER, "input parameter is NULL");
+    }
+    if (unlikely(!yyjson_mut_is_arr(patch))) {
+        return_err(INVALID_PARAMETER, "input patch is not array");
+    }
+    root = yyjson_mut_val_mut_copy(doc, orig);
+    if (unlikely(!root)) return_err_copy();
+
+    /* iterate through the patch array */
+    yyjson_mut_arr_iter_init(patch, &iter);
+    while ((obj = yyjson_mut_arr_iter_next(&iter))) {
+        patch_op op_enum;
+        yyjson_mut_val *op, *path, *from = NULL, *value;
+        yyjson_mut_val *val = NULL, *test;
+        usize path_len, from_len = 0;
+        if (!unsafe_yyjson_is_obj(obj)) {
+            return_err(INVALID_OPERATION, "JSON patch operation is not object");
+        }
+
+        /* get required member: op */
+        op = yyjson_mut_obj_get(obj, "op");
+        if (unlikely(!op)) return_err_key("`op`");
+        if (unlikely(!yyjson_mut_is_str(op))) return_err_val("`op`");
+        op_enum = patch_op_get((yyjson_val *)(void *)op);
+
+        /* get required member: path */
+        path = yyjson_mut_obj_get(obj, "path");
+        if (unlikely(!path)) return_err_key("`path`");
+        if (unlikely(!yyjson_mut_is_str(path))) return_err_val("`path`");
+        path_len = unsafe_yyjson_get_len(path);
+
+        /* get required member: value, from */
+        switch ((int)op_enum) {
+            case PATCH_OP_ADD: case PATCH_OP_REPLACE: case PATCH_OP_TEST:
+                value = yyjson_mut_obj_get(obj, "value");
+                if (unlikely(!value)) return_err_key("`value`");
+                val = yyjson_mut_val_mut_copy(doc, value);
+                if (unlikely(!val)) return_err_copy();
+                break;
+            case PATCH_OP_MOVE: case PATCH_OP_COPY:
+                from = yyjson_mut_obj_get(obj, "from");
+                if (unlikely(!from)) return_err_key("`from`");
+                if (unlikely(!yyjson_mut_is_str(from))) {
+                    return_err_val("`from`");
+                }
+                from_len = unsafe_yyjson_get_len(from);
+                break;
+            default:
+                break;
+        }
+
+        /* perform an operation */
+        switch ((int)op_enum) {
+            case PATCH_OP_ADD: /* add(path, val) */
+                if (unlikely(path_len == 0)) { root = val; break; }
+                if (unlikely(!ptr_add(path, val))) {
+                    return_err(POINTER, "failed to add `path`");
+                }
+                break;
+            case PATCH_OP_REMOVE: /* remove(path) */
+                if (unlikely(!ptr_remove(path))) {
+                    return_err(POINTER, "failed to remove `path`");
+                }
+                break;
+            case PATCH_OP_REPLACE: /* replace(path, val) */
+                if (unlikely(path_len == 0)) { root = val; break; }
+                if (unlikely(!ptr_replace(path, val))) {
+                    return_err(POINTER, "failed to replace `path`");
+                }
+                break;
+            case PATCH_OP_MOVE: /* val = remove(from), add(path, val) */
+                if (unlikely(from_len == 0 && path_len == 0)) break;
+                val = ptr_remove(from);
+                if (unlikely(!val)) {
+                    return_err(POINTER, "failed to remove `from`");
+                }
+                if (unlikely(path_len == 0)) { root = val; break; }
+                if (unlikely(!ptr_add(path, val))) {
+                    return_err(POINTER, "failed to add `path`");
+                }
+                break;
+            case PATCH_OP_COPY: /* val = get(from).copy, add(path, val) */
+                val = ptr_get(from);
+                if (unlikely(!val)) {
+                    return_err(POINTER, "failed to get `from`");
+                }
+                if (unlikely(path_len == 0)) { root = val; break; }
+                val = yyjson_mut_val_mut_copy(doc, val);
+                if (unlikely(!val)) return_err_copy();
+                if (unlikely(!ptr_add(path, val))) {
+                    return_err(POINTER, "failed to add `path`");
+                }
+                break;
+            case PATCH_OP_TEST: /* test = get(path), test.eq(val) */
+                test = ptr_get(path);
+                if (unlikely(!test)) {
+                    return_err(POINTER, "failed to get `path`");
+                }
+                if (unlikely(!yyjson_mut_equals(val, test))) {
+                    return_err(EQUAL, "failed to test equal");
+                }
+                break;
+            default:
+                return_err(INVALID_MEMBER, "unsupported `op`");
+        }
+    }
+    return root;
+}
+
+/* macros for yyjson_patch */
+#undef return_err
+#undef return_err_copy
+#undef return_err_key
+#undef return_err_val
+#undef ptr_get
+#undef ptr_add
+#undef ptr_remove
+#undef ptr_replace
+
+
+
+/*==============================================================================
+ * JSON Merge-Patch API (RFC 7386)
+ *============================================================================*/
+
+yyjson_mut_val *yyjson_merge_patch(yyjson_mut_doc *doc,
+                                   yyjson_val *orig,
+                                   yyjson_val *patch) {
+    usize idx, max;
+    yyjson_val *key, *orig_val, *patch_val, local_orig;
+    yyjson_mut_val *builder, *mut_key, *mut_val, *merged_val;
+
+    if (unlikely(!yyjson_is_obj(patch))) {
+        return yyjson_val_mut_copy(doc, patch);
+    }
+
+    builder = yyjson_mut_obj(doc);
+    if (unlikely(!builder)) return NULL;
+
+    memset(&local_orig, 0, sizeof(local_orig));
+    if (!yyjson_is_obj(orig)) {
+        orig = &local_orig;
+        orig->tag = builder->tag;
+        orig->uni = builder->uni;
+    }
+
+    /* If orig is contributing, copy any items not modified by the patch */
+    if (orig != &local_orig) {
+        yyjson_obj_foreach(orig, idx, max, key, orig_val) {
+            patch_val = yyjson_obj_getn(patch,
+                                        unsafe_yyjson_get_str(key),
+                                        unsafe_yyjson_get_len(key));
+            if (!patch_val) {
+                mut_key = yyjson_val_mut_copy(doc, key);
+                mut_val = yyjson_val_mut_copy(doc, orig_val);
+                if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
+            }
+        }
+    }
+
+    /* Merge items modified by the patch. */
+    yyjson_obj_foreach(patch, idx, max, key, patch_val) {
+        /* null indicates the field is removed. */
+        if (unsafe_yyjson_is_null(patch_val)) {
+            continue;
+        }
+        mut_key = yyjson_val_mut_copy(doc, key);
+        orig_val = yyjson_obj_getn(orig,
+                                   unsafe_yyjson_get_str(key),
+                                   unsafe_yyjson_get_len(key));
+        merged_val = yyjson_merge_patch(doc, orig_val, patch_val);
+        if (!yyjson_mut_obj_add(builder, mut_key, merged_val)) return NULL;
+    }
+
+    return builder;
+}
+
+yyjson_mut_val *yyjson_mut_merge_patch(yyjson_mut_doc *doc,
+                                       yyjson_mut_val *orig,
+                                       yyjson_mut_val *patch) {
+    usize idx, max;
+    yyjson_mut_val *key, *orig_val, *patch_val, local_orig;
+    yyjson_mut_val *builder, *mut_key, *mut_val, *merged_val;
+
+    if (unlikely(!yyjson_mut_is_obj(patch))) {
+        return yyjson_mut_val_mut_copy(doc, patch);
+    }
+
+    builder = yyjson_mut_obj(doc);
+    if (unlikely(!builder)) return NULL;
+
+    memset(&local_orig, 0, sizeof(local_orig));
+    if (!yyjson_mut_is_obj(orig)) {
+        orig = &local_orig;
+        orig->tag = builder->tag;
+        orig->uni = builder->uni;
+    }
+
+    /* If orig is contributing, copy any items not modified by the patch */
+    if (orig != &local_orig) {
+        yyjson_mut_obj_foreach(orig, idx, max, key, orig_val) {
+            patch_val = yyjson_mut_obj_getn(patch,
+                                            unsafe_yyjson_get_str(key),
+                                            unsafe_yyjson_get_len(key));
+            if (!patch_val) {
+                mut_key = yyjson_mut_val_mut_copy(doc, key);
+                mut_val = yyjson_mut_val_mut_copy(doc, orig_val);
+                if (!yyjson_mut_obj_add(builder, mut_key, mut_val)) return NULL;
+            }
+        }
+    }
+
+    /* Merge items modified by the patch. */
+    yyjson_mut_obj_foreach(patch, idx, max, key, patch_val) {
+        /* null indicates the field is removed. */
+        if (unsafe_yyjson_is_null(patch_val)) {
+            continue;
+        }
+        mut_key = yyjson_mut_val_mut_copy(doc, key);
+        orig_val = yyjson_mut_obj_getn(orig,
+                                       unsafe_yyjson_get_str(key),
+                                       unsafe_yyjson_get_len(key));
+        merged_val = yyjson_mut_merge_patch(doc, orig_val, patch_val);
+        if (!yyjson_mut_obj_add(builder, mut_key, merged_val)) return NULL;
+    }
+
+    return builder;
+}
+
+#endif /* YYJSON_DISABLE_UTILS */
+
+
 
 /*==============================================================================
  * Power10 Lookup Table
  * These data are used by the floating-point number reader and writer.
  *============================================================================*/
 
-#if (!YYJSON_DISABLE_READER || !YYJSON_DISABLE_WRITER) && (!YYJSON_DISABLE_FAST_FP_CONV)
+#if (!YYJSON_DISABLE_READER || !YYJSON_DISABLE_WRITER) && \
+    (!YYJSON_DISABLE_FAST_FP_CONV)
 
 /** Minimum decimal exponent in pow10_sig_table. */
 #define POW10_SIG_TABLE_MIN_EXP -343
@@ -2570,23 +3467,23 @@ static const u64 pow10_sig_table[] = {
  @param lo    The lower 64 bits after `hi`.
  */
 static_inline void pow10_table_get_sig(i32 exp10, u64 *hi, u64 *lo) {
-	i32 idx = exp10 - (POW10_SIG_TABLE_MIN_EXP);
-	*hi = pow10_sig_table[idx * 2];
-	*lo = pow10_sig_table[idx * 2 + 1];
+    i32 idx = exp10 - (POW10_SIG_TABLE_MIN_EXP);
+    *hi = pow10_sig_table[idx * 2];
+    *lo = pow10_sig_table[idx * 2 + 1];
 }
 
 /**
  Get the exponent (base 2) for highest 64 bits significand in pow10_sig_table.
  */
 static_inline void pow10_table_get_exp(i32 exp10, i32 *exp2) {
-	/* e2 = floor(log2(pow(10, e))) - 64 + 1 */
-	/*    = floor(e * log2(10) - 63)         */
-	*exp2 = (exp10 * 217706 - 4128768) >> 16;
+    /* e2 = floor(log2(pow(10, e))) - 64 + 1 */
+    /*    = floor(e * log2(10) - 63)         */
+    *exp2 = (exp10 * 217706 - 4128768) >> 16;
 }
 
 #endif
 
-#if !YYJSON_DISABLE_READER
+
 
 /*==============================================================================
  * JSON Character Matcher
@@ -2596,77 +3493,107 @@ static_inline void pow10_table_get_exp(i32 exp10, i32 *exp2) {
 typedef u8 char_type;
 
 /** Whitespace character: ' ', '\\t', '\\n', '\\r'. */
-static const char_type CHAR_TYPE_SPACE = 1 << 0;
+static const char_type CHAR_TYPE_SPACE      = 1 << 0;
 
 /** Number character: '-', [0-9]. */
-static const char_type CHAR_TYPE_NUMBER = 1 << 1;
+static const char_type CHAR_TYPE_NUMBER     = 1 << 1;
 
 /** JSON Escaped character: '"', '\', [0x00-0x1F]. */
-static const char_type CHAR_TYPE_ESC_ASCII = 1 << 2;
+static const char_type CHAR_TYPE_ESC_ASCII  = 1 << 2;
 
 /** Non-ASCII character: [0x80-0xFF]. */
-static const char_type CHAR_TYPE_NON_ASCII = 1 << 3;
+static const char_type CHAR_TYPE_NON_ASCII  = 1 << 3;
 
 /** JSON container character: '{', '['. */
-static const char_type CHAR_TYPE_CONTAINER = 1 << 4;
+static const char_type CHAR_TYPE_CONTAINER  = 1 << 4;
 
 /** Comment character: '/'. */
-static const char_type CHAR_TYPE_COMMENT = 1 << 5;
+static const char_type CHAR_TYPE_COMMENT    = 1 << 5;
 
-/** Line end character '\\n', '\\r', '\0'. */
-static const char_type CHAR_TYPE_LINE_END = 1 << 6;
+/** Line end character: '\\n', '\\r', '\0'. */
+static const char_type CHAR_TYPE_LINE_END   = 1 << 6;
+
+/** Hexadecimal numeric character: [0-9a-fA-F]. */
+static const char_type CHAR_TYPE_HEX        = 1 << 7;
 
 /** Character type table (generate with misc/make_tables.c) */
 static const char_type char_table[256] = {
-    0x44, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x05, 0x45, 0x04, 0x04, 0x45, 0x04, 0x04, 0x04, 0x04, 0x04,
-    0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x20, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
-    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x04, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x08, 0x08, 0x08, 0x08, 0x08,
-    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
-    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
-    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
-    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
-    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
-    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
-    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08};
+    0x44, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+    0x04, 0x05, 0x45, 0x04, 0x04, 0x45, 0x04, 0x04,
+    0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+    0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+    0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x20,
+    0x82, 0x82, 0x82, 0x82, 0x82, 0x82, 0x82, 0x82,
+    0x82, 0x82, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x10, 0x04, 0x00, 0x00, 0x00,
+    0x00, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08
+};
 
 /** Match a character with specified type. */
 static_inline bool char_is_type(u8 c, char_type type) {
-	return (char_table[c] & type) != 0;
+    return (char_table[c] & type) != 0;
 }
 
 /** Match a whitespace: ' ', '\\t', '\\n', '\\r'. */
 static_inline bool char_is_space(u8 c) {
-	return char_is_type(c, (char_type)CHAR_TYPE_SPACE);
+    return char_is_type(c, (char_type)CHAR_TYPE_SPACE);
 }
 
 /** Match a whitespace or comment: ' ', '\\t', '\\n', '\\r', '/'. */
 static_inline bool char_is_space_or_comment(u8 c) {
-	return char_is_type(c, (char_type)(CHAR_TYPE_SPACE | CHAR_TYPE_COMMENT));
+    return char_is_type(c, (char_type)(CHAR_TYPE_SPACE | CHAR_TYPE_COMMENT));
 }
 
 /** Match a JSON number: '-', [0-9]. */
 static_inline bool char_is_number(u8 c) {
-	return char_is_type(c, (char_type)CHAR_TYPE_NUMBER);
+    return char_is_type(c, (char_type)CHAR_TYPE_NUMBER);
 }
 
 /** Match a JSON container: '{', '['. */
 static_inline bool char_is_container(u8 c) {
-	return char_is_type(c, (char_type)CHAR_TYPE_CONTAINER);
+    return char_is_type(c, (char_type)CHAR_TYPE_CONTAINER);
 }
 
-/** Match a stop character in ASCII string: '"', '\', [0x00-0x1F], [0x80-0xFF]*/
+/** Match a stop character in ASCII string: '"', '\', [0x00-0x1F,0x80-0xFF]. */
 static_inline bool char_is_ascii_stop(u8 c) {
-	return char_is_type(c, (char_type)(CHAR_TYPE_ESC_ASCII | CHAR_TYPE_NON_ASCII));
+    return char_is_type(c, (char_type)(CHAR_TYPE_ESC_ASCII |
+                                       CHAR_TYPE_NON_ASCII));
 }
 
-/** Match a line end character: '\\n', '\\r', '\0'*/
+/** Match a line end character: '\\n', '\\r', '\0'. */
 static_inline bool char_is_line_end(u8 c) {
-	return char_is_type(c, (char_type)CHAR_TYPE_LINE_END);
+    return char_is_type(c, (char_type)CHAR_TYPE_LINE_END);
 }
+
+/** Match a hexadecimal numeric character: [0-9a-fA-F]. */
+static_inline bool char_is_hex(u8 c) {
+    return char_is_type(c, (char_type)CHAR_TYPE_HEX);
+}
+
+
 
 /*==============================================================================
  * Digit Character Matcher
@@ -2676,67 +3603,82 @@ static_inline bool char_is_line_end(u8 c) {
 typedef u8 digi_type;
 
 /** Digit: '0'. */
-static const digi_type DIGI_TYPE_ZERO = 1 << 0;
+static const digi_type DIGI_TYPE_ZERO       = 1 << 0;
 
 /** Digit: [1-9]. */
-static const digi_type DIGI_TYPE_NONZERO = 1 << 1;
+static const digi_type DIGI_TYPE_NONZERO    = 1 << 1;
 
 /** Plus sign (positive): '+'. */
-static const digi_type DIGI_TYPE_POS = 1 << 2;
+static const digi_type DIGI_TYPE_POS        = 1 << 2;
 
 /** Minus sign (negative): '-'. */
-static const digi_type DIGI_TYPE_NEG = 1 << 3;
+static const digi_type DIGI_TYPE_NEG        = 1 << 3;
 
 /** Decimal point: '.' */
-static const digi_type DIGI_TYPE_DOT = 1 << 4;
+static const digi_type DIGI_TYPE_DOT        = 1 << 4;
 
 /** Exponent sign: 'e, 'E'. */
-static const digi_type DIGI_TYPE_EXP = 1 << 5;
+static const digi_type DIGI_TYPE_EXP        = 1 << 5;
 
 /** Digit type table (generate with misc/make_tables.c) */
 static const digi_type digi_table[256] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x08, 0x10, 0x00, 0x01, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
-    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x04, 0x00, 0x08, 0x10, 0x00,
+    0x01, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+    0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
 
 /** Match a character with specified type. */
 static_inline bool digi_is_type(u8 d, digi_type type) {
-	return (digi_table[d] & type) != 0;
+    return (digi_table[d] & type) != 0;
 }
 
 /** Match a sign: '+', '-' */
 static_inline bool digi_is_sign(u8 d) {
-	return digi_is_type(d, (digi_type)(DIGI_TYPE_POS | DIGI_TYPE_NEG));
+    return digi_is_type(d, (digi_type)(DIGI_TYPE_POS | DIGI_TYPE_NEG));
 }
 
 /** Match a none zero digit: [1-9] */
 static_inline bool digi_is_nonzero(u8 d) {
-	return digi_is_type(d, (digi_type)DIGI_TYPE_NONZERO);
+    return digi_is_type(d, (digi_type)DIGI_TYPE_NONZERO);
 }
 
 /** Match a digit: [0-9] */
 static_inline bool digi_is_digit(u8 d) {
-	return digi_is_type(d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO));
+    return digi_is_type(d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO));
 }
 
 /** Match an exponent sign: 'e', 'E'. */
 static_inline bool digi_is_exp(u8 d) {
-	return digi_is_type(d, (digi_type)DIGI_TYPE_EXP);
+    return digi_is_type(d, (digi_type)DIGI_TYPE_EXP);
 }
 
 /** Match a floating point indicator: '.', 'e', 'E'. */
 static_inline bool digi_is_fp(u8 d) {
-	return digi_is_type(d, (digi_type)(DIGI_TYPE_DOT | DIGI_TYPE_EXP));
+    return digi_is_type(d, (digi_type)(DIGI_TYPE_DOT | DIGI_TYPE_EXP));
 }
 
 /** Match a digit or floating point indicator: [0-9], '.', 'e', 'E'. */
 static_inline bool digi_is_digit_or_fp(u8 d) {
-	return digi_is_type(d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO | DIGI_TYPE_DOT | DIGI_TYPE_EXP));
+    return digi_is_type(d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO |
+                                       DIGI_TYPE_DOT | DIGI_TYPE_EXP));
 }
+
+
+
+#if !YYJSON_DISABLE_READER
 
 /*==============================================================================
  * Hex Character Reader
@@ -2750,20 +3692,39 @@ static_inline bool digi_is_digit_or_fp(u8 d) {
  (generate with misc/make_tables.c)
  */
 static const u8 hex_conv_table[256] = {
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-    0x09, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0};
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0
+};
 
 /**
  Scans an escaped character sequence as a UTF-16 code unit (branchless).
@@ -2772,16 +3733,18 @@ static const u8 hex_conv_table[256] = {
  This requires the string has 4-byte zero padding.
  */
 static_inline bool read_hex_u16(const u8 *cur, u16 *val) {
-	u16 c0, c1, c2, c3, t0, t1;
-	c0 = hex_conv_table[cur[0]];
-	c1 = hex_conv_table[cur[1]];
-	c2 = hex_conv_table[cur[2]];
-	c3 = hex_conv_table[cur[3]];
-	t0 = (u16)((c0 << 8) | c2);
-	t1 = (u16)((c1 << 8) | c3);
-	*val = (u16)((t0 << 4) | t1);
-	return ((t0 | t1) & (u16)0xF0F0) == 0;
+    u16 c0, c1, c2, c3, t0, t1;
+    c0 = hex_conv_table[cur[0]];
+    c1 = hex_conv_table[cur[1]];
+    c2 = hex_conv_table[cur[2]];
+    c3 = hex_conv_table[cur[3]];
+    t0 = (u16)((c0 << 8) | c2);
+    t1 = (u16)((c1 << 8) | c3);
+    *val = (u16)((t0 << 4) | t1);
+    return ((t0 | t1) & (u16)0xF0F0) == 0;
 }
+
+
 
 /*==============================================================================
  * JSON Reader Utils
@@ -2790,181 +3753,174 @@ static_inline bool read_hex_u16(const u8 *cur, u16 *val) {
 
 /** Read 'true' literal, '*cur' should be 't'. */
 static_inline bool read_true(u8 **ptr, yyjson_val *val) {
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	if (likely(byte_match_4(cur, "true"))) {
-		val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
-		*end = cur + 4;
-		return true;
-	}
-	return false;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    if (likely(byte_match_4(cur, "true"))) {
+        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE;
+        *end = cur + 4;
+        return true;
+    }
+    return false;
 }
 
 /** Read 'false' literal, '*cur' should be 'f'. */
 static_inline bool read_false(u8 **ptr, yyjson_val *val) {
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	if (likely(byte_match_4(cur + 1, "alse"))) {
-		val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
-		*end = cur + 5;
-		return true;
-	}
-	return false;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    if (likely(byte_match_4(cur + 1, "alse"))) {
+        val->tag = YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE;
+        *end = cur + 5;
+        return true;
+    }
+    return false;
 }
 
 /** Read 'null' literal, '*cur' should be 'n'. */
 static_inline bool read_null(u8 **ptr, yyjson_val *val) {
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	if (likely(byte_match_4(cur, "null"))) {
-		val->tag = YYJSON_TYPE_NULL;
-		*end = cur + 4;
-		return true;
-	}
-	return false;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    if (likely(byte_match_4(cur, "null"))) {
+        val->tag = YYJSON_TYPE_NULL;
+        *end = cur + 4;
+        return true;
+    }
+    return false;
 }
 
 /** Read 'Inf' or 'Infinity' literal (ignoring case). */
 static_inline bool read_inf(bool sign, u8 **ptr, u8 **pre, yyjson_val *val) {
-#if !YYJSON_DISABLE_NON_STANDARD
-	u8 *hdr = *ptr - sign;
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	if ((cur[0] == 'I' || cur[0] == 'i') && (cur[1] == 'N' || cur[1] == 'n') && (cur[2] == 'F' || cur[2] == 'f')) {
-		if ((cur[3] == 'I' || cur[3] == 'i') && (cur[4] == 'N' || cur[4] == 'n') && (cur[5] == 'I' || cur[5] == 'i') &&
-		    (cur[6] == 'T' || cur[6] == 't') && (cur[7] == 'Y' || cur[7] == 'y')) {
-			cur += 8;
-		} else {
-			cur += 3;
-		}
-		*end = cur;
-		if (pre) {
-			/* add null-terminator for previous raw string */
-			if (*pre)
-				**pre = '\0';
-			*pre = cur;
-			val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
-			val->uni.str = (const char *)hdr;
-		} else {
-			val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-			val->uni.u64 = f64_raw_get_inf(sign);
-		}
-		return true;
-	}
-#endif
-	return false;
+    u8 *hdr = *ptr - sign;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    if ((cur[0] == 'I' || cur[0] == 'i') &&
+        (cur[1] == 'N' || cur[1] == 'n') &&
+        (cur[2] == 'F' || cur[2] == 'f')) {
+        if ((cur[3] == 'I' || cur[3] == 'i') &&
+            (cur[4] == 'N' || cur[4] == 'n') &&
+            (cur[5] == 'I' || cur[5] == 'i') &&
+            (cur[6] == 'T' || cur[6] == 't') &&
+            (cur[7] == 'Y' || cur[7] == 'y')) {
+            cur += 8;
+        } else {
+            cur += 3;
+        }
+        *end = cur;
+        if (pre) {
+            /* add null-terminator for previous raw string */
+            if (*pre) **pre = '\0';
+            *pre = cur;
+            val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+            val->uni.str = (const char *)hdr;
+        } else {
+            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+            val->uni.u64 = f64_raw_get_inf(sign);
+        }
+        return true;
+    }
+    return false;
 }
 
 /** Read 'NaN' literal (ignoring case). */
 static_inline bool read_nan(bool sign, u8 **ptr, u8 **pre, yyjson_val *val) {
-#if !YYJSON_DISABLE_NON_STANDARD
-	u8 *hdr = *ptr - sign;
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	if ((cur[0] == 'N' || cur[0] == 'n') && (cur[1] == 'A' || cur[1] == 'a') && (cur[2] == 'N' || cur[2] == 'n')) {
-		cur += 3;
-		*end = cur;
-		if (pre) {
-			/* add null-terminator for previous raw string */
-			if (*pre)
-				**pre = '\0';
-			*pre = cur;
-			val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
-			val->uni.str = (const char *)hdr;
-		} else {
-			val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-			val->uni.u64 = f64_raw_get_nan(sign);
-		}
-		return true;
-	}
-#endif
-	return false;
+    u8 *hdr = *ptr - sign;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    if ((cur[0] == 'N' || cur[0] == 'n') &&
+        (cur[1] == 'A' || cur[1] == 'a') &&
+        (cur[2] == 'N' || cur[2] == 'n')) {
+        cur += 3;
+        *end = cur;
+        if (pre) {
+            /* add null-terminator for previous raw string */
+            if (*pre) **pre = '\0';
+            *pre = cur;
+            val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;
+            val->uni.str = (const char *)hdr;
+        } else {
+            val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+            val->uni.u64 = f64_raw_get_nan(sign);
+        }
+        return true;
+    }
+    return false;
 }
 
 /** Read 'Inf', 'Infinity' or 'NaN' literal (ignoring case). */
-static_inline bool read_inf_or_nan(bool sign, u8 **ptr, u8 **pre, yyjson_val *val) {
-	if (read_inf(sign, ptr, pre, val))
-		return true;
-	if (read_nan(sign, ptr, pre, val))
-		return true;
-	return false;
+static_inline bool read_inf_or_nan(bool sign, u8 **ptr, u8 **pre,
+                                   yyjson_val *val) {
+    if (read_inf(sign, ptr, pre, val)) return true;
+    if (read_nan(sign, ptr, pre, val)) return true;
+    return false;
 }
 
 /** Read a JSON number as raw string. */
-static_noinline bool read_number_raw(u8 **ptr, u8 **pre, bool ext, yyjson_val *val, const char **msg) {
+static_noinline bool read_number_raw(u8 **ptr,
+                                     u8 **pre,
+                                     yyjson_read_flag flg,
+                                     yyjson_val *val,
+                                     const char **msg) {
 
-#define return_err(_pos, _msg)                                                                                         \
-	do {                                                                                                               \
-		*msg = _msg;                                                                                                   \
-		*end = _pos;                                                                                                   \
-		return false;                                                                                                  \
-	} while (false)
+#define return_err(_pos, _msg) do { \
+    *msg = _msg; \
+    *end = _pos; \
+    return false; \
+} while (false)
 
-#define return_raw()                                                                                                   \
-	do {                                                                                                               \
-		val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW;                                             \
-		val->uni.str = (const char *)hdr;                                                                              \
-		*pre = cur;                                                                                                    \
-		*end = cur;                                                                                                    \
-		return true;                                                                                                   \
-	} while (false)
+#define return_raw() do { \
+    val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW; \
+    val->uni.str = (const char *)hdr; \
+    *pre = cur; *end = cur; return true; \
+} while (false)
 
-	u8 *hdr = *ptr;
-	u8 *cur = *ptr;
-	u8 **end = ptr;
+    u8 *hdr = *ptr;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
 
-	/* add null-terminator for previous raw string */
-	if (*pre)
-		**pre = '\0';
+    /* add null-terminator for previous raw string */
+    if (*pre) **pre = '\0';
 
-	/* skip sign */
-	cur += (*cur == '-');
+    /* skip sign */
+    cur += (*cur == '-');
 
-	/* read first digit, check leading zero */
-	if (unlikely(!digi_is_digit(*cur))) {
-		if (unlikely(ext)) {
-			if (read_inf_or_nan(*hdr == '-', &cur, pre, val))
-				return_raw();
-		}
-		return_err(cur, "no digit after minus sign");
-	}
+    /* read first digit, check leading zero */
+    if (unlikely(!digi_is_digit(*cur))) {
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (read_inf_or_nan(*hdr == '-', &cur, pre, val)) return_raw();
+        }
+        return_err(cur, "no digit after minus sign");
+    }
 
-	/* read integral part */
-	if (*cur == '0') {
-		cur++;
-		if (unlikely(digi_is_digit(*cur))) {
-			return_err(cur - 1, "number with leading zero is not allowed");
-		}
-		if (!digi_is_fp(*cur))
-			return_raw();
-	} else {
-		while (digi_is_digit(*cur))
-			cur++;
-		if (!digi_is_fp(*cur))
-			return_raw();
-	}
+    /* read integral part */
+    if (*cur == '0') {
+        cur++;
+        if (unlikely(digi_is_digit(*cur))) {
+            return_err(cur - 1, "number with leading zero is not allowed");
+        }
+        if (!digi_is_fp(*cur)) return_raw();
+    } else {
+        while (digi_is_digit(*cur)) cur++;
+        if (!digi_is_fp(*cur)) return_raw();
+    }
 
-	/* read fraction part */
-	if (*cur == '.') {
-		cur++;
-		if (!digi_is_digit(*cur++)) {
-			return_err(cur, "no digit after decimal point");
-		}
-		while (digi_is_digit(*cur))
-			cur++;
-	}
+    /* read fraction part */
+    if (*cur == '.') {
+        cur++;
+        if (!digi_is_digit(*cur++)) {
+            return_err(cur, "no digit after decimal point");
+        }
+        while (digi_is_digit(*cur)) cur++;
+    }
 
-	/* read exponent part */
-	if (digi_is_exp(*cur)) {
-		cur += 1 + digi_is_sign(cur[1]);
-		if (!digi_is_digit(*cur++)) {
-			return_err(cur, "no digit after exponent sign");
-		}
-		while (digi_is_digit(*cur))
-			cur++;
-	}
+    /* read exponent part */
+    if (digi_is_exp(*cur)) {
+        cur += 1 + digi_is_sign(cur[1]);
+        if (!digi_is_digit(*cur++)) {
+            return_err(cur, "no digit after exponent sign");
+        }
+        while (digi_is_digit(*cur)) cur++;
+    }
 
-	return_raw();
+    return_raw();
 
 #undef return_err
 #undef return_raw
@@ -2979,43 +3935,152 @@ static_noinline bool read_number_raw(u8 **ptr, u8 **pre, bool ext, yyjson_val *v
        of this comment block.
  */
 static_noinline bool skip_spaces_and_comments(u8 **ptr) {
-	u8 *hdr = *ptr;
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	while (true) {
-		if (byte_match_2(cur, "/*")) {
-			hdr = cur;
-			cur += 2;
-			while (true) {
-				if (byte_match_2(cur, "*/")) {
-					cur += 2;
-					break;
-				}
-				if (*cur == 0) {
-					*end = hdr;
-					return false;
-				}
-				cur++;
-			}
-			continue;
-		}
-		if (byte_match_2(cur, "//")) {
-			cur += 2;
-			while (!char_is_line_end(*cur))
-				cur++;
-			continue;
-		}
-		if (char_is_space(*cur)) {
-			cur += 1;
-			while (char_is_space(*cur))
-				cur++;
-			continue;
-		}
-		break;
-	}
-	*end = cur;
-	return hdr != cur;
+    u8 *hdr = *ptr;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    while (true) {
+        if (byte_match_2(cur, "/*")) {
+            hdr = cur;
+            cur += 2;
+            while (true) {
+                if (byte_match_2(cur, "*/")) {
+                    cur += 2;
+                    break;
+                }
+                if (*cur == 0) {
+                    *end = hdr;
+                    return false;
+                }
+                cur++;
+            }
+            continue;
+        }
+        if (byte_match_2(cur, "//")) {
+            cur += 2;
+            while (!char_is_line_end(*cur)) cur++;
+            continue;
+        }
+        if (char_is_space(*cur)) {
+            cur += 1;
+            while (char_is_space(*cur)) cur++;
+            continue;
+        }
+        break;
+    }
+    *end = cur;
+    return hdr != cur;
 }
+
+/**
+ Check truncated string.
+ Returns true if `cur` match `str` but is truncated.
+ */
+static_inline bool is_truncated_str(u8 *cur, u8 *end,
+                                    const char *str,
+                                    bool case_sensitive) {
+    usize len = strlen(str);
+    if (cur + len <= end || end <= cur) return false;
+    if (case_sensitive) {
+        return memcmp(cur, str, (usize)(end - cur)) == 0;
+    }
+    for (; cur < end; cur++, str++) {
+        if ((*cur != (u8)*str) && (*cur != (u8)*str - 'a' + 'A')) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ Check truncated JSON on parsing errors.
+ Returns true if the input is valid but truncated.
+ */
+static_noinline bool is_truncated_end(u8 *hdr, u8 *cur, u8 *end,
+                                      yyjson_read_code code,
+                                      yyjson_read_flag flg) {
+    if (cur >= end) return true;
+    if (code == YYJSON_READ_ERROR_LITERAL) {
+        if (is_truncated_str(cur, end, "true", true) ||
+            is_truncated_str(cur, end, "false", true) ||
+            is_truncated_str(cur, end, "null", true)) {
+            return true;
+        }
+    }
+    if (code == YYJSON_READ_ERROR_UNEXPECTED_CHARACTER ||
+        code == YYJSON_READ_ERROR_INVALID_NUMBER ||
+        code == YYJSON_READ_ERROR_LITERAL) {
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (*cur == '-') cur++;
+            if (is_truncated_str(cur, end, "infinity", false) ||
+                is_truncated_str(cur, end, "nan", false)) {
+                return true;
+            }
+        }
+    }
+    if (code == YYJSON_READ_ERROR_UNEXPECTED_CONTENT) {
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (hdr + 3 <= cur &&
+                is_truncated_str(cur - 3, end, "infinity", false)) {
+                return true; /* e.g. infin would be read as inf + in */
+            }
+        }
+    }
+    if (code == YYJSON_READ_ERROR_INVALID_STRING) {
+        usize len = (usize)(end - cur);
+
+        /* unicode escape sequence */
+        if (*cur == '\\') {
+            if (len == 1) return true;
+            if (len <= 5) {
+                if (*++cur != 'u') return false;
+                for (++cur; cur < end; cur++) {
+                    if (!char_is_hex(*cur)) return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        /* 2 to 4 bytes UTF-8, see `read_string()` for details. */
+        if (*cur & 0x80) {
+            u8 c0 = cur[0], c1 = cur[1], c2 = cur[2];
+            if (len == 1) {
+                /* 2 bytes UTF-8, truncated */
+                if ((c0 & 0xE0) == 0xC0 && (c0 & 0x1E) != 0x00) return true;
+                /* 3 bytes UTF-8, truncated */
+                if ((c0 & 0xF0) == 0xE0) return true;
+                /* 4 bytes UTF-8, truncated */
+                if ((c0 & 0xF8) == 0xF0 && (c0 & 0x07) <= 0x04) return true;
+            }
+            if (len == 2) {
+                /* 3 bytes UTF-8, truncated */
+                if ((c0 & 0xF0) == 0xE0 &&
+                    (c1 & 0xC0) == 0x80) {
+                    u8 pat = (u8)(((c0 & 0x0F) << 1) | ((c1 & 0x20) >> 5));
+                    return 0x01 <= pat && pat != 0x1B;
+                }
+                /* 4 bytes UTF-8, truncated */
+                if ((c0 & 0xF8) == 0xF0 &&
+                    (c1 & 0xC0) == 0x80) {
+                    u8 pat = (u8)(((c0 & 0x07) << 2) | ((c1 & 0x30) >> 4));
+                    return 0x01 <= pat && pat <= 0x10;
+                }
+            }
+            if (len == 3) {
+                /* 4 bytes UTF-8, truncated */
+                if ((c0 & 0xF8) == 0xF0 &&
+                    (c1 & 0xC0) == 0x80 &&
+                    (c2 & 0xC0) == 0x80) {
+                    u8 pat = (u8)(((c0 & 0x07) << 2) | ((c1 & 0x30) >> 4));
+                    return 0x01 <= pat && pat <= 0x10;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+
 
 #if YYJSON_HAS_IEEE_754 && !YYJSON_DISABLE_FAST_FP_CONV /* FP_READER */
 
@@ -3032,19 +4097,25 @@ static_noinline bool skip_spaces_and_comments(u8 **ptr) {
 
 /** Table: [ 10^0, ..., 10^19 ] (generate with misc/make_tables.c) */
 static const u64 u64_pow10_table[U64_POW10_MAX_EXP + 1] = {
-    U64(0x00000000, 0x00000001), U64(0x00000000, 0x0000000A), U64(0x00000000, 0x00000064), U64(0x00000000, 0x000003E8),
-    U64(0x00000000, 0x00002710), U64(0x00000000, 0x000186A0), U64(0x00000000, 0x000F4240), U64(0x00000000, 0x00989680),
-    U64(0x00000000, 0x05F5E100), U64(0x00000000, 0x3B9ACA00), U64(0x00000002, 0x540BE400), U64(0x00000017, 0x4876E800),
-    U64(0x000000E8, 0xD4A51000), U64(0x00000918, 0x4E72A000), U64(0x00005AF3, 0x107A4000), U64(0x00038D7E, 0xA4C68000),
-    U64(0x002386F2, 0x6FC10000), U64(0x01634578, 0x5D8A0000), U64(0x0DE0B6B3, 0xA7640000), U64(0x8AC72304, 0x89E80000)};
+    U64(0x00000000, 0x00000001), U64(0x00000000, 0x0000000A),
+    U64(0x00000000, 0x00000064), U64(0x00000000, 0x000003E8),
+    U64(0x00000000, 0x00002710), U64(0x00000000, 0x000186A0),
+    U64(0x00000000, 0x000F4240), U64(0x00000000, 0x00989680),
+    U64(0x00000000, 0x05F5E100), U64(0x00000000, 0x3B9ACA00),
+    U64(0x00000002, 0x540BE400), U64(0x00000017, 0x4876E800),
+    U64(0x000000E8, 0xD4A51000), U64(0x00000918, 0x4E72A000),
+    U64(0x00005AF3, 0x107A4000), U64(0x00038D7E, 0xA4C68000),
+    U64(0x002386F2, 0x6FC10000), U64(0x01634578, 0x5D8A0000),
+    U64(0x0DE0B6B3, 0xA7640000), U64(0x8AC72304, 0x89E80000)
+};
 
 /** Maximum numbers of chunks used by a bigint (58 is enough here). */
 #define BIGINT_MAX_CHUNKS 64
 
 /** Unsigned arbitrarily large integer */
 typedef struct bigint {
-	u32 used;                    /* used chunks count, should not be 0 */
-	u64 bits[BIGINT_MAX_CHUNKS]; /* chunks */
+    u32 used; /* used chunks count, should not be 0 */
+    u64 bits[BIGINT_MAX_CHUNKS]; /* chunks */
 } bigint;
 
 /**
@@ -3053,20 +4124,19 @@ typedef struct bigint {
  @param val An unsigned integer (can be 0).
  */
 static_inline void bigint_add_u64(bigint *big, u64 val) {
-	u32 idx, max;
-	u64 num = big->bits[0];
-	u64 add = num + val;
-	big->bits[0] = add;
-	if (likely((add >= num) || (add >= val)))
-		return;
-	for ((void)(idx = 1), max = big->used; idx < max; idx++) {
-		if (likely(big->bits[idx] != U64_MAX)) {
-			big->bits[idx] += 1;
-			return;
-		}
-		big->bits[idx] = 0;
-	}
-	big->bits[big->used++] = 1;
+    u32 idx, max;
+    u64 num = big->bits[0];
+    u64 add = num + val;
+    big->bits[0] = add;
+    if (likely((add >= num) || (add >= val))) return;
+    for ((void)(idx = 1), max = big->used; idx < max; idx++) {
+        if (likely(big->bits[idx] != U64_MAX)) {
+            big->bits[idx] += 1;
+            return;
+        }
+        big->bits[idx] = 0;
+    }
+    big->bits[big->used++] = 1;
 }
 
 /**
@@ -3075,19 +4145,17 @@ static_inline void bigint_add_u64(bigint *big, u64 val) {
  @param val An unsigned integer (cannot be 0).
  */
 static_inline void bigint_mul_u64(bigint *big, u64 val) {
-	u32 idx = 0, max = big->used;
-	u64 hi, lo, carry = 0;
-	for (; idx < max; idx++) {
-		if (big->bits[idx])
-			break;
-	}
-	for (; idx < max; idx++) {
-		u128_mul_add(big->bits[idx], val, carry, &hi, &lo);
-		big->bits[idx] = lo;
-		carry = hi;
-	}
-	if (carry)
-		big->bits[big->used++] = carry;
+    u32 idx = 0, max = big->used;
+    u64 hi, lo, carry = 0;
+    for (; idx < max; idx++) {
+        if (big->bits[idx]) break;
+    }
+    for (; idx < max; idx++) {
+        u128_mul_add(big->bits[idx], val, carry, &hi, &lo);
+        big->bits[idx] = lo;
+        carry = hi;
+    }
+    if (carry) big->bits[big->used++] = carry;
 }
 
 /**
@@ -3096,28 +4164,26 @@ static_inline void bigint_mul_u64(bigint *big, u64 val) {
  @param exp An exponent integer (can be 0).
  */
 static_inline void bigint_mul_pow2(bigint *big, u32 exp) {
-	u32 shft = exp % 64;
-	u32 move = exp / 64;
-	u32 idx = big->used;
-	if (unlikely(shft == 0)) {
-		for (; idx > 0; idx--) {
-			big->bits[idx + move - 1] = big->bits[idx - 1];
-		}
-		big->used += move;
-		while (move)
-			big->bits[--move] = 0;
-	} else {
-		big->bits[idx] = 0;
-		for (; idx > 0; idx--) {
-			u64 num = big->bits[idx] << shft;
-			num |= big->bits[idx - 1] >> (64 - shft);
-			big->bits[idx + move] = num;
-		}
-		big->bits[move] = big->bits[0] << shft;
-		big->used += move + (big->bits[big->used + move] > 0);
-		while (move)
-			big->bits[--move] = 0;
-	}
+    u32 shft = exp % 64;
+    u32 move = exp / 64;
+    u32 idx = big->used;
+    if (unlikely(shft == 0)) {
+        for (; idx > 0; idx--) {
+            big->bits[idx + move - 1] = big->bits[idx - 1];
+        }
+        big->used += move;
+        while (move) big->bits[--move] = 0;
+    } else {
+        big->bits[idx] = 0;
+        for (; idx > 0; idx--) {
+            u64 num = big->bits[idx] << shft;
+            num |= big->bits[idx - 1] >> (64 - shft);
+            big->bits[idx + move] = num;
+        }
+        big->bits[move] = big->bits[0] << shft;
+        big->used += move + (big->bits[big->used + move] > 0);
+        while (move) big->bits[--move] = 0;
+    }
 }
 
 /**
@@ -3126,12 +4192,12 @@ static_inline void bigint_mul_pow2(bigint *big, u32 exp) {
  @param exp An exponent integer (cannot be 0).
  */
 static_inline void bigint_mul_pow10(bigint *big, i32 exp) {
-	for (; exp >= U64_POW10_MAX_EXP; exp -= U64_POW10_MAX_EXP) {
-		bigint_mul_u64(big, u64_pow10_table[U64_POW10_MAX_EXP]);
-	}
-	if (exp) {
-		bigint_mul_u64(big, u64_pow10_table[exp]);
-	}
+    for (; exp >= U64_POW10_MAX_EXP; exp -= U64_POW10_MAX_EXP) {
+        bigint_mul_u64(big, u64_pow10_table[U64_POW10_MAX_EXP]);
+    }
+    if (exp) {
+        bigint_mul_u64(big, u64_pow10_table[exp]);
+    }
 }
 
 /**
@@ -3139,20 +4205,16 @@ static_inline void bigint_mul_pow10(bigint *big, i32 exp) {
  @return -1 if 'a < b', +1 if 'a > b', 0 if 'a == b'.
  */
 static_inline i32 bigint_cmp(bigint *a, bigint *b) {
-	u32 idx = a->used;
-	if (a->used < b->used)
-		return -1;
-	if (a->used > b->used)
-		return +1;
-	while (idx-- > 0) {
-		u64 av = a->bits[idx];
-		u64 bv = b->bits[idx];
-		if (av < bv)
-			return -1;
-		if (av > bv)
-			return +1;
-	}
-	return 0;
+    u32 idx = a->used;
+    if (a->used < b->used) return -1;
+    if (a->used > b->used) return +1;
+    while (idx-- > 0) {
+        u64 av = a->bits[idx];
+        u64 bv = b->bits[idx];
+        if (av < bv) return -1;
+        if (av > bv) return +1;
+    }
+    return 0;
 }
 
 /**
@@ -3161,60 +4223,63 @@ static_inline i32 bigint_cmp(bigint *a, bigint *b) {
  @param val An unsigned integer (can be 0).
  */
 static_inline void bigint_set_u64(bigint *big, u64 val) {
-	big->used = 1;
-	big->bits[0] = val;
+    big->used = 1;
+    big->bits[0] = val;
 }
 
 /** Set a bigint with floating point number string. */
-static_noinline void bigint_set_buf(bigint *big, u64 sig, i32 *exp, u8 *sig_cut, u8 *sig_end, u8 *dot_pos) {
+static_noinline void bigint_set_buf(bigint *big, u64 sig, i32 *exp,
+                                    u8 *sig_cut, u8 *sig_end, u8 *dot_pos) {
 
-	if (unlikely(!sig_cut)) {
-		/* no digit cut, set significant part only */
-		bigint_set_u64(big, sig);
-		return;
+    if (unlikely(!sig_cut)) {
+        /* no digit cut, set significant part only */
+        bigint_set_u64(big, sig);
+        return;
 
-	} else {
-		/* some digits were cut, read them from 'sig_cut' to 'sig_end' */
-		u8 *hdr = sig_cut;
-		u8 *cur = hdr;
-		u32 len = 0;
-		u64 val = 0;
-		bool dig_big_cut = false;
-		bool has_dot = (hdr < dot_pos) & (dot_pos < sig_end);
-		u32 dig_len_total = U64_SAFE_DIG + (u32)(sig_end - hdr) - has_dot;
+    } else {
+        /* some digits were cut, read them from 'sig_cut' to 'sig_end' */
+        u8 *hdr = sig_cut;
+        u8 *cur = hdr;
+        u32 len = 0;
+        u64 val = 0;
+        bool dig_big_cut = false;
+        bool has_dot = (hdr < dot_pos) & (dot_pos < sig_end);
+        u32 dig_len_total = U64_SAFE_DIG + (u32)(sig_end - hdr) - has_dot;
 
-		sig -= (*sig_cut >= '5'); /* sig was rounded before */
-		if (dig_len_total > F64_MAX_DEC_DIG) {
-			dig_big_cut = true;
-			sig_end -= dig_len_total - (F64_MAX_DEC_DIG + 1);
-			sig_end -= (dot_pos + 1 == sig_end);
-			dig_len_total = (F64_MAX_DEC_DIG + 1);
-		}
-		*exp -= (i32)dig_len_total - U64_SAFE_DIG;
+        sig -= (*sig_cut >= '5'); /* sig was rounded before */
+        if (dig_len_total > F64_MAX_DEC_DIG) {
+            dig_big_cut = true;
+            sig_end -= dig_len_total - (F64_MAX_DEC_DIG + 1);
+            sig_end -= (dot_pos + 1 == sig_end);
+            dig_len_total = (F64_MAX_DEC_DIG + 1);
+        }
+        *exp -= (i32)dig_len_total - U64_SAFE_DIG;
 
-		big->used = 1;
-		big->bits[0] = sig;
-		while (cur < sig_end) {
-			if (likely(cur != dot_pos)) {
-				val = val * 10 + (u8)(*cur++ - '0');
-				len++;
-				if (unlikely(cur == sig_end && dig_big_cut)) {
-					/* The last digit must be non-zero,    */
-					/* set it to '1' for correct rounding. */
-					val = val - (val % 10) + 1;
-				}
-				if (len == U64_SAFE_DIG || cur == sig_end) {
-					bigint_mul_pow10(big, (i32)len);
-					bigint_add_u64(big, val);
-					val = 0;
-					len = 0;
-				}
-			} else {
-				cur++;
-			}
-		}
-	}
+        big->used = 1;
+        big->bits[0] = sig;
+        while (cur < sig_end) {
+            if (likely(cur != dot_pos)) {
+                val = val * 10 + (u8)(*cur++ - '0');
+                len++;
+                if (unlikely(cur == sig_end && dig_big_cut)) {
+                    /* The last digit must be non-zero,    */
+                    /* set it to '1' for correct rounding. */
+                    val = val - (val % 10) + 1;
+                }
+                if (len == U64_SAFE_DIG || cur == sig_end) {
+                    bigint_mul_pow10(big, (i32)len);
+                    bigint_add_u64(big, val);
+                    val = 0;
+                    len = 0;
+                }
+            } else {
+                cur++;
+            }
+        }
+    }
 }
+
+
 
 /*==============================================================================
  * Diy Floating Point
@@ -3222,61 +4287,62 @@ static_noinline void bigint_set_buf(bigint *big, u64 sig, i32 *exp, u8 *sig_cut,
 
 /** "Do It Yourself Floating Point" struct. */
 typedef struct diy_fp {
-	u64 sig; /* significand */
-	i32 exp; /* exponent, base 2 */
-	i32 pad; /* padding, useless */
+    u64 sig; /* significand */
+    i32 exp; /* exponent, base 2 */
+    i32 pad; /* padding, useless */
 } diy_fp;
 
 /** Get cached rounded diy_fp with pow(10, e) The input value must in range
     [POW10_SIG_TABLE_MIN_EXP, POW10_SIG_TABLE_MAX_EXP]. */
 static_inline diy_fp diy_fp_get_cached_pow10(i32 exp10) {
-	diy_fp fp;
-	u64 sig_ext;
-	pow10_table_get_sig(exp10, &fp.sig, &sig_ext);
-	pow10_table_get_exp(exp10, &fp.exp);
-	fp.sig += (sig_ext >> 63);
-	return fp;
+    diy_fp fp;
+    u64 sig_ext;
+    pow10_table_get_sig(exp10, &fp.sig, &sig_ext);
+    pow10_table_get_exp(exp10, &fp.exp);
+    fp.sig += (sig_ext >> 63);
+    return fp;
 }
 
 /** Returns fp * fp2. */
 static_inline diy_fp diy_fp_mul(diy_fp fp, diy_fp fp2) {
-	u64 hi, lo;
-	u128_mul(fp.sig, fp2.sig, &hi, &lo);
-	fp.sig = hi + (lo >> 63);
-	fp.exp += fp2.exp + 64;
-	return fp;
+    u64 hi, lo;
+    u128_mul(fp.sig, fp2.sig, &hi, &lo);
+    fp.sig = hi + (lo >> 63);
+    fp.exp += fp2.exp + 64;
+    return fp;
 }
 
 /** Convert diy_fp to IEEE-754 raw value. */
 static_inline u64 diy_fp_to_ieee_raw(diy_fp fp) {
-	u64 sig = fp.sig;
-	i32 exp = fp.exp;
-	u32 lz_bits;
-	if (unlikely(fp.sig == 0))
-		return 0;
+    u64 sig = fp.sig;
+    i32 exp = fp.exp;
+    u32 lz_bits;
+    if (unlikely(fp.sig == 0)) return 0;
 
-	lz_bits = u64_lz_bits(sig);
-	sig <<= lz_bits;
-	sig >>= F64_BITS - F64_SIG_FULL_BITS;
-	exp -= (i32)lz_bits;
-	exp += F64_BITS - F64_SIG_FULL_BITS;
-	exp += F64_SIG_BITS;
+    lz_bits = u64_lz_bits(sig);
+    sig <<= lz_bits;
+    sig >>= F64_BITS - F64_SIG_FULL_BITS;
+    exp -= (i32)lz_bits;
+    exp += F64_BITS - F64_SIG_FULL_BITS;
+    exp += F64_SIG_BITS;
 
-	if (unlikely(exp >= F64_MAX_BIN_EXP)) {
-		/* overflow */
-		return F64_RAW_INF;
-	} else if (likely(exp >= F64_MIN_BIN_EXP - 1)) {
-		/* normal */
-		exp += F64_EXP_BIAS;
-		return ((u64)exp << F64_SIG_BITS) | (sig & F64_SIG_MASK);
-	} else if (likely(exp >= F64_MIN_BIN_EXP - F64_SIG_FULL_BITS)) {
-		/* subnormal */
-		return sig >> (F64_MIN_BIN_EXP - exp - 1);
-	} else {
-		/* underflow */
-		return 0;
-	}
+    if (unlikely(exp >= F64_MAX_BIN_EXP)) {
+        /* overflow */
+        return F64_RAW_INF;
+    } else if (likely(exp >= F64_MIN_BIN_EXP - 1)) {
+        /* normal */
+        exp += F64_EXP_BIAS;
+        return ((u64)exp << F64_SIG_BITS) | (sig & F64_SIG_MASK);
+    } else if (likely(exp >= F64_MIN_BIN_EXP - F64_SIG_FULL_BITS)) {
+        /* subnormal */
+        return sig >> (F64_MIN_BIN_EXP - exp - 1);
+    } else {
+        /* underflow */
+        return 0;
+    }
 }
+
+
 
 /*==============================================================================
  * JSON Number Reader (IEEE-754)
@@ -3286,8 +4352,10 @@ static_inline u64 diy_fp_to_ieee_raw(diy_fp fp) {
 #define F64_POW10_EXP_MAX_EXACT 22
 
 /** Cached pow10 table. */
-static const f64 f64_pow10_table[] = {1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
-                                      1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22};
+static const f64 f64_pow10_table[] = {
+    1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12,
+    1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22
+};
 
 /**
  Read a JSON number.
@@ -3298,594 +4366,610 @@ static const f64 f64_pow10_table[] = {1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  
     number is infinite, the return value is based on flag.
  3. This function (with inline attribute) may generate a lot of instructions.
  */
-static_inline bool read_number(u8 **ptr, u8 **pre, bool ext, yyjson_val *val, const char **msg) {
+static_inline bool read_number(u8 **ptr,
+                               u8 **pre,
+                               yyjson_read_flag flg,
+                               yyjson_val *val,
+                               const char **msg) {
 
-#define return_err(_pos, _msg)                                                                                         \
-	do {                                                                                                               \
-		*msg = _msg;                                                                                                   \
-		*end = _pos;                                                                                                   \
-		return false;                                                                                                  \
-	} while (false)
+#define return_err(_pos, _msg) do { \
+    *msg = _msg; \
+    *end = _pos; \
+    return false; \
+} while (false)
 
-#define return_i64(_v)                                                                                                 \
-	do {                                                                                                               \
-		val->tag = YYJSON_TYPE_NUM | (u8)((u8)sign << 3);                                                              \
-		val->uni.u64 = (u64)(sign ? (u64)(~(_v) + 1) : (u64)(_v));                                                     \
-		*end = cur;                                                                                                    \
-		return true;                                                                                                   \
-	} while (false)
+#define return_0() do { \
+    val->tag = YYJSON_TYPE_NUM | (u8)((u8)sign << 3); \
+    val->uni.u64 = 0; \
+    *end = cur; return true; \
+} while (false)
 
-#define return_f64(_v)                                                                                                 \
-	do {                                                                                                               \
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;                                                              \
-		val->uni.f64 = sign ? -(f64)(_v) : (f64)(_v);                                                                  \
-		*end = cur;                                                                                                    \
-		return true;                                                                                                   \
-	} while (false)
+#define return_i64(_v) do { \
+    val->tag = YYJSON_TYPE_NUM | (u8)((u8)sign << 3); \
+    val->uni.u64 = (u64)(sign ? (u64)(~(_v) + 1) : (u64)(_v)); \
+    *end = cur; return true; \
+} while (false)
 
-#define return_f64_raw(_v)                                                                                             \
-	do {                                                                                                               \
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;                                                              \
-		val->uni.u64 = ((u64)sign << 63) | (u64)(_v);                                                                  \
-		*end = cur;                                                                                                    \
-		return true;                                                                                                   \
-	} while (false)
+#define return_f64(_v) do { \
+    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
+    val->uni.f64 = sign ? -(f64)(_v) : (f64)(_v); \
+    *end = cur; return true; \
+} while (false)
 
-#define return_inf()                                                                                                   \
-	do {                                                                                                               \
-		if (unlikely(ext))                                                                                             \
-			return_f64_raw(F64_RAW_INF);                                                                               \
-		else                                                                                                           \
-			return_err(hdr, "number is infinity when parsed as double");                                               \
-	} while (false)
+#define return_f64_bin(_v) do { \
+    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
+    val->uni.u64 = ((u64)sign << 63) | (u64)(_v); \
+    *end = cur; return true; \
+} while (false)
 
-	u8 *sig_cut = NULL; /* significant part cutting position for long number */
-	u8 *sig_end = NULL; /* significant part ending position */
-	u8 *dot_pos = NULL; /* decimal point position */
+#define return_inf() do { \
+    if (has_read_flag(BIGNUM_AS_RAW)) return_raw(); \
+    if (has_read_flag(ALLOW_INF_AND_NAN)) return_f64_bin(F64_RAW_INF); \
+    else return_err(hdr, "number is infinity when parsed as double"); \
+} while (false)
 
-	u64 sig = 0; /* significant part of the number */
-	i32 exp = 0; /* exponent part of the number */
+#define return_raw() do { \
+    if (*pre) **pre = '\0'; /* add null-terminator for previous raw string */ \
+    val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW; \
+    val->uni.str = (const char *)hdr; \
+    *pre = cur; *end = cur; return true; \
+} while (false)
 
-	bool exp_sign;   /* temporary exponent sign from literal part */
-	i64 exp_sig = 0; /* temporary exponent number from significant part */
-	i64 exp_lit = 0; /* temporary exponent number from exponent literal part */
-	u64 num;         /* temporary number for reading */
-	u8 *tmp;         /* temporary cursor for reading */
+    u8 *sig_cut = NULL; /* significant part cutting position for long number */
+    u8 *sig_end = NULL; /* significant part ending position */
+    u8 *dot_pos = NULL; /* decimal point position */
 
-	u8 *hdr = *ptr;
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	bool sign;
+    u64 sig = 0; /* significant part of the number */
+    i32 exp = 0; /* exponent part of the number */
 
-	/* read number as raw string if has flag */
-	if (unlikely(pre)) {
-		return read_number_raw(ptr, pre, ext, val, msg);
-	}
+    bool exp_sign; /* temporary exponent sign from literal part */
+    i64 exp_sig = 0; /* temporary exponent number from significant part */
+    i64 exp_lit = 0; /* temporary exponent number from exponent literal part */
+    u64 num; /* temporary number for reading */
+    u8 *tmp; /* temporary cursor for reading */
 
-	sign = (*hdr == '-');
-	cur += sign;
+    u8 *hdr = *ptr;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    bool sign;
 
-	/* begin with a leading zero or non-digit */
-	if (unlikely(!digi_is_nonzero(*cur))) { /* 0 or non-digit char */
-		if (unlikely(*cur != '0')) {        /* non-digit char */
-			if (unlikely(ext)) {
-				if (read_inf_or_nan(sign, &cur, pre, val)) {
-					*end = cur;
-					return true;
-				}
-			}
-			return_err(cur, "no digit after minus sign");
-		}
-		/* begin with 0 */
-		if (likely(!digi_is_digit_or_fp(*++cur)))
-			return_i64(0);
-		if (likely(*cur == '.')) {
-			dot_pos = cur++;
-			if (unlikely(!digi_is_digit(*cur))) {
-				return_err(cur, "no digit after decimal point");
-			}
-			while (unlikely(*cur == '0'))
-				cur++;
-			if (likely(digi_is_digit(*cur))) {
-				/* first non-zero digit after decimal point */
-				sig = (u64)(*cur - '0'); /* read first digit */
-				cur--;
-				goto digi_frac_1; /* continue read fraction part */
-			}
-		}
-		if (unlikely(digi_is_digit(*cur))) {
-			return_err(cur - 1, "number with leading zero is not allowed");
-		}
-		if (unlikely(digi_is_exp(*cur))) { /* 0 with any exponent is still 0 */
-			cur += (usize)1 + digi_is_sign(cur[1]);
-			if (unlikely(!digi_is_digit(*cur))) {
-				return_err(cur, "no digit after exponent sign");
-			}
-			while (digi_is_digit(*++cur))
-				;
-		}
-		return_f64_raw(0);
-	}
+    /* read number as raw string if has `YYJSON_READ_NUMBER_AS_RAW` flag */
+    if (unlikely(pre && !has_read_flag(BIGNUM_AS_RAW))) {
+        return read_number_raw(ptr, pre, flg, val, msg);
+    }
 
-	/* begin with non-zero digit */
-	sig = (u64)(*cur - '0');
+    sign = (*hdr == '-');
+    cur += sign;
 
-	/*
-	 Read integral part, same as the following code.
+    /* begin with a leading zero or non-digit */
+    if (unlikely(!digi_is_nonzero(*cur))) { /* 0 or non-digit char */
+        if (unlikely(*cur != '0')) { /* non-digit char */
+            if (has_read_flag(ALLOW_INF_AND_NAN)) {
+                if (read_inf_or_nan(sign, &cur, pre, val)) {
+                    *end = cur;
+                    return true;
+                }
+            }
+            return_err(cur, "no digit after minus sign");
+        }
+        /* begin with 0 */
+        if (likely(!digi_is_digit_or_fp(*++cur))) return_0();
+        if (likely(*cur == '.')) {
+            dot_pos = cur++;
+            if (unlikely(!digi_is_digit(*cur))) {
+                return_err(cur, "no digit after decimal point");
+            }
+            while (unlikely(*cur == '0')) cur++;
+            if (likely(digi_is_digit(*cur))) {
+                /* first non-zero digit after decimal point */
+                sig = (u64)(*cur - '0'); /* read first digit */
+                cur--;
+                goto digi_frac_1; /* continue read fraction part */
+            }
+        }
+        if (unlikely(digi_is_digit(*cur))) {
+            return_err(cur - 1, "number with leading zero is not allowed");
+        }
+        if (unlikely(digi_is_exp(*cur))) { /* 0 with any exponent is still 0 */
+            cur += (usize)1 + digi_is_sign(cur[1]);
+            if (unlikely(!digi_is_digit(*cur))) {
+                return_err(cur, "no digit after exponent sign");
+            }
+            while (digi_is_digit(*++cur));
+        }
+        return_f64_bin(0);
+    }
 
-	     for (int i = 1; i <= 18; i++) {
-	        num = cur[i] - '0';
-	        if (num <= 9) sig = num + sig * 10;
-	        else goto digi_sepr_i;
-	     }
-	 */
-#define expr_intg(i)                                                                                                   \
-	if (likely((num = (u64)(cur[i] - (u8)'0')) <= 9))                                                                  \
-		sig = num + sig * 10;                                                                                          \
-	else {                                                                                                             \
-		goto digi_sepr_##i;                                                                                            \
-	}
-	repeat_in_1_18(expr_intg);
+    /* begin with non-zero digit */
+    sig = (u64)(*cur - '0');
+
+    /*
+     Read integral part, same as the following code.
+
+         for (int i = 1; i <= 18; i++) {
+            num = cur[i] - '0';
+            if (num <= 9) sig = num + sig * 10;
+            else goto digi_sepr_i;
+         }
+     */
+#define expr_intg(i) \
+    if (likely((num = (u64)(cur[i] - (u8)'0')) <= 9)) sig = num + sig * 10; \
+    else { goto digi_sepr_##i; }
+    repeat_in_1_18(expr_intg)
 #undef expr_intg
 
-	cur += 19; /* skip continuous 19 digits */
-	if (!digi_is_digit_or_fp(*cur)) {
-		/* this number is an integer consisting of 19 digits */
-		if (sign && (sig > ((u64)1 << 63))) { /* overflow */
-			return_f64(normalized_u64_to_f64(sig));
-		}
-		return_i64(sig);
-	}
-	goto digi_intg_more; /* read more digits in integral part */
 
-	/* process first non-digit character */
-#define expr_sepr(i)                                                                                                   \
-	digi_sepr_##i : if (likely(!digi_is_fp(cur[i]))) {                                                                 \
-		cur += i;                                                                                                      \
-		return_i64(sig);                                                                                               \
-	}                                                                                                                  \
-	dot_pos = cur + i;                                                                                                 \
-	if (likely(cur[i] == '.'))                                                                                         \
-		goto digi_frac_##i;                                                                                            \
-	cur += i;                                                                                                          \
-	sig_end = cur;                                                                                                     \
-	goto digi_exp_more;
-	repeat_in_1_18(expr_sepr)
+    cur += 19; /* skip continuous 19 digits */
+    if (!digi_is_digit_or_fp(*cur)) {
+        /* this number is an integer consisting of 19 digits */
+        if (sign && (sig > ((u64)1 << 63))) { /* overflow */
+            if (has_read_flag(BIGNUM_AS_RAW)) return_raw();
+            return_f64(normalized_u64_to_f64(sig));
+        }
+        return_i64(sig);
+    }
+    goto digi_intg_more; /* read more digits in integral part */
+
+
+    /* process first non-digit character */
+#define expr_sepr(i) \
+    digi_sepr_##i: \
+    if (likely(!digi_is_fp(cur[i]))) { cur += i; return_i64(sig); } \
+    dot_pos = cur + i; \
+    if (likely(cur[i] == '.')) goto digi_frac_##i; \
+    cur += i; sig_end = cur; goto digi_exp_more;
+    repeat_in_1_18(expr_sepr)
 #undef expr_sepr
 
-	/* read fraction part */
-#define expr_frac(i)                                                                                                   \
-	digi_frac_##i : if (likely((num = (u64)(cur[i + 1] - (u8)'0')) <= 9)) sig = num + sig * 10;                        \
-	else {                                                                                                             \
-		goto digi_stop_##i;                                                                                            \
-	}
-	    repeat_in_1_18(expr_frac)
+
+    /* read fraction part */
+#define expr_frac(i) \
+    digi_frac_##i: \
+    if (likely((num = (u64)(cur[i + 1] - (u8)'0')) <= 9)) \
+        sig = num + sig * 10; \
+    else { goto digi_stop_##i; }
+    repeat_in_1_18(expr_frac)
 #undef expr_frac
 
-	        cur += 20; /* skip 19 digits and 1 decimal point */
-	if (!digi_is_digit(*cur))
-		goto digi_frac_end; /* fraction part end */
-	goto digi_frac_more;    /* read more digits in fraction part */
+    cur += 20; /* skip 19 digits and 1 decimal point */
+    if (!digi_is_digit(*cur)) goto digi_frac_end; /* fraction part end */
+    goto digi_frac_more; /* read more digits in fraction part */
 
-	/* significant part end */
-#define expr_stop(i)                                                                                                   \
-	digi_stop_##i : cur += i + 1;                                                                                      \
-	goto digi_frac_end;
-	repeat_in_1_18(expr_stop)
+
+    /* significant part end */
+#define expr_stop(i) \
+    digi_stop_##i: \
+    cur += i + 1; \
+    goto digi_frac_end;
+    repeat_in_1_18(expr_stop)
 #undef expr_stop
 
-	    /* read more digits in integral part */
-	    digi_intg_more : if (digi_is_digit(*cur)) {
-		if (!digi_is_digit_or_fp(cur[1])) {
-			/* this number is an integer consisting of 20 digits */
-			num = (u64)(*cur - '0');
-			if ((sig < (U64_MAX / 10)) || (sig == (U64_MAX / 10) && num <= (U64_MAX % 10))) {
-				sig = num + sig * 10;
-				cur++;
-				/* convert to double if overflow */
-				if (sign)
-					return_f64(normalized_u64_to_f64(sig));
-				return_i64(sig);
-			}
-		}
-	}
 
-	if (digi_is_exp(*cur)) {
-		dot_pos = cur;
-		goto digi_exp_more;
-	}
+    /* read more digits in integral part */
+digi_intg_more:
+    if (digi_is_digit(*cur)) {
+        if (!digi_is_digit_or_fp(cur[1])) {
+            /* this number is an integer consisting of 20 digits */
+            num = (u64)(*cur - '0');
+            if ((sig < (U64_MAX / 10)) ||
+                (sig == (U64_MAX / 10) && num <= (U64_MAX % 10))) {
+                sig = num + sig * 10;
+                cur++;
+                /* convert to double if overflow */
+                if (sign) {
+                    if (has_read_flag(BIGNUM_AS_RAW)) return_raw();
+                    return_f64(normalized_u64_to_f64(sig));
+                }
+                return_i64(sig);
+            }
+        }
+    }
 
-	if (*cur == '.') {
-		dot_pos = cur++;
-		if (!digi_is_digit(*cur)) {
-			return_err(cur, "no digit after decimal point");
-		}
-	}
+    if (digi_is_exp(*cur)) {
+        dot_pos = cur;
+        goto digi_exp_more;
+    }
 
-	/* read more digits in fraction part */
+    if (*cur == '.') {
+        dot_pos = cur++;
+        if (!digi_is_digit(*cur)) {
+            return_err(cur, "no digit after decimal point");
+        }
+    }
+
+
+    /* read more digits in fraction part */
 digi_frac_more:
-	sig_cut = cur;        /* too large to fit in u64, excess digits need to be cut */
-	sig += (*cur >= '5'); /* round */
-	while (digi_is_digit(*++cur))
-		;
-	if (!dot_pos) {
-		dot_pos = cur;
-		if (*cur == '.') {
-			if (!digi_is_digit(*++cur)) {
-				return_err(cur, "no digit after decimal point");
-			}
-			while (digi_is_digit(*cur))
-				cur++;
-		}
-	}
-	exp_sig = (i64)(dot_pos - sig_cut);
-	exp_sig += (dot_pos < sig_cut);
+    sig_cut = cur; /* too large to fit in u64, excess digits need to be cut */
+    sig += (*cur >= '5'); /* round */
+    while (digi_is_digit(*++cur));
+    if (!dot_pos) {
+        if (!digi_is_fp(*cur) && has_read_flag(BIGNUM_AS_RAW)) {
+            return_raw(); /* it's a large integer */
+        }
+        dot_pos = cur;
+        if (*cur == '.') {
+            if (!digi_is_digit(*++cur)) {
+                return_err(cur, "no digit after decimal point");
+            }
+            while (digi_is_digit(*cur)) cur++;
+        }
+    }
+    exp_sig = (i64)(dot_pos - sig_cut);
+    exp_sig += (dot_pos < sig_cut);
 
-	/* ignore trailing zeros */
-	tmp = cur - 1;
-	while (*tmp == '0' || *tmp == '.')
-		tmp--;
-	if (tmp < sig_cut) {
-		sig_cut = NULL;
-	} else {
-		sig_end = cur;
-	}
+    /* ignore trailing zeros */
+    tmp = cur - 1;
+    while (*tmp == '0' || *tmp == '.') tmp--;
+    if (tmp < sig_cut) {
+        sig_cut = NULL;
+    } else {
+        sig_end = cur;
+    }
 
-	if (digi_is_exp(*cur))
-		goto digi_exp_more;
-	goto digi_exp_finish;
+    if (digi_is_exp(*cur)) goto digi_exp_more;
+    goto digi_exp_finish;
 
-	/* fraction part end */
+
+    /* fraction part end */
 digi_frac_end:
-	if (unlikely(dot_pos + 1 == cur)) {
-		return_err(cur, "no digit after decimal point");
-	}
-	sig_end = cur;
-	exp_sig = -(i64)((u64)(cur - dot_pos) - 1);
-	if (likely(!digi_is_exp(*cur))) {
-		if (unlikely(exp_sig < F64_MIN_DEC_EXP - 19)) {
-			return_f64_raw(0); /* underflow */
-		}
-		exp = (i32)exp_sig;
-		goto digi_finish;
-	} else {
-		goto digi_exp_more;
-	}
+    if (unlikely(dot_pos + 1 == cur)) {
+        return_err(cur, "no digit after decimal point");
+    }
+    sig_end = cur;
+    exp_sig = -(i64)((u64)(cur - dot_pos) - 1);
+    if (likely(!digi_is_exp(*cur))) {
+        if (unlikely(exp_sig < F64_MIN_DEC_EXP - 19)) {
+            return_f64_bin(0); /* underflow */
+        }
+        exp = (i32)exp_sig;
+        goto digi_finish;
+    } else {
+        goto digi_exp_more;
+    }
 
-	/* read exponent part */
+
+    /* read exponent part */
 digi_exp_more:
-	exp_sign = (*++cur == '-');
-	cur += digi_is_sign(*cur);
-	if (unlikely(!digi_is_digit(*cur))) {
-		return_err(cur, "no digit after exponent sign");
-	}
-	while (*cur == '0')
-		cur++;
+    exp_sign = (*++cur == '-');
+    cur += digi_is_sign(*cur);
+    if (unlikely(!digi_is_digit(*cur))) {
+        return_err(cur, "no digit after exponent sign");
+    }
+    while (*cur == '0') cur++;
 
-	/* read exponent literal */
-	tmp = cur;
-	while (digi_is_digit(*cur)) {
-		exp_lit = (i64)((u8)(*cur++ - '0') + (u64)exp_lit * 10);
-	}
-	if (unlikely(cur - tmp >= U64_SAFE_DIG)) {
-		if (exp_sign) {
-			return_f64_raw(0); /* underflow */
-		} else {
-			return_inf(); /* overflow */
-		}
-	}
-	exp_sig += exp_sign ? -exp_lit : exp_lit;
+    /* read exponent literal */
+    tmp = cur;
+    while (digi_is_digit(*cur)) {
+        exp_lit = (i64)((u8)(*cur++ - '0') + (u64)exp_lit * 10);
+    }
+    if (unlikely(cur - tmp >= U64_SAFE_DIG)) {
+        if (exp_sign) {
+            return_f64_bin(0); /* underflow */
+        } else {
+            return_inf(); /* overflow */
+        }
+    }
+    exp_sig += exp_sign ? -exp_lit : exp_lit;
 
-	/* validate exponent value */
+
+    /* validate exponent value */
 digi_exp_finish:
-	if (unlikely(exp_sig < F64_MIN_DEC_EXP - 19)) {
-		return_f64_raw(0); /* underflow */
-	}
-	if (unlikely(exp_sig > F64_MAX_DEC_EXP)) {
-		return_inf(); /* overflow */
-	}
-	exp = (i32)exp_sig;
+    if (unlikely(exp_sig < F64_MIN_DEC_EXP - 19)) {
+        return_f64_bin(0); /* underflow */
+    }
+    if (unlikely(exp_sig > F64_MAX_DEC_EXP)) {
+        return_inf(); /* overflow */
+    }
+    exp = (i32)exp_sig;
 
-	/* all digit read finished */
+
+    /* all digit read finished */
 digi_finish:
 
-	/*
-	 Fast path 1:
+    /*
+     Fast path 1:
 
-	 1. The floating-point number calculation should be accurate, see the
-	    comments of macro `YYJSON_DOUBLE_MATH_CORRECT`.
-	 2. Correct rounding should be performed (fegetround() == FE_TONEAREST).
-	 3. The input of floating point number calculation does not lose precision,
-	    which means: 64 - leading_zero(input) - trailing_zero(input) < 53.
+     1. The floating-point number calculation should be accurate, see the
+        comments of macro `YYJSON_DOUBLE_MATH_CORRECT`.
+     2. Correct rounding should be performed (fegetround() == FE_TONEAREST).
+     3. The input of floating point number calculation does not lose precision,
+        which means: 64 - leading_zero(input) - trailing_zero(input) < 53.
 
-	 We don't check all available inputs here, because that would make the code
-	 more complicated, and not friendly to branch predictor.
-	 */
+     We don't check all available inputs here, because that would make the code
+     more complicated, and not friendly to branch predictor.
+     */
 #if YYJSON_DOUBLE_MATH_CORRECT
-	if (sig < ((u64)1 << 53) && exp >= -F64_POW10_EXP_MAX_EXACT && exp <= +F64_POW10_EXP_MAX_EXACT) {
-		f64 dbl = (f64)sig;
-		if (exp < 0) {
-			dbl /= f64_pow10_table[-exp];
-		} else {
-			dbl *= f64_pow10_table[+exp];
-		}
-		return_f64(dbl);
-	}
+    if (sig < ((u64)1 << 53) &&
+        exp >= -F64_POW10_EXP_MAX_EXACT &&
+        exp <= +F64_POW10_EXP_MAX_EXACT) {
+        f64 dbl = (f64)sig;
+        if (exp < 0) {
+            dbl /= f64_pow10_table[-exp];
+        } else {
+            dbl *= f64_pow10_table[+exp];
+        }
+        return_f64(dbl);
+    }
 #endif
 
-	/*
-	 Fast path 2:
+    /*
+     Fast path 2:
 
-	 To keep it simple, we only accept normal number here,
-	 let the slow path to handle subnormal and infinity number.
-	 */
-	if (likely(!sig_cut && exp > -F64_MAX_DEC_EXP + 1 && exp < +F64_MAX_DEC_EXP - 20)) {
-		/*
-		 The result value is exactly equal to (sig * 10^exp),
-		 the exponent part (10^exp) can be converted to (sig2 * 2^exp2).
+     To keep it simple, we only accept normal number here,
+     let the slow path to handle subnormal and infinity number.
+     */
+    if (likely(!sig_cut &&
+               exp > -F64_MAX_DEC_EXP + 1 &&
+               exp < +F64_MAX_DEC_EXP - 20)) {
+        /*
+         The result value is exactly equal to (sig * 10^exp),
+         the exponent part (10^exp) can be converted to (sig2 * 2^exp2).
 
-		 The sig2 can be an infinite length number, only the highest 128 bits
-		 is cached in the pow10_sig_table.
+         The sig2 can be an infinite length number, only the highest 128 bits
+         is cached in the pow10_sig_table.
 
-		 Now we have these bits:
-		 sig1 (normalized 64bit)        : aaaaaaaa
-		 sig2 (higher 64bit)            : bbbbbbbb
-		 sig2_ext (lower 64bit)         : cccccccc
-		 sig2_cut (extra unknown bits)  : dddddddddddd....
+         Now we have these bits:
+         sig1 (normalized 64bit)        : aaaaaaaa
+         sig2 (higher 64bit)            : bbbbbbbb
+         sig2_ext (lower 64bit)         : cccccccc
+         sig2_cut (extra unknown bits)  : dddddddddddd....
 
-		 And the calculation process is:
-		 ----------------------------------------
-		         aaaaaaaa *
-		         bbbbbbbbccccccccdddddddddddd....
-		 ----------------------------------------
-		 abababababababab +
-		         acacacacacacacac +
-		                 adadadadadadadadadad....
-		 ----------------------------------------
-		 [hi____][lo____] +
-		         [hi2___][lo2___] +
-		                 [unknown___________....]
-		 ----------------------------------------
+         And the calculation process is:
+         ----------------------------------------
+                 aaaaaaaa *
+                 bbbbbbbbccccccccdddddddddddd....
+         ----------------------------------------
+         abababababababab +
+                 acacacacacacacac +
+                         adadadadadadadadadad....
+         ----------------------------------------
+         [hi____][lo____] +
+                 [hi2___][lo2___] +
+                         [unknown___________....]
+         ----------------------------------------
 
-		 The addition with carry may affect higher bits, but if there is a 0
-		 in higher bits, the bits higher than 0 will not be affected.
+         The addition with carry may affect higher bits, but if there is a 0
+         in higher bits, the bits higher than 0 will not be affected.
 
-		 `lo2` + `unknown` may get a carry bit and may affect `hi2`, the max
-		 value of `hi2` is 0xFFFFFFFFFFFFFFFE, so `hi2` will not overflow.
+         `lo2` + `unknown` may get a carry bit and may affect `hi2`, the max
+         value of `hi2` is 0xFFFFFFFFFFFFFFFE, so `hi2` will not overflow.
 
-		 `lo` + `hi2` may also get a carry bit and may affect `hi`, but only
-		 the highest significant 53 bits of `hi` is needed. If there is a 0
-		 in the lower bits of `hi`, then all the following bits can be dropped.
+         `lo` + `hi2` may also get a carry bit and may affect `hi`, but only
+         the highest significant 53 bits of `hi` is needed. If there is a 0
+         in the lower bits of `hi`, then all the following bits can be dropped.
 
-		 To convert the result to IEEE-754 double number, we need to perform
-		 correct rounding:
-		 1. if bit 54 is 0, round down,
-		 2. if bit 54 is 1 and any bit beyond bit 54 is 1, round up,
-		 3. if bit 54 is 1 and all bits beyond bit 54 are 0, round to even,
-		    as the extra bits is unknown, this case will not be handled here.
-		 */
+         To convert the result to IEEE-754 double number, we need to perform
+         correct rounding:
+         1. if bit 54 is 0, round down,
+         2. if bit 54 is 1 and any bit beyond bit 54 is 1, round up,
+         3. if bit 54 is 1 and all bits beyond bit 54 are 0, round to even,
+            as the extra bits is unknown, this case will not be handled here.
+         */
 
-		u64 raw;
-		u64 sig1, sig2, sig2_ext, hi, lo, hi2, lo2, add, bits;
-		i32 exp2;
-		u32 lz;
-		bool exact = false, carry, round_up;
+        u64 raw;
+        u64 sig1, sig2, sig2_ext, hi, lo, hi2, lo2, add, bits;
+        i32 exp2;
+        u32 lz;
+        bool exact = false, carry, round_up;
 
-		/* convert (10^exp) to (sig2 * 2^exp2) */
-		pow10_table_get_sig(exp, &sig2, &sig2_ext);
-		pow10_table_get_exp(exp, &exp2);
+        /* convert (10^exp) to (sig2 * 2^exp2) */
+        pow10_table_get_sig(exp, &sig2, &sig2_ext);
+        pow10_table_get_exp(exp, &exp2);
 
-		/* normalize and multiply */
-		lz = u64_lz_bits(sig);
-		sig1 = sig << lz;
-		exp2 -= (i32)lz;
-		u128_mul(sig1, sig2, &hi, &lo);
+        /* normalize and multiply */
+        lz = u64_lz_bits(sig);
+        sig1 = sig << lz;
+        exp2 -= (i32)lz;
+        u128_mul(sig1, sig2, &hi, &lo);
 
-		/*
-		 The `hi` is in range [0x4000000000000000, 0xFFFFFFFFFFFFFFFE],
-		 To get normalized value, `hi` should be shifted to the left by 0 or 1.
+        /*
+         The `hi` is in range [0x4000000000000000, 0xFFFFFFFFFFFFFFFE],
+         To get normalized value, `hi` should be shifted to the left by 0 or 1.
 
-		 The highest significant 53 bits is used by IEEE-754 double number,
-		 and the bit 54 is used to detect rounding direction.
+         The highest significant 53 bits is used by IEEE-754 double number,
+         and the bit 54 is used to detect rounding direction.
 
-		 The lowest (64 - 54 - 1) bits is used to check whether it contains 0.
-		 */
-		bits = hi & (((u64)1 << (64 - 54 - 1)) - 1);
-		if (bits - 1 < (((u64)1 << (64 - 54 - 1)) - 2)) {
-			/*
-			 (bits != 0 && bits != 0x1FF) => (bits - 1 < 0x1FF - 1)
-			 The `bits` is not zero, so we don't need to check `round to even`
-			 case. The `bits` contains bit `0`, so we can drop the extra bits
-			 after `0`.
-			 */
-			exact = true;
+         The lowest (64 - 54 - 1) bits is used to check whether it contains 0.
+         */
+        bits = hi & (((u64)1 << (64 - 54 - 1)) - 1);
+        if (bits - 1 < (((u64)1 << (64 - 54 - 1)) - 2)) {
+            /*
+             (bits != 0 && bits != 0x1FF) => (bits - 1 < 0x1FF - 1)
+             The `bits` is not zero, so we don't need to check `round to even`
+             case. The `bits` contains bit `0`, so we can drop the extra bits
+             after `0`.
+             */
+            exact = true;
 
-		} else {
-			/*
-			 (bits == 0 || bits == 0x1FF)
-			 The `bits` is filled with all `0` or all `1`, so we need to check
-			 lower bits with another 64-bit multiplication.
-			 */
-			u128_mul(sig1, sig2_ext, &hi2, &lo2);
+        } else {
+            /*
+             (bits == 0 || bits == 0x1FF)
+             The `bits` is filled with all `0` or all `1`, so we need to check
+             lower bits with another 64-bit multiplication.
+             */
+            u128_mul(sig1, sig2_ext, &hi2, &lo2);
 
-			add = lo + hi2;
-			if (add + 1 > (u64)1) {
-				/*
-				 (add != 0 && add != U64_MAX) => (add + 1 > 1)
-				 The `add` is not zero, so we don't need to check `round to
-				 even` case. The `add` contains bit `0`, so we can drop the
-				 extra bits after `0`. The `hi` cannot be U64_MAX, so it will
-				 not overflow.
-				 */
-				carry = add < lo || add < hi2;
-				hi += carry;
-				exact = true;
-			}
-		}
+            add = lo + hi2;
+            if (add + 1 > (u64)1) {
+                /*
+                 (add != 0 && add != U64_MAX) => (add + 1 > 1)
+                 The `add` is not zero, so we don't need to check `round to
+                 even` case. The `add` contains bit `0`, so we can drop the
+                 extra bits after `0`. The `hi` cannot be U64_MAX, so it will
+                 not overflow.
+                 */
+                carry = add < lo || add < hi2;
+                hi += carry;
+                exact = true;
+            }
+        }
 
-		if (exact) {
-			/* normalize */
-			lz = hi < ((u64)1 << 63);
-			hi <<= lz;
-			exp2 -= (i32)lz;
-			exp2 += 64;
+        if (exact) {
+            /* normalize */
+            lz = hi < ((u64)1 << 63);
+            hi <<= lz;
+            exp2 -= (i32)lz;
+            exp2 += 64;
 
-			/* test the bit 54 and get rounding direction */
-			round_up = (hi & ((u64)1 << (64 - 54))) > (u64)0;
-			hi += (round_up ? ((u64)1 << (64 - 54)) : (u64)0);
+            /* test the bit 54 and get rounding direction */
+            round_up = (hi & ((u64)1 << (64 - 54))) > (u64)0;
+            hi += (round_up ? ((u64)1 << (64 - 54)) : (u64)0);
 
-			/* test overflow */
-			if (hi < ((u64)1 << (64 - 54))) {
-				hi = ((u64)1 << 63);
-				exp2 += 1;
-			}
+            /* test overflow */
+            if (hi < ((u64)1 << (64 - 54))) {
+                hi = ((u64)1 << 63);
+                exp2 += 1;
+            }
 
-			/* This is a normal number, convert it to IEEE-754 format. */
-			hi >>= F64_BITS - F64_SIG_FULL_BITS;
-			exp2 += F64_BITS - F64_SIG_FULL_BITS + F64_SIG_BITS;
-			exp2 += F64_EXP_BIAS;
-			raw = ((u64)exp2 << F64_SIG_BITS) | (hi & F64_SIG_MASK);
-			return_f64_raw(raw);
-		}
-	}
+            /* This is a normal number, convert it to IEEE-754 format. */
+            hi >>= F64_BITS - F64_SIG_FULL_BITS;
+            exp2 += F64_BITS - F64_SIG_FULL_BITS + F64_SIG_BITS;
+            exp2 += F64_EXP_BIAS;
+            raw = ((u64)exp2 << F64_SIG_BITS) | (hi & F64_SIG_MASK);
+            return_f64_bin(raw);
+        }
+    }
 
-	/*
-	 Slow path: read double number exactly with diyfp.
-	 1. Use cached diyfp to get an approximation value.
-	 2. Use bigcomp to check the approximation value if needed.
+    /*
+     Slow path: read double number exactly with diyfp.
+     1. Use cached diyfp to get an approximation value.
+     2. Use bigcomp to check the approximation value if needed.
 
-	 This algorithm refers to google's double-conversion project:
-	 https://github.com/google/double-conversion
-	 */
-	{
-		const i32 ERR_ULP_LOG = 3;
-		const i32 ERR_ULP = 1 << ERR_ULP_LOG;
-		const i32 ERR_CACHED_POW = ERR_ULP / 2;
-		const i32 ERR_MUL_FIXED = ERR_ULP / 2;
-		const i32 DIY_SIG_BITS = 64;
-		const i32 EXP_BIAS = F64_EXP_BIAS + F64_SIG_BITS;
-		const i32 EXP_SUBNORMAL = -EXP_BIAS + 1;
+     This algorithm refers to google's double-conversion project:
+     https://github.com/google/double-conversion
+     */
+    {
+        const i32 ERR_ULP_LOG = 3;
+        const i32 ERR_ULP = 1 << ERR_ULP_LOG;
+        const i32 ERR_CACHED_POW = ERR_ULP / 2;
+        const i32 ERR_MUL_FIXED = ERR_ULP / 2;
+        const i32 DIY_SIG_BITS = 64;
+        const i32 EXP_BIAS = F64_EXP_BIAS + F64_SIG_BITS;
+        const i32 EXP_SUBNORMAL = -EXP_BIAS + 1;
 
-		u64 fp_err;
-		u32 bits;
-		i32 order_of_magnitude;
-		i32 effective_significand_size;
-		i32 precision_digits_count;
-		u64 precision_bits;
-		u64 half_way;
+        u64 fp_err;
+        u32 bits;
+        i32 order_of_magnitude;
+        i32 effective_significand_size;
+        i32 precision_digits_count;
+        u64 precision_bits;
+        u64 half_way;
 
-		u64 raw;
-		diy_fp fp, fp_upper;
-		bigint big_full, big_comp;
-		i32 cmp;
+        u64 raw;
+        diy_fp fp, fp_upper;
+        bigint big_full, big_comp;
+        i32 cmp;
 
-		fp.sig = sig;
-		fp.exp = 0;
-		fp_err = sig_cut ? (u64)(ERR_ULP / 2) : (u64)0;
+        fp.sig = sig;
+        fp.exp = 0;
+        fp_err = sig_cut ? (u64)(ERR_ULP / 2) : (u64)0;
 
-		/* normalize */
-		bits = u64_lz_bits(fp.sig);
-		fp.sig <<= bits;
-		fp.exp -= (i32)bits;
-		fp_err <<= bits;
+        /* normalize */
+        bits = u64_lz_bits(fp.sig);
+        fp.sig <<= bits;
+        fp.exp -= (i32)bits;
+        fp_err <<= bits;
 
-		/* multiply and add error */
-		fp = diy_fp_mul(fp, diy_fp_get_cached_pow10(exp));
-		fp_err += (u64)ERR_CACHED_POW + (fp_err != 0) + (u64)ERR_MUL_FIXED;
+        /* multiply and add error */
+        fp = diy_fp_mul(fp, diy_fp_get_cached_pow10(exp));
+        fp_err += (u64)ERR_CACHED_POW + (fp_err != 0) + (u64)ERR_MUL_FIXED;
 
-		/* normalize */
-		bits = u64_lz_bits(fp.sig);
-		fp.sig <<= bits;
-		fp.exp -= (i32)bits;
-		fp_err <<= bits;
+        /* normalize */
+        bits = u64_lz_bits(fp.sig);
+        fp.sig <<= bits;
+        fp.exp -= (i32)bits;
+        fp_err <<= bits;
 
-		/* effective significand */
-		order_of_magnitude = DIY_SIG_BITS + fp.exp;
-		if (likely(order_of_magnitude >= EXP_SUBNORMAL + F64_SIG_FULL_BITS)) {
-			effective_significand_size = F64_SIG_FULL_BITS;
-		} else if (order_of_magnitude <= EXP_SUBNORMAL) {
-			effective_significand_size = 0;
-		} else {
-			effective_significand_size = order_of_magnitude - EXP_SUBNORMAL;
-		}
+        /* effective significand */
+        order_of_magnitude = DIY_SIG_BITS + fp.exp;
+        if (likely(order_of_magnitude >= EXP_SUBNORMAL + F64_SIG_FULL_BITS)) {
+            effective_significand_size = F64_SIG_FULL_BITS;
+        } else if (order_of_magnitude <= EXP_SUBNORMAL) {
+            effective_significand_size = 0;
+        } else {
+            effective_significand_size = order_of_magnitude - EXP_SUBNORMAL;
+        }
 
-		/* precision digits count */
-		precision_digits_count = DIY_SIG_BITS - effective_significand_size;
-		if (unlikely(precision_digits_count + ERR_ULP_LOG >= DIY_SIG_BITS)) {
-			i32 shr = (precision_digits_count + ERR_ULP_LOG) - DIY_SIG_BITS + 1;
-			fp.sig >>= shr;
-			fp.exp += shr;
-			fp_err = (fp_err >> shr) + 1 + (u32)ERR_ULP;
-			precision_digits_count -= shr;
-		}
+        /* precision digits count */
+        precision_digits_count = DIY_SIG_BITS - effective_significand_size;
+        if (unlikely(precision_digits_count + ERR_ULP_LOG >= DIY_SIG_BITS)) {
+            i32 shr = (precision_digits_count + ERR_ULP_LOG) - DIY_SIG_BITS + 1;
+            fp.sig >>= shr;
+            fp.exp += shr;
+            fp_err = (fp_err >> shr) + 1 + (u32)ERR_ULP;
+            precision_digits_count -= shr;
+        }
 
-		/* half way */
-		precision_bits = fp.sig & (((u64)1 << precision_digits_count) - 1);
-		precision_bits *= (u32)ERR_ULP;
-		half_way = (u64)1 << (precision_digits_count - 1);
-		half_way *= (u32)ERR_ULP;
+        /* half way */
+        precision_bits = fp.sig & (((u64)1 << precision_digits_count) - 1);
+        precision_bits *= (u32)ERR_ULP;
+        half_way = (u64)1 << (precision_digits_count - 1);
+        half_way *= (u32)ERR_ULP;
 
-		/* rounding */
-		fp.sig >>= precision_digits_count;
-		fp.sig += (precision_bits >= half_way + fp_err);
-		fp.exp += precision_digits_count;
+        /* rounding */
+        fp.sig >>= precision_digits_count;
+        fp.sig += (precision_bits >= half_way + fp_err);
+        fp.exp += precision_digits_count;
 
-		/* get IEEE double raw value */
-		raw = diy_fp_to_ieee_raw(fp);
-		if (unlikely(raw == F64_RAW_INF))
-			return_inf();
-		if (likely(precision_bits <= half_way - fp_err || precision_bits >= half_way + fp_err)) {
-			return_f64_raw(raw); /* number is accurate */
-		}
-		/* now the number is the correct value, or the next lower value */
+        /* get IEEE double raw value */
+        raw = diy_fp_to_ieee_raw(fp);
+        if (unlikely(raw == F64_RAW_INF)) return_inf();
+        if (likely(precision_bits <= half_way - fp_err ||
+                   precision_bits >= half_way + fp_err)) {
+            return_f64_bin(raw); /* number is accurate */
+        }
+        /* now the number is the correct value, or the next lower value */
 
-		/* upper boundary */
-		if (raw & F64_EXP_MASK) {
-			fp_upper.sig = (raw & F64_SIG_MASK) + ((u64)1 << F64_SIG_BITS);
-			fp_upper.exp = (i32)((raw & F64_EXP_MASK) >> F64_SIG_BITS);
-		} else {
-			fp_upper.sig = (raw & F64_SIG_MASK);
-			fp_upper.exp = 1;
-		}
-		fp_upper.exp -= F64_EXP_BIAS + F64_SIG_BITS;
-		fp_upper.sig <<= 1;
-		fp_upper.exp -= 1;
-		fp_upper.sig += 1; /* add half ulp */
+        /* upper boundary */
+        if (raw & F64_EXP_MASK) {
+            fp_upper.sig = (raw & F64_SIG_MASK) + ((u64)1 << F64_SIG_BITS);
+            fp_upper.exp = (i32)((raw & F64_EXP_MASK) >> F64_SIG_BITS);
+        } else {
+            fp_upper.sig = (raw & F64_SIG_MASK);
+            fp_upper.exp = 1;
+        }
+        fp_upper.exp -= F64_EXP_BIAS + F64_SIG_BITS;
+        fp_upper.sig <<= 1;
+        fp_upper.exp -= 1;
+        fp_upper.sig += 1; /* add half ulp */
 
-		/* compare with bigint */
-		bigint_set_buf(&big_full, sig, &exp, sig_cut, sig_end, dot_pos);
-		bigint_set_u64(&big_comp, fp_upper.sig);
-		if (exp >= 0) {
-			bigint_mul_pow10(&big_full, +exp);
-		} else {
-			bigint_mul_pow10(&big_comp, -exp);
-		}
-		if (fp_upper.exp > 0) {
-			bigint_mul_pow2(&big_comp, (u32) + fp_upper.exp);
-		} else {
-			bigint_mul_pow2(&big_full, (u32)-fp_upper.exp);
-		}
-		cmp = bigint_cmp(&big_full, &big_comp);
-		if (likely(cmp != 0)) {
-			/* round down or round up */
-			raw += (cmp > 0);
-		} else {
-			/* falls midway, round to even */
-			raw += (raw & 1);
-		}
+        /* compare with bigint */
+        bigint_set_buf(&big_full, sig, &exp, sig_cut, sig_end, dot_pos);
+        bigint_set_u64(&big_comp, fp_upper.sig);
+        if (exp >= 0) {
+            bigint_mul_pow10(&big_full, +exp);
+        } else {
+            bigint_mul_pow10(&big_comp, -exp);
+        }
+        if (fp_upper.exp > 0) {
+            bigint_mul_pow2(&big_comp, (u32)+fp_upper.exp);
+        } else {
+            bigint_mul_pow2(&big_full, (u32)-fp_upper.exp);
+        }
+        cmp = bigint_cmp(&big_full, &big_comp);
+        if (likely(cmp != 0)) {
+            /* round down or round up */
+            raw += (cmp > 0);
+        } else {
+            /* falls midway, round to even */
+            raw += (raw & 1);
+        }
 
-		if (unlikely(raw == F64_RAW_INF))
-			return_inf();
-		return_f64_raw(raw);
-	}
+        if (unlikely(raw == F64_RAW_INF)) return_inf();
+        return_f64_bin(raw);
+    }
 
-#undef has_flag
 #undef return_err
 #undef return_inf
+#undef return_0
 #undef return_i64
 #undef return_f64
-#undef return_f64_raw
+#undef return_f64_bin
+#undef return_raw
 }
+
+
 
 #else /* FP_READER */
 
@@ -3894,179 +4978,197 @@ digi_finish:
  This is a fallback function if the custom number reader is disabled.
  This function use libc's strtod() to read floating-point number.
  */
-static_noinline bool read_number(u8 **ptr, u8 **pre, bool ext, yyjson_val *val, const char **msg) {
+static_inline bool read_number(u8 **ptr,
+                               u8 **pre,
+                               yyjson_read_flag flg,
+                               yyjson_val *val,
+                               const char **msg) {
 
-#define return_err(_pos, _msg)                                                                                         \
-	do {                                                                                                               \
-		*msg = _msg;                                                                                                   \
-		*end = _pos;                                                                                                   \
-		return false;                                                                                                  \
-	} while (false)
+#define return_err(_pos, _msg) do { \
+    *msg = _msg; \
+    *end = _pos; \
+    return false; \
+} while (false)
 
-#define return_i64(_v)                                                                                                 \
-	do {                                                                                                               \
-		val->tag = YYJSON_TYPE_NUM | (u64)((u8)sign << 3);                                                             \
-		val->uni.u64 = (u64)(sign ? (u64)(~(_v) + 1) : (u64)(_v));                                                     \
-		*end = cur;                                                                                                    \
-		return true;                                                                                                   \
-	} while (false)
+#define return_0() do { \
+    val->tag = YYJSON_TYPE_NUM | (u64)((u8)sign << 3); \
+    val->uni.u64 = 0; \
+    *end = cur; return true; \
+} while (false)
 
-#define return_f64(_v)                                                                                                 \
-	do {                                                                                                               \
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;                                                              \
-		val->uni.f64 = sign ? -(f64)(_v) : (f64)(_v);                                                                  \
-		*end = cur;                                                                                                    \
-		return true;                                                                                                   \
-	} while (false)
+#define return_i64(_v) do { \
+    val->tag = YYJSON_TYPE_NUM | (u64)((u8)sign << 3); \
+    val->uni.u64 = (u64)(sign ? (u64)(~(_v) + 1) : (u64)(_v)); \
+    *end = cur; return true; \
+} while (false)
 
-#define return_f64_raw(_v)                                                                                             \
-	do {                                                                                                               \
-		val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;                                                              \
-		val->uni.u64 = ((u64)sign << 63) | (u64)(_v);                                                                  \
-		*end = cur;                                                                                                    \
-		return true;                                                                                                   \
-	} while (false)
+#define return_f64(_v) do { \
+    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
+    val->uni.f64 = sign ? -(f64)(_v) : (f64)(_v); \
+    *end = cur; return true; \
+} while (false)
 
-	u64 sig, num;
-	u8 *hdr = *ptr;
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	u8 *dot = NULL;
-	u8 *f64_end = NULL;
-	bool sign;
+#define return_f64_bin(_v) do { \
+    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL; \
+    val->uni.u64 = ((u64)sign << 63) | (u64)(_v); \
+    *end = cur; return true; \
+} while (false)
 
-	/* read number as raw string if has flag */
-	if (unlikely(pre)) {
-		return read_number_raw(ptr, pre, ext, val, msg);
-	}
+#define return_inf() do { \
+    if (has_read_flag(BIGNUM_AS_RAW)) return_raw(); \
+    if (has_read_flag(ALLOW_INF_AND_NAN)) return_f64_bin(F64_RAW_INF); \
+    else return_err(hdr, "number is infinity when parsed as double"); \
+} while (false)
 
-	sign = (*hdr == '-');
-	cur += sign;
-	sig = (u8)(*cur - '0');
+#define return_raw() do { \
+    if (*pre) **pre = '\0'; /* add null-terminator for previous raw string */ \
+    val->tag = ((u64)(cur - hdr) << YYJSON_TAG_BIT) | YYJSON_TYPE_RAW; \
+    val->uni.str = (const char *)hdr; \
+    *pre = cur; *end = cur; return true; \
+} while (false)
 
-	/* read first digit, check leading zero */
-	if (unlikely(!digi_is_digit(*cur))) {
-		if (unlikely(ext)) {
-			if (read_inf_or_nan(sign, &cur, pre, val)) {
-				*end = cur;
-				return true;
-			}
-		}
-		return_err(cur, "no digit after minus sign");
-	}
-	if (*cur == '0') {
-		cur++;
-		if (unlikely(digi_is_digit(*cur))) {
-			return_err(cur - 1, "number with leading zero is not allowed");
-		}
-		if (!digi_is_fp(*cur))
-			return_i64(0);
-		goto read_double;
-	}
+    u64 sig, num;
+    u8 *hdr = *ptr;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    u8 *dot = NULL;
+    u8 *f64_end = NULL;
+    bool sign;
 
-	/* read continuous digits, up to 19 characters */
-#define expr_intg(i)                                                                                                   \
-	if (likely((num = (u64)(cur[i] - (u8)'0')) <= 9))                                                                  \
-		sig = num + sig * 10;                                                                                          \
-	else {                                                                                                             \
-		cur += i;                                                                                                      \
-		goto intg_end;                                                                                                 \
-	}
-	repeat_in_1_18(expr_intg);
+    /* read number as raw string if has `YYJSON_READ_NUMBER_AS_RAW` flag */
+    if (unlikely(pre && !has_read_flag(BIGNUM_AS_RAW))) {
+        return read_number_raw(ptr, pre, flg, val, msg);
+    }
+
+    sign = (*hdr == '-');
+    cur += sign;
+    sig = (u8)(*cur - '0');
+
+    /* read first digit, check leading zero */
+    if (unlikely(!digi_is_digit(*cur))) {
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (read_inf_or_nan(sign, &cur, pre, val)) {
+                *end = cur;
+                return true;
+            }
+        }
+        return_err(cur, "no digit after minus sign");
+    }
+    if (*cur == '0') {
+        cur++;
+        if (unlikely(digi_is_digit(*cur))) {
+            return_err(cur - 1, "number with leading zero is not allowed");
+        }
+        if (!digi_is_fp(*cur)) return_0();
+        goto read_double;
+    }
+
+    /* read continuous digits, up to 19 characters */
+#define expr_intg(i) \
+    if (likely((num = (u64)(cur[i] - (u8)'0')) <= 9)) sig = num + sig * 10; \
+    else { cur += i; goto intg_end; }
+    repeat_in_1_18(expr_intg)
 #undef expr_intg
 
-	/* here are 19 continuous digits, skip them */
-	cur += 19;
-	if (digi_is_digit(cur[0]) && !digi_is_digit_or_fp(cur[1])) {
-		/* this number is an integer consisting of 20 digits */
-		num = (u8)(*cur - '0');
-		if ((sig < (U64_MAX / 10)) || (sig == (U64_MAX / 10) && num <= (U64_MAX % 10))) {
-			sig = num + sig * 10;
-			cur++;
-			if (sign)
-				return_f64(normalized_u64_to_f64(sig));
-			return_i64(sig);
-		}
-	}
+    /* here are 19 continuous digits, skip them */
+    cur += 19;
+    if (digi_is_digit(cur[0]) && !digi_is_digit_or_fp(cur[1])) {
+        /* this number is an integer consisting of 20 digits */
+        num = (u8)(*cur - '0');
+        if ((sig < (U64_MAX / 10)) ||
+            (sig == (U64_MAX / 10) && num <= (U64_MAX % 10))) {
+            sig = num + sig * 10;
+            cur++;
+            if (sign) {
+                if (has_read_flag(BIGNUM_AS_RAW)) return_raw();
+                return_f64(normalized_u64_to_f64(sig));
+            }
+            return_i64(sig);
+        }
+    }
 
 intg_end:
-	/* continuous digits ended */
-	if (!digi_is_digit_or_fp(*cur)) {
-		/* this number is an integer consisting of 1 to 19 digits */
-		if (sign && (sig > ((u64)1 << 63))) {
-			return_f64(normalized_u64_to_f64(sig));
-		}
-		return_i64(sig);
-	}
+    /* continuous digits ended */
+    if (!digi_is_digit_or_fp(*cur)) {
+        /* this number is an integer consisting of 1 to 19 digits */
+        if (sign && (sig > ((u64)1 << 63))) {
+            if (has_read_flag(BIGNUM_AS_RAW)) return_raw();
+            return_f64(normalized_u64_to_f64(sig));
+        }
+        return_i64(sig);
+    }
 
 read_double:
-	/* this number should be read as double */
-	while (digi_is_digit(*cur))
-		cur++;
-	if (*cur == '.') {
-		/* skip fraction part */
-		dot = cur;
-		cur++;
-		if (!digi_is_digit(*cur)) {
-			return_err(cur, "no digit after decimal point");
-		}
-		cur++;
-		while (digi_is_digit(*cur))
-			cur++;
-	}
-	if (digi_is_exp(*cur)) {
-		/* skip exponent part */
-		cur += 1 + digi_is_sign(cur[1]);
-		if (!digi_is_digit(*cur)) {
-			return_err(cur, "no digit after exponent sign");
-		}
-		cur++;
-		while (digi_is_digit(*cur))
-			cur++;
-	}
+    /* this number should be read as double */
+    while (digi_is_digit(*cur)) cur++;
+    if (!digi_is_fp(*cur) && has_read_flag(BIGNUM_AS_RAW)) {
+        return_raw(); /* it's a large integer */
+    }
+    if (*cur == '.') {
+        /* skip fraction part */
+        dot = cur;
+        cur++;
+        if (!digi_is_digit(*cur)) {
+            return_err(cur, "no digit after decimal point");
+        }
+        cur++;
+        while (digi_is_digit(*cur)) cur++;
+    }
+    if (digi_is_exp(*cur)) {
+        /* skip exponent part */
+        cur += 1 + digi_is_sign(cur[1]);
+        if (!digi_is_digit(*cur)) {
+            return_err(cur, "no digit after exponent sign");
+        }
+        cur++;
+        while (digi_is_digit(*cur)) cur++;
+    }
 
-	/*
-	 libc's strtod() is used to parse the floating-point number.
+    /*
+     libc's strtod() is used to parse the floating-point number.
 
-	 Note that the decimal point character used by strtod() is locale-dependent,
-	 and the rounding direction may affected by fesetround().
+     Note that the decimal point character used by strtod() is locale-dependent,
+     and the rounding direction may affected by fesetround().
 
-	 For currently known locales, (en, zh, ja, ko, am, he, hi) use '.' as the
-	 decimal point, while other locales use ',' as the decimal point.
+     For currently known locales, (en, zh, ja, ko, am, he, hi) use '.' as the
+     decimal point, while other locales use ',' as the decimal point.
 
-	 Here strtod() is called twice for different locales, but if another thread
-	 happens calls setlocale() between two strtod(), parsing may still fail.
-	 */
-	val->uni.f64 = strtod((const char *)hdr, (char **)&f64_end);
-	if (unlikely(f64_end != cur)) {
-		bool cut = (*cur == ',');
-		if (dot)
-			*dot = ',';
-		if (cut)
-			*cur = ' ';
-		val->uni.f64 = strtod((const char *)hdr, (char **)&f64_end);
-		if (cut)
-			*cur = ',';
-		if (unlikely(f64_end != cur)) {
-			return_err(hdr, "strtod() failed to parse the number");
-		}
-	}
-	if (unlikely(val->uni.f64 == HUGE_VAL || val->uni.f64 == -HUGE_VAL)) {
-		if (!ext) {
-			return_err(hdr, "number is infinity when parsed as double");
-		}
-	}
-	val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
-	*end = cur;
-	return true;
+     Here strtod() is called twice for different locales, but if another thread
+     happens calls setlocale() between two strtod(), parsing may still fail.
+     */
+    val->uni.f64 = strtod((const char *)hdr, (char **)&f64_end);
+    if (unlikely(f64_end != cur)) {
+        /* replace '.' with ',' for locale */
+        bool cut = (*cur == ',');
+        if (cut) *cur = ' ';
+        if (dot) *dot = ',';
+        val->uni.f64 = strtod((const char *)hdr, (char **)&f64_end);
+        /* restore ',' to '.' */
+        if (cut) *cur = ',';
+        if (dot) *dot = '.';
+        if (unlikely(f64_end != cur)) {
+            return_err(hdr, "strtod() failed to parse the number");
+        }
+    }
+    if (unlikely(val->uni.f64 >= HUGE_VAL || val->uni.f64 <= -HUGE_VAL)) {
+        return_inf();
+    }
+    val->tag = YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL;
+    *end = cur;
+    return true;
 
-#undef has_flag
 #undef return_err
+#undef return_0
 #undef return_i64
 #undef return_f64
+#undef return_f64_bin
+#undef return_inf
+#undef return_raw
 }
 
 #endif /* FP_READER */
+
+
 
 /*==============================================================================
  * JSON String Reader
@@ -4081,460 +5183,493 @@ read_double:
  @param msg The error message pointer.
  @return Whether success.
  */
-static_inline bool read_string(u8 **ptr, u8 *lst, bool inv, yyjson_val *val, const char **msg) {
-	/*
-	 Each unicode code point is encoded as 1 to 4 bytes in UTF-8 encoding,
-	 we use 4-byte mask and pattern value to validate UTF-8 byte sequence,
-	 this requires the input data to have 4-byte zero padding.
-	 ---------------------------------------------------
-	 1 byte
-	 unicode range [U+0000, U+007F]
-	 unicode min   [.......0]
-	 unicode max   [.1111111]
-	 bit pattern   [0.......]
-	 ---------------------------------------------------
-	 2 byte
-	 unicode range [U+0080, U+07FF]
-	 unicode min   [......10 ..000000]
-	 unicode max   [...11111 ..111111]
-	 bit require   [...xxxx. ........] (1E 00)
-	 bit mask      [xxx..... xx......] (E0 C0)
-	 bit pattern   [110..... 10......] (C0 80)
-	 ---------------------------------------------------
-	 3 byte
-	 unicode range [U+0800, U+FFFF]
-	 unicode min   [........ ..100000 ..000000]
-	 unicode max   [....1111 ..111111 ..111111]
-	 bit require   [....xxxx ..x..... ........] (0F 20 00)
-	 bit mask      [xxxx.... xx...... xx......] (F0 C0 C0)
-	 bit pattern   [1110.... 10...... 10......] (E0 80 80)
-	 ---------------------------------------------------
-	 3 byte invalid (reserved for surrogate halves)
-	 unicode range [U+D800, U+DFFF]
-	 unicode min   [....1101 ..100000 ..000000]
-	 unicode max   [....1101 ..111111 ..111111]
-	 bit mask      [....xxxx ..x..... ........] (0F 20 00)
-	 bit pattern   [....1101 ..1..... ........] (0D 20 00)
-	 ---------------------------------------------------
-	 4 byte
-	 unicode range [U+10000, U+10FFFF]
-	 unicode min   [........ ...10000 ..000000 ..000000]
-	 unicode max   [.....100 ..001111 ..111111 ..111111]
-	 bit require   [.....xxx ..xx.... ........ ........] (07 30 00 00)
-	 bit mask      [xxxxx... xx...... xx...... xx......] (F8 C0 C0 C0)
-	 bit pattern   [11110... 10...... 10...... 10......] (F0 80 80 80)
-	 ---------------------------------------------------
-	 */
+static_inline bool read_string(u8 **ptr,
+                               u8 *lst,
+                               bool inv,
+                               yyjson_val *val,
+                               const char **msg) {
+    /*
+     Each unicode code point is encoded as 1 to 4 bytes in UTF-8 encoding,
+     we use 4-byte mask and pattern value to validate UTF-8 byte sequence,
+     this requires the input data to have 4-byte zero padding.
+     ---------------------------------------------------
+     1 byte
+     unicode range [U+0000, U+007F]
+     unicode min   [.......0]
+     unicode max   [.1111111]
+     bit pattern   [0.......]
+     ---------------------------------------------------
+     2 byte
+     unicode range [U+0080, U+07FF]
+     unicode min   [......10 ..000000]
+     unicode max   [...11111 ..111111]
+     bit require   [...xxxx. ........] (1E 00)
+     bit mask      [xxx..... xx......] (E0 C0)
+     bit pattern   [110..... 10......] (C0 80)
+     ---------------------------------------------------
+     3 byte
+     unicode range [U+0800, U+FFFF]
+     unicode min   [........ ..100000 ..000000]
+     unicode max   [....1111 ..111111 ..111111]
+     bit require   [....xxxx ..x..... ........] (0F 20 00)
+     bit mask      [xxxx.... xx...... xx......] (F0 C0 C0)
+     bit pattern   [1110.... 10...... 10......] (E0 80 80)
+     ---------------------------------------------------
+     3 byte invalid (reserved for surrogate halves)
+     unicode range [U+D800, U+DFFF]
+     unicode min   [....1101 ..100000 ..000000]
+     unicode max   [....1101 ..111111 ..111111]
+     bit mask      [....xxxx ..x..... ........] (0F 20 00)
+     bit pattern   [....1101 ..1..... ........] (0D 20 00)
+     ---------------------------------------------------
+     4 byte
+     unicode range [U+10000, U+10FFFF]
+     unicode min   [........ ...10000 ..000000 ..000000]
+     unicode max   [.....100 ..001111 ..111111 ..111111]
+     bit require   [.....xxx ..xx.... ........ ........] (07 30 00 00)
+     bit mask      [xxxxx... xx...... xx...... xx......] (F8 C0 C0 C0)
+     bit pattern   [11110... 10...... 10...... 10......] (F0 80 80 80)
+     ---------------------------------------------------
+     */
 #if YYJSON_ENDIAN == YYJSON_BIG_ENDIAN
-	const u32 b1_mask = 0x80000000UL;
-	const u32 b1_patt = 0x00000000UL;
-	const u32 b2_mask = 0xE0C00000UL;
-	const u32 b2_patt = 0xC0800000UL;
-	const u32 b2_requ = 0x1E000000UL;
-	const u32 b3_mask = 0xF0C0C000UL;
-	const u32 b3_patt = 0xE0808000UL;
-	const u32 b3_requ = 0x0F200000UL;
-	const u32 b3_erro = 0x0D200000UL;
-	const u32 b4_mask = 0xF8C0C0C0UL;
-	const u32 b4_patt = 0xF0808080UL;
-	const u32 b4_requ = 0x07300000UL;
-	const u32 b4_err0 = 0x04000000UL;
-	const u32 b4_err1 = 0x03300000UL;
+    const u32 b1_mask = 0x80000000UL;
+    const u32 b1_patt = 0x00000000UL;
+    const u32 b2_mask = 0xE0C00000UL;
+    const u32 b2_patt = 0xC0800000UL;
+    const u32 b2_requ = 0x1E000000UL;
+    const u32 b3_mask = 0xF0C0C000UL;
+    const u32 b3_patt = 0xE0808000UL;
+    const u32 b3_requ = 0x0F200000UL;
+    const u32 b3_erro = 0x0D200000UL;
+    const u32 b4_mask = 0xF8C0C0C0UL;
+    const u32 b4_patt = 0xF0808080UL;
+    const u32 b4_requ = 0x07300000UL;
+    const u32 b4_err0 = 0x04000000UL;
+    const u32 b4_err1 = 0x03300000UL;
 #elif YYJSON_ENDIAN == YYJSON_LITTLE_ENDIAN
-	const u32 b1_mask = 0x00000080UL;
-	const u32 b1_patt = 0x00000000UL;
-	const u32 b2_mask = 0x0000C0E0UL;
-	const u32 b2_patt = 0x000080C0UL;
-	const u32 b2_requ = 0x0000001EUL;
-	const u32 b3_mask = 0x00C0C0F0UL;
-	const u32 b3_patt = 0x008080E0UL;
-	const u32 b3_requ = 0x0000200FUL;
-	const u32 b3_erro = 0x0000200DUL;
-	const u32 b4_mask = 0xC0C0C0F8UL;
-	const u32 b4_patt = 0x808080F0UL;
-	const u32 b4_requ = 0x00003007UL;
-	const u32 b4_err0 = 0x00000004UL;
-	const u32 b4_err1 = 0x00003003UL;
+    const u32 b1_mask = 0x00000080UL;
+    const u32 b1_patt = 0x00000000UL;
+    const u32 b2_mask = 0x0000C0E0UL;
+    const u32 b2_patt = 0x000080C0UL;
+    const u32 b2_requ = 0x0000001EUL;
+    const u32 b3_mask = 0x00C0C0F0UL;
+    const u32 b3_patt = 0x008080E0UL;
+    const u32 b3_requ = 0x0000200FUL;
+    const u32 b3_erro = 0x0000200DUL;
+    const u32 b4_mask = 0xC0C0C0F8UL;
+    const u32 b4_patt = 0x808080F0UL;
+    const u32 b4_requ = 0x00003007UL;
+    const u32 b4_err0 = 0x00000004UL;
+    const u32 b4_err1 = 0x00003003UL;
 #else
-	v32_uni b1_mask_uni = {{0x80, 0x00, 0x00, 0x00}};
-	v32_uni b1_patt_uni = {{0x00, 0x00, 0x00, 0x00}};
-	v32_uni b2_mask_uni = {{0xE0, 0xC0, 0x00, 0x00}};
-	v32_uni b2_patt_uni = {{0xC0, 0x80, 0x00, 0x00}};
-	v32_uni b2_requ_uni = {{0x1E, 0x00, 0x00, 0x00}};
-	v32_uni b3_mask_uni = {{0xF0, 0xC0, 0xC0, 0x00}};
-	v32_uni b3_patt_uni = {{0xE0, 0x80, 0x80, 0x00}};
-	v32_uni b3_requ_uni = {{0x0F, 0x20, 0x00, 0x00}};
-	v32_uni b3_erro_uni = {{0x0D, 0x20, 0x00, 0x00}};
-	v32_uni b4_mask_uni = {{0xF8, 0xC0, 0xC0, 0xC0}};
-	v32_uni b4_patt_uni = {{0xF0, 0x80, 0x80, 0x80}};
-	v32_uni b4_requ_uni = {{0x07, 0x30, 0x00, 0x00}};
-	v32_uni b4_err0_uni = {{0x04, 0x00, 0x00, 0x00}};
-	v32_uni b4_err1_uni = {{0x03, 0x30, 0x00, 0x00}};
-	u32 b1_mask = b1_mask_uni.u;
-	u32 b1_patt = b1_patt_uni.u;
-	u32 b2_mask = b2_mask_uni.u;
-	u32 b2_patt = b2_patt_uni.u;
-	u32 b2_requ = b2_requ_uni.u;
-	u32 b3_mask = b3_mask_uni.u;
-	u32 b3_patt = b3_patt_uni.u;
-	u32 b3_requ = b3_requ_uni.u;
-	u32 b3_erro = b3_erro_uni.u;
-	u32 b4_mask = b4_mask_uni.u;
-	u32 b4_patt = b4_patt_uni.u;
-	u32 b4_requ = b4_requ_uni.u;
-	u32 b4_err0 = b4_err0_uni.u;
-	u32 b4_err1 = b4_err1_uni.u;
+    /* this should be evaluated at compile-time */
+    v32_uni b1_mask_uni = {{ 0x80, 0x00, 0x00, 0x00 }};
+    v32_uni b1_patt_uni = {{ 0x00, 0x00, 0x00, 0x00 }};
+    v32_uni b2_mask_uni = {{ 0xE0, 0xC0, 0x00, 0x00 }};
+    v32_uni b2_patt_uni = {{ 0xC0, 0x80, 0x00, 0x00 }};
+    v32_uni b2_requ_uni = {{ 0x1E, 0x00, 0x00, 0x00 }};
+    v32_uni b3_mask_uni = {{ 0xF0, 0xC0, 0xC0, 0x00 }};
+    v32_uni b3_patt_uni = {{ 0xE0, 0x80, 0x80, 0x00 }};
+    v32_uni b3_requ_uni = {{ 0x0F, 0x20, 0x00, 0x00 }};
+    v32_uni b3_erro_uni = {{ 0x0D, 0x20, 0x00, 0x00 }};
+    v32_uni b4_mask_uni = {{ 0xF8, 0xC0, 0xC0, 0xC0 }};
+    v32_uni b4_patt_uni = {{ 0xF0, 0x80, 0x80, 0x80 }};
+    v32_uni b4_requ_uni = {{ 0x07, 0x30, 0x00, 0x00 }};
+    v32_uni b4_err0_uni = {{ 0x04, 0x00, 0x00, 0x00 }};
+    v32_uni b4_err1_uni = {{ 0x03, 0x30, 0x00, 0x00 }};
+    u32 b1_mask = b1_mask_uni.u;
+    u32 b1_patt = b1_patt_uni.u;
+    u32 b2_mask = b2_mask_uni.u;
+    u32 b2_patt = b2_patt_uni.u;
+    u32 b2_requ = b2_requ_uni.u;
+    u32 b3_mask = b3_mask_uni.u;
+    u32 b3_patt = b3_patt_uni.u;
+    u32 b3_requ = b3_requ_uni.u;
+    u32 b3_erro = b3_erro_uni.u;
+    u32 b4_mask = b4_mask_uni.u;
+    u32 b4_patt = b4_patt_uni.u;
+    u32 b4_requ = b4_requ_uni.u;
+    u32 b4_err0 = b4_err0_uni.u;
+    u32 b4_err1 = b4_err1_uni.u;
 #endif
 
-#define is_valid_seq_1(uni) (((uni & b1_mask) == b1_patt))
+#define is_valid_seq_1(uni) ( \
+    ((uni & b1_mask) == b1_patt) \
+)
 
-#define is_valid_seq_2(uni) (((uni & b2_mask) == b2_patt) && ((uni & b2_requ)))
+#define is_valid_seq_2(uni) ( \
+    ((uni & b2_mask) == b2_patt) && \
+    ((uni & b2_requ)) \
+)
 
-#define is_valid_seq_3(uni) (((uni & b3_mask) == b3_patt) && ((tmp = (uni & b3_requ))) && ((tmp != b3_erro)))
+#define is_valid_seq_3(uni) ( \
+    ((uni & b3_mask) == b3_patt) && \
+    ((tmp = (uni & b3_requ))) && \
+    ((tmp != b3_erro)) \
+)
 
-#define is_valid_seq_4(uni)                                                                                            \
-	(((uni & b4_mask) == b4_patt) && ((tmp = (uni & b4_requ))) && ((tmp & b4_err0) == 0 || (tmp & b4_err1) == 0))
+#define is_valid_seq_4(uni) ( \
+    ((uni & b4_mask) == b4_patt) && \
+    ((tmp = (uni & b4_requ))) && \
+    ((tmp & b4_err0) == 0 || (tmp & b4_err1) == 0) \
+)
 
-#define return_err(_end, _msg)                                                                                         \
-	do {                                                                                                               \
-		*msg = _msg;                                                                                                   \
-		*end = _end;                                                                                                   \
-		return false;                                                                                                  \
-	} while (false)
+#define return_err(_end, _msg) do { \
+    *msg = _msg; \
+    *end = _end; \
+    return false; \
+} while (false)
 
-	u8 *cur = *ptr;
-	u8 **end = ptr;
-	u8 *src = ++cur, *dst, *pos;
-	u16 hi, lo;
-	u32 uni, tmp;
+    u8 *cur = *ptr;
+    u8 **end = ptr;
+    u8 *src = ++cur, *dst, *pos;
+    u16 hi, lo;
+    u32 uni, tmp;
 
 skip_ascii:
-	/* Most strings have no escaped characters, so we can jump them quickly. */
+    /* Most strings have no escaped characters, so we can jump them quickly. */
 
 skip_ascii_begin:
-	/*
-	 We want to make loop unrolling, as shown in the following code. Some
-	 compiler may not generate instructions as expected, so we rewrite it with
-	 explicit goto statements. We hope the compiler can generate instructions
-	 like this: https://godbolt.org/z/8vjsYq
+    /*
+     We want to make loop unrolling, as shown in the following code. Some
+     compiler may not generate instructions as expected, so we rewrite it with
+     explicit goto statements. We hope the compiler can generate instructions
+     like this: https://godbolt.org/z/8vjsYq
 
-	     while (true) repeat16({
-	        if (likely(!(char_is_ascii_stop(*src)))) src++;
-	        else break;
-	     });
-	 */
-#define expr_jump(i)                                                                                                   \
-	if (likely(!char_is_ascii_stop(src[i]))) {                                                                         \
-	} else                                                                                                             \
-		goto skip_ascii_stop##i;
+         while (true) repeat16({
+            if (likely(!(char_is_ascii_stop(*src)))) src++;
+            else break;
+         })
+     */
+#define expr_jump(i) \
+    if (likely(!char_is_ascii_stop(src[i]))) {} \
+    else goto skip_ascii_stop##i;
 
-#define expr_stop(i)                                                                                                   \
-	skip_ascii_stop##i : src += i;                                                                                     \
-	goto skip_ascii_end;
+#define expr_stop(i) \
+    skip_ascii_stop##i: \
+    src += i; \
+    goto skip_ascii_end;
 
-	repeat16_incr(expr_jump);
-	src += 16;
-	goto skip_ascii_begin;
-	repeat16_incr(expr_stop);
+    repeat16_incr(expr_jump)
+    src += 16;
+    goto skip_ascii_begin;
+    repeat16_incr(expr_stop)
 
 #undef expr_jump
 #undef expr_stop
 
 skip_ascii_end:
 
-	/*
-	 GCC may store src[i] in a register at each line of expr_jump(i) above.
-	 These instructions are useless and will degrade performance.
-	 This inline asm is a hint for gcc: "the memory has been modified,
-	 do not cache it".
+    /*
+     GCC may store src[i] in a register at each line of expr_jump(i) above.
+     These instructions are useless and will degrade performance.
+     This inline asm is a hint for gcc: "the memory has been modified,
+     do not cache it".
 
-	 MSVC, Clang, ICC can generate expected instructions without this hint.
-	 */
+     MSVC, Clang, ICC can generate expected instructions without this hint.
+     */
 #if YYJSON_IS_REAL_GCC
-	__asm__ volatile("" : "=m"(*src));
+    __asm__ volatile("":"=m"(*src));
 #endif
-	if (likely(*src == '"')) {
-		val->tag = ((u64)(src - cur) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		val->uni.str = (const char *)cur;
-		*src = '\0';
-		*end = src + 1;
-		return true;
-	}
+    if (likely(*src == '"')) {
+        val->tag = ((u64)(src - cur) << YYJSON_TAG_BIT) |
+                    (u64)(YYJSON_TYPE_STR | YYJSON_SUBTYPE_NOESC);
+        val->uni.str = (const char *)cur;
+        *src = '\0';
+        *end = src + 1;
+        return true;
+    }
 
 skip_utf8:
-	if (*src & 0x80) { /* non-ASCII character */
-		/*
-		 Non-ASCII character appears here, which means that the text is likely
-		 to be written in non-English or emoticons. According to some common
-		 data set statistics, byte sequences of the same length may appear
-		 consecutively. We process the byte sequences of the same length in each
-		 loop, which is more friendly to branch prediction.
-		 */
-		pos = src;
-		uni = byte_load_4(src);
-		while (is_valid_seq_3(uni)) {
-			src += 3;
-			uni = byte_load_4(src);
-		}
-		if (is_valid_seq_1(uni))
-			goto skip_ascii;
-		while (is_valid_seq_2(uni)) {
-			src += 2;
-			uni = byte_load_4(src);
-		}
-		while (is_valid_seq_4(uni)) {
-			src += 4;
-			uni = byte_load_4(src);
-		}
-		if (unlikely(pos == src)) {
-			if (!inv)
-				return_err(src, "invalid UTF-8 encoding in string");
-			++src;
-		}
-		goto skip_ascii;
-	}
+    if (*src & 0x80) { /* non-ASCII character */
+        /*
+         Non-ASCII character appears here, which means that the text is likely
+         to be written in non-English or emoticons. According to some common
+         data set statistics, byte sequences of the same length may appear
+         consecutively. We process the byte sequences of the same length in each
+         loop, which is more friendly to branch prediction.
+         */
+        pos = src;
+#if YYJSON_DISABLE_UTF8_VALIDATION
+        while (true) repeat8({
+            if (likely((*src & 0xF0) == 0xE0)) src += 3;
+            else break;
+        })
+        if (*src < 0x80) goto skip_ascii;
+        while (true) repeat8({
+            if (likely((*src & 0xE0) == 0xC0)) src += 2;
+            else break;
+        })
+        while (true) repeat8({
+            if (likely((*src & 0xF8) == 0xF0)) src += 4;
+            else break;
+        })
+#else
+        uni = byte_load_4(src);
+        while (is_valid_seq_3(uni)) {
+            src += 3;
+            uni = byte_load_4(src);
+        }
+        if (is_valid_seq_1(uni)) goto skip_ascii;
+        while (is_valid_seq_2(uni)) {
+            src += 2;
+            uni = byte_load_4(src);
+        }
+        while (is_valid_seq_4(uni)) {
+            src += 4;
+            uni = byte_load_4(src);
+        }
+#endif
+        if (unlikely(pos == src)) {
+            if (!inv) return_err(src, "invalid UTF-8 encoding in string");
+            ++src;
+        }
+        goto skip_ascii;
+    }
 
-	/* The escape character appears, we need to copy it. */
-	dst = src;
+    /* The escape character appears, we need to copy it. */
+    dst = src;
 copy_escape:
-	if (likely(*src == '\\')) {
-		switch (*++src) {
-		case '"':
-			*dst++ = '"';
-			src++;
-			break;
-		case '\\':
-			*dst++ = '\\';
-			src++;
-			break;
-		case '/':
-			*dst++ = '/';
-			src++;
-			break;
-		case 'b':
-			*dst++ = '\b';
-			src++;
-			break;
-		case 'f':
-			*dst++ = '\f';
-			src++;
-			break;
-		case 'n':
-			*dst++ = '\n';
-			src++;
-			break;
-		case 'r':
-			*dst++ = '\r';
-			src++;
-			break;
-		case 't':
-			*dst++ = '\t';
-			src++;
-			break;
-		case 'u':
-			if (unlikely(!read_hex_u16(++src, &hi))) {
-				return_err(src - 2, "invalid escaped unicode in string");
-			}
-			src += 4;
-			if (likely((hi & 0xF800) != 0xD800)) {
-				/* a BMP character */
-				if (hi >= 0x800) {
-					*dst++ = (u8)(0xE0 | (hi >> 12));
-					*dst++ = (u8)(0x80 | ((hi >> 6) & 0x3F));
-					*dst++ = (u8)(0x80 | (hi & 0x3F));
-				} else if (hi >= 0x80) {
-					*dst++ = (u8)(0xC0 | (hi >> 6));
-					*dst++ = (u8)(0x80 | (hi & 0x3F));
-				} else {
-					*dst++ = (u8)hi;
-				}
-			} else {
-				/* a non-BMP character, represented as a surrogate pair */
-				if (unlikely((hi & 0xFC00) != 0xD800)) {
-					return_err(src - 6, "invalid high surrogate in string");
-				}
-				if (unlikely(!byte_match_2(src, "\\u")) || unlikely(!read_hex_u16(src + 2, &lo))) {
-					return_err(src, "no matched low surrogate in string");
-				}
-				if (unlikely((lo & 0xFC00) != 0xDC00)) {
-					return_err(src, "invalid low surrogate in string");
-				}
-				uni = ((((u32)hi - 0xD800) << 10) | ((u32)lo - 0xDC00)) + 0x10000;
-				*dst++ = (u8)(0xF0 | (uni >> 18));
-				*dst++ = (u8)(0x80 | ((uni >> 12) & 0x3F));
-				*dst++ = (u8)(0x80 | ((uni >> 6) & 0x3F));
-				*dst++ = (u8)(0x80 | (uni & 0x3F));
-				src += 6;
-			}
-			break;
-		default:
-			return_err(src, "invalid escaped character in string");
-		}
-	} else if (likely(*src == '"')) {
-		val->tag = ((u64)(dst - cur) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
-		val->uni.str = (const char *)cur;
-		*dst = '\0';
-		*end = src + 1;
-		return true;
-	} else {
-		if (!inv)
-			return_err(src, "unexpected control character in string");
-		if (src >= lst)
-			return_err(src, "unclosed string");
-		*dst++ = *src++;
-	}
+    if (likely(*src == '\\')) {
+        switch (*++src) {
+            case '"':  *dst++ = '"';  src++; break;
+            case '\\': *dst++ = '\\'; src++; break;
+            case '/':  *dst++ = '/';  src++; break;
+            case 'b':  *dst++ = '\b'; src++; break;
+            case 'f':  *dst++ = '\f'; src++; break;
+            case 'n':  *dst++ = '\n'; src++; break;
+            case 'r':  *dst++ = '\r'; src++; break;
+            case 't':  *dst++ = '\t'; src++; break;
+            case 'u':
+                if (unlikely(!read_hex_u16(++src, &hi))) {
+                    return_err(src - 2, "invalid escaped sequence in string");
+                }
+                src += 4;
+                if (likely((hi & 0xF800) != 0xD800)) {
+                    /* a BMP character */
+                    if (hi >= 0x800) {
+                        *dst++ = (u8)(0xE0 | (hi >> 12));
+                        *dst++ = (u8)(0x80 | ((hi >> 6) & 0x3F));
+                        *dst++ = (u8)(0x80 | (hi & 0x3F));
+                    } else if (hi >= 0x80) {
+                        *dst++ = (u8)(0xC0 | (hi >> 6));
+                        *dst++ = (u8)(0x80 | (hi & 0x3F));
+                    } else {
+                        *dst++ = (u8)hi;
+                    }
+                } else {
+                    /* a non-BMP character, represented as a surrogate pair */
+                    if (unlikely((hi & 0xFC00) != 0xD800)) {
+                        return_err(src - 6, "invalid high surrogate in string");
+                    }
+                    if (unlikely(!byte_match_2(src, "\\u"))) {
+                        return_err(src, "no low surrogate in string");
+                    }
+                    if (unlikely(!read_hex_u16(src + 2, &lo))) {
+                        return_err(src, "invalid escaped sequence in string");
+                    }
+                    if (unlikely((lo & 0xFC00) != 0xDC00)) {
+                        return_err(src, "invalid low surrogate in string");
+                    }
+                    uni = ((((u32)hi - 0xD800) << 10) |
+                            ((u32)lo - 0xDC00)) + 0x10000;
+                    *dst++ = (u8)(0xF0 | (uni >> 18));
+                    *dst++ = (u8)(0x80 | ((uni >> 12) & 0x3F));
+                    *dst++ = (u8)(0x80 | ((uni >> 6) & 0x3F));
+                    *dst++ = (u8)(0x80 | (uni & 0x3F));
+                    src += 6;
+                }
+                break;
+            default: return_err(src, "invalid escaped character in string");
+        }
+    } else if (likely(*src == '"')) {
+        val->tag = ((u64)(dst - cur) << YYJSON_TAG_BIT) | YYJSON_TYPE_STR;
+        val->uni.str = (const char *)cur;
+        *dst = '\0';
+        *end = src + 1;
+        return true;
+    } else {
+        if (!inv) return_err(src, "unexpected control character in string");
+        if (src >= lst) return_err(src, "unclosed string");
+        *dst++ = *src++;
+    }
 
 copy_ascii:
-	/*
-	 Copy continuous ASCII, loop unrolling, same as the following code:
+    /*
+     Copy continuous ASCII, loop unrolling, same as the following code:
 
-	     while (true) repeat16({
-	        if (unlikely(char_is_ascii_stop(*src))) break;
-	        *dst++ = *src++;
-	     });
-	 */
+         while (true) repeat16({
+            if (unlikely(char_is_ascii_stop(*src))) break;
+            *dst++ = *src++;
+         })
+     */
 #if YYJSON_IS_REAL_GCC
-#define expr_jump(i)                                                                                                   \
-	if (likely(!(char_is_ascii_stop(src[i])))) {                                                                       \
-	} else {                                                                                                           \
-		__asm__ volatile("" : "=m"(src[i]));                                                                           \
-		goto copy_ascii_stop_##i;                                                                                      \
-	}
+#   define expr_jump(i) \
+    if (likely(!(char_is_ascii_stop(src[i])))) {} \
+    else { __asm__ volatile("":"=m"(src[i])); goto copy_ascii_stop_##i; }
 #else
-#define expr_jump(i)                                                                                                   \
-	if (likely(!(char_is_ascii_stop(src[i])))) {                                                                       \
-	} else {                                                                                                           \
-		goto copy_ascii_stop_##i;                                                                                      \
-	}
+#   define expr_jump(i) \
+    if (likely(!(char_is_ascii_stop(src[i])))) {} \
+    else { goto copy_ascii_stop_##i; }
 #endif
-	repeat16_incr(expr_jump);
+    repeat16_incr(expr_jump)
 #undef expr_jump
 
-	byte_move_16(dst, src);
-	src += 16;
-	dst += 16;
-	goto copy_ascii;
+    byte_move_16(dst, src);
+    src += 16;
+    dst += 16;
+    goto copy_ascii;
 
+    /*
+     The memory will be moved forward by at least 1 byte. So the `byte_move`
+     can be one byte more than needed to reduce the number of instructions.
+     */
 copy_ascii_stop_0:
-	goto copy_utf8;
+    goto copy_utf8;
 copy_ascii_stop_1:
-	byte_move_2(dst, src);
-	src += 1;
-	dst += 1;
-	goto copy_utf8;
+    byte_move_2(dst, src);
+    src += 1;
+    dst += 1;
+    goto copy_utf8;
 copy_ascii_stop_2:
-	byte_move_2(dst, src);
-	src += 2;
-	dst += 2;
-	goto copy_utf8;
+    byte_move_2(dst, src);
+    src += 2;
+    dst += 2;
+    goto copy_utf8;
 copy_ascii_stop_3:
-	byte_move_4(dst, src);
-	src += 3;
-	dst += 3;
-	goto copy_utf8;
+    byte_move_4(dst, src);
+    src += 3;
+    dst += 3;
+    goto copy_utf8;
 copy_ascii_stop_4:
-	byte_move_4(dst, src);
-	src += 4;
-	dst += 4;
-	goto copy_utf8;
+    byte_move_4(dst, src);
+    src += 4;
+    dst += 4;
+    goto copy_utf8;
 copy_ascii_stop_5:
-	byte_move_4(dst, src);
-	byte_move_2(dst + 4, src + 4);
-	src += 5;
-	dst += 5;
-	goto copy_utf8;
+    byte_move_4(dst, src);
+    byte_move_2(dst + 4, src + 4);
+    src += 5;
+    dst += 5;
+    goto copy_utf8;
 copy_ascii_stop_6:
-	byte_move_4(dst, src);
-	byte_move_2(dst + 4, src + 4);
-	src += 6;
-	dst += 6;
-	goto copy_utf8;
+    byte_move_4(dst, src);
+    byte_move_2(dst + 4, src + 4);
+    src += 6;
+    dst += 6;
+    goto copy_utf8;
 copy_ascii_stop_7:
-	byte_move_8(dst, src);
-	src += 7;
-	dst += 7;
-	goto copy_utf8;
+    byte_move_8(dst, src);
+    src += 7;
+    dst += 7;
+    goto copy_utf8;
 copy_ascii_stop_8:
-	byte_move_8(dst, src);
-	src += 8;
-	dst += 8;
-	goto copy_utf8;
+    byte_move_8(dst, src);
+    src += 8;
+    dst += 8;
+    goto copy_utf8;
 copy_ascii_stop_9:
-	byte_move_8(dst, src);
-	byte_move_2(dst + 8, src + 8);
-	src += 9;
-	dst += 9;
-	goto copy_utf8;
+    byte_move_8(dst, src);
+    byte_move_2(dst + 8, src + 8);
+    src += 9;
+    dst += 9;
+    goto copy_utf8;
 copy_ascii_stop_10:
-	byte_move_8(dst, src);
-	byte_move_2(dst + 8, src + 8);
-	src += 10;
-	dst += 10;
-	goto copy_utf8;
+    byte_move_8(dst, src);
+    byte_move_2(dst + 8, src + 8);
+    src += 10;
+    dst += 10;
+    goto copy_utf8;
 copy_ascii_stop_11:
-	byte_move_8(dst, src);
-	byte_move_4(dst + 8, src + 8);
-	src += 11;
-	dst += 11;
-	goto copy_utf8;
+    byte_move_8(dst, src);
+    byte_move_4(dst + 8, src + 8);
+    src += 11;
+    dst += 11;
+    goto copy_utf8;
 copy_ascii_stop_12:
-	byte_move_8(dst, src);
-	byte_move_4(dst + 8, src + 8);
-	src += 12;
-	dst += 12;
-	goto copy_utf8;
+    byte_move_8(dst, src);
+    byte_move_4(dst + 8, src + 8);
+    src += 12;
+    dst += 12;
+    goto copy_utf8;
 copy_ascii_stop_13:
-	byte_move_8(dst, src);
-	byte_move_4(dst + 8, src + 8);
-	byte_move_2(dst + 12, src + 12);
-	src += 13;
-	dst += 13;
-	goto copy_utf8;
+    byte_move_8(dst, src);
+    byte_move_4(dst + 8, src + 8);
+    byte_move_2(dst + 12, src + 12);
+    src += 13;
+    dst += 13;
+    goto copy_utf8;
 copy_ascii_stop_14:
-	byte_move_8(dst, src);
-	byte_move_4(dst + 8, src + 8);
-	byte_move_2(dst + 12, src + 12);
-	src += 14;
-	dst += 14;
-	goto copy_utf8;
+    byte_move_8(dst, src);
+    byte_move_4(dst + 8, src + 8);
+    byte_move_2(dst + 12, src + 12);
+    src += 14;
+    dst += 14;
+    goto copy_utf8;
 copy_ascii_stop_15:
-	byte_move_16(dst, src);
-	src += 15;
-	dst += 15;
-	goto copy_utf8;
+    byte_move_16(dst, src);
+    src += 15;
+    dst += 15;
+    goto copy_utf8;
 
 copy_utf8:
-	if (*src & 0x80) { /* non-ASCII character */
-		pos = src;
-		uni = byte_load_4(src);
-		while (is_valid_seq_3(uni)) {
-			byte_move_4(dst, &uni);
-			dst += 3;
-			src += 3;
-			uni = byte_load_4(src);
-		}
-		if (is_valid_seq_1(uni))
-			goto copy_ascii;
-		while (is_valid_seq_2(uni)) {
-			byte_move_2(dst, &uni);
-			dst += 2;
-			src += 2;
-			uni = byte_load_4(src);
-		}
-		while (is_valid_seq_4(uni)) {
-			byte_move_4(dst, &uni);
-			dst += 4;
-			src += 4;
-			uni = byte_load_4(src);
-		}
-		if (unlikely(pos == src)) {
-			if (!inv)
-				return_err(src, "invalid UTF-8 encoding in string");
-			goto copy_ascii_stop_1;
-		}
-		goto copy_ascii;
-	}
-	goto copy_escape;
+    if (*src & 0x80) { /* non-ASCII character */
+        pos = src;
+        uni = byte_load_4(src);
+#if YYJSON_DISABLE_UTF8_VALIDATION
+        while (true) repeat4({
+            if ((uni & b3_mask) == b3_patt) {
+                byte_copy_4(dst, &uni);
+                dst += 3;
+                src += 3;
+                uni = byte_load_4(src);
+            } else break;
+        })
+        if ((uni & b1_mask) == b1_patt) goto copy_ascii;
+        while (true) repeat4({
+            if ((uni & b2_mask) == b2_patt) {
+                byte_copy_2(dst, &uni);
+                dst += 2;
+                src += 2;
+                uni = byte_load_4(src);
+            } else break;
+        })
+        while (true) repeat4({
+            if ((uni & b4_mask) == b4_patt) {
+                byte_copy_4(dst, &uni);
+                dst += 4;
+                src += 4;
+                uni = byte_load_4(src);
+            } else break;
+        })
+#else
+        while (is_valid_seq_3(uni)) {
+            byte_copy_4(dst, &uni);
+            dst += 3;
+            src += 3;
+            uni = byte_load_4(src);
+        }
+        if (is_valid_seq_1(uni)) goto copy_ascii;
+        while (is_valid_seq_2(uni)) {
+            byte_copy_2(dst, &uni);
+            dst += 2;
+            src += 2;
+            uni = byte_load_4(src);
+        }
+        while (is_valid_seq_4(uni)) {
+            byte_copy_4(dst, &uni);
+            dst += 4;
+            src += 4;
+            uni = byte_load_4(src);
+        }
+#endif
+        if (unlikely(pos == src)) {
+            if (!inv) return_err(src, "invalid UTF-8 encoding in string");
+            goto copy_ascii_stop_1;
+        }
+        goto copy_ascii;
+    }
+    goto copy_escape;
 
 #undef return_err
 #undef is_valid_seq_1
@@ -4542,6 +5677,8 @@ copy_utf8:
 #undef is_valid_seq_3
 #undef is_valid_seq_4
 }
+
+
 
 /*==============================================================================
  * JSON Reader Implementation
@@ -4552,1358 +5689,1245 @@ copy_utf8:
  *============================================================================*/
 
 /** Read single value JSON document. */
-static_noinline yyjson_doc *read_root_single(u8 *hdr, u8 *cur, u8 *end, yyjson_alc alc, yyjson_read_flag flg,
+static_noinline yyjson_doc *read_root_single(u8 *hdr,
+                                             u8 *cur,
+                                             u8 *end,
+                                             yyjson_alc alc,
+                                             yyjson_read_flag flg,
                                              yyjson_read_err *err) {
 
-#define has_flag(_flag) unlikely((flg & YYJSON_READ_##_flag) != 0)
+#define return_err(_pos, _code, _msg) do { \
+    if (is_truncated_end(hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) { \
+        err->pos = (usize)(end - hdr); \
+        err->code = YYJSON_READ_ERROR_UNEXPECTED_END; \
+        err->msg = "unexpected end of data"; \
+    } else { \
+        err->pos = (usize)(_pos - hdr); \
+        err->code = YYJSON_READ_ERROR_##_code; \
+        err->msg = _msg; \
+    } \
+    if (val_hdr) alc.free(alc.ctx, (void *)val_hdr); \
+    return NULL; \
+} while (false)
 
-#define return_err(_pos, _code, _msg)                                                                                  \
-	do {                                                                                                               \
-		if (_pos >= end) {                                                                                             \
-			err->pos = (usize)(end - hdr);                                                                             \
-			err->code = YYJSON_READ_ERROR_UNEXPECTED_END;                                                              \
-			err->msg = "unexpected end of data";                                                                       \
-		} else {                                                                                                       \
-			err->pos = (usize)(_pos - hdr);                                                                            \
-			err->code = YYJSON_READ_ERROR_##_code;                                                                     \
-			err->msg = _msg;                                                                                           \
-		}                                                                                                              \
-		if (val_hdr)                                                                                                   \
-			alc.free(alc.ctx, (void *)val_hdr);                                                                        \
-		return NULL;                                                                                                   \
-	} while (false)
+    usize hdr_len; /* value count used by doc */
+    usize alc_num; /* value count capacity */
+    yyjson_val *val_hdr; /* the head of allocated values */
+    yyjson_val *val; /* current value */
+    yyjson_doc *doc; /* the JSON document, equals to val_hdr */
+    const char *msg; /* error message */
 
-	usize hdr_len;       /* value count used by doc */
-	usize alc_num;       /* value count capacity */
-	yyjson_val *val_hdr; /* the head of allocated values */
-	yyjson_val *val;     /* current value */
-	yyjson_doc *doc;     /* the JSON document, equals to val_hdr */
-	const char *msg;     /* error message */
+    bool raw; /* read number as raw */
+    bool inv; /* allow invalid unicode */
+    u8 *raw_end; /* raw end for null-terminator */
+    u8 **pre; /* previous raw end pointer */
 
-	bool raw;    /* read number as raw */
-	bool ext;    /* allow inf and nan */
-	bool inv;    /* allow invalid unicode */
-	u8 *raw_end; /* raw end for null-terminator */
-	u8 **pre;    /* previous raw end pointer */
+    hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
+    hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
+    alc_num = hdr_len + 1; /* single value */
 
-	hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
-	hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
-	alc_num = hdr_len + 1; /* single value */
+    val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_num * sizeof(yyjson_val));
+    if (unlikely(!val_hdr)) goto fail_alloc;
+    val = val_hdr + hdr_len;
+    raw = has_read_flag(NUMBER_AS_RAW) || has_read_flag(BIGNUM_AS_RAW);
+    inv = has_read_flag(ALLOW_INVALID_UNICODE) != 0;
+    raw_end = NULL;
+    pre = raw ? &raw_end : NULL;
 
-	val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_num * sizeof(yyjson_val));
-	if (unlikely(!val_hdr))
-		goto fail_alloc;
-	val = val_hdr + hdr_len;
-	raw = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
-	ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
-	inv = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
-	raw_end = NULL;
-	pre = raw ? &raw_end : NULL;
-
-	if (char_is_number(*cur)) {
-		if (likely(read_number(&cur, pre, ext, val, &msg)))
-			goto doc_end;
-		goto fail_number;
-	}
-	if (*cur == '"') {
-		if (likely(read_string(&cur, end, inv, val, &msg)))
-			goto doc_end;
-		goto fail_string;
-	}
-	if (*cur == 't') {
-		if (likely(read_true(&cur, val)))
-			goto doc_end;
-		goto fail_literal;
-	}
-	if (*cur == 'f') {
-		if (likely(read_false(&cur, val)))
-			goto doc_end;
-		goto fail_literal;
-	}
-	if (*cur == 'n') {
-		if (likely(read_null(&cur, val)))
-			goto doc_end;
-		if (unlikely(ext)) {
-			if (read_nan(false, &cur, pre, val))
-				goto doc_end;
-		}
-		goto fail_literal;
-	}
-	if (unlikely(ext)) {
-		if (read_inf_or_nan(false, &cur, pre, val))
-			goto doc_end;
-	}
-	goto fail_character;
+    if (char_is_number(*cur)) {
+        if (likely(read_number(&cur, pre, flg, val, &msg))) goto doc_end;
+        goto fail_number;
+    }
+    if (*cur == '"') {
+        if (likely(read_string(&cur, end, inv, val, &msg))) goto doc_end;
+        goto fail_string;
+    }
+    if (*cur == 't') {
+        if (likely(read_true(&cur, val))) goto doc_end;
+        goto fail_literal;
+    }
+    if (*cur == 'f') {
+        if (likely(read_false(&cur, val))) goto doc_end;
+        goto fail_literal;
+    }
+    if (*cur == 'n') {
+        if (likely(read_null(&cur, val))) goto doc_end;
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (read_nan(false, &cur, pre, val)) goto doc_end;
+        }
+        goto fail_literal;
+    }
+    if (has_read_flag(ALLOW_INF_AND_NAN)) {
+        if (read_inf_or_nan(false, &cur, pre, val)) goto doc_end;
+    }
+    goto fail_character;
 
 doc_end:
-	/* check invalid contents after json document */
-	if (unlikely(cur < end) && !has_flag(STOP_WHEN_DONE)) {
-		if (has_flag(ALLOW_COMMENTS)) {
-			if (!skip_spaces_and_comments(&cur)) {
-				if (byte_match_2(cur, "/*"))
-					goto fail_comment;
-			}
-		} else {
-			while (char_is_space(*cur))
-				cur++;
-		}
-		if (unlikely(cur < end))
-			goto fail_garbage;
-	}
+    /* check invalid contents after json document */
+    if (unlikely(cur < end) && !has_read_flag(STOP_WHEN_DONE)) {
+        if (has_read_flag(ALLOW_COMMENTS)) {
+            if (!skip_spaces_and_comments(&cur)) {
+                if (byte_match_2(cur, "/*")) goto fail_comment;
+            }
+        } else {
+            while (char_is_space(*cur)) cur++;
+        }
+        if (unlikely(cur < end)) goto fail_garbage;
+    }
 
-	if (pre && *pre)
-		**pre = '\0';
-	doc = (yyjson_doc *)val_hdr;
-	doc->root = val_hdr + hdr_len;
-	doc->alc = alc;
-	doc->dat_read = (usize)(cur - hdr);
-	doc->val_read = 1;
-	doc->str_pool = has_flag(INSITU) ? NULL : (char *)hdr;
-	return doc;
+    if (pre && *pre) **pre = '\0';
+    doc = (yyjson_doc *)val_hdr;
+    doc->root = val_hdr + hdr_len;
+    doc->alc = alc;
+    doc->dat_read = (usize)(cur - hdr);
+    doc->val_read = 1;
+    doc->str_pool = has_read_flag(INSITU) ? NULL : (char *)hdr;
+    return doc;
 
 fail_string:
-	return_err(cur, INVALID_STRING, msg);
+    return_err(cur, INVALID_STRING, msg);
 fail_number:
-	return_err(cur, INVALID_NUMBER, msg);
+    return_err(cur, INVALID_NUMBER, msg);
 fail_alloc:
-	return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
+    return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
 fail_literal:
-	return_err(cur, LITERAL, "invalid literal");
+    return_err(cur, LITERAL, "invalid literal");
 fail_comment:
-	return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
+    return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
 fail_character:
-	return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
+    return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
 fail_garbage:
-	return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
+    return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
 
-#undef has_flag
 #undef return_err
 }
 
 /** Read JSON document (accept all style, but optimized for minify). */
-static_inline yyjson_doc *read_root_minify(u8 *hdr, u8 *cur, u8 *end, yyjson_alc alc, yyjson_read_flag flg,
+static_inline yyjson_doc *read_root_minify(u8 *hdr,
+                                           u8 *cur,
+                                           u8 *end,
+                                           yyjson_alc alc,
+                                           yyjson_read_flag flg,
                                            yyjson_read_err *err) {
 
-#define has_flag(_flag) unlikely((flg & YYJSON_READ_##_flag) != 0)
+#define return_err(_pos, _code, _msg) do { \
+    if (is_truncated_end(hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) { \
+        err->pos = (usize)(end - hdr); \
+        err->code = YYJSON_READ_ERROR_UNEXPECTED_END; \
+        err->msg = "unexpected end of data"; \
+    } else { \
+        err->pos = (usize)(_pos - hdr); \
+        err->code = YYJSON_READ_ERROR_##_code; \
+        err->msg = _msg; \
+    } \
+    if (val_hdr) alc.free(alc.ctx, (void *)val_hdr); \
+    return NULL; \
+} while (false)
 
-#define return_err(_pos, _code, _msg)                                                                                  \
-	do {                                                                                                               \
-		if (_pos >= end) {                                                                                             \
-			err->pos = (usize)(end - hdr);                                                                             \
-			err->code = YYJSON_READ_ERROR_UNEXPECTED_END;                                                              \
-			err->msg = "unexpected end of data";                                                                       \
-		} else {                                                                                                       \
-			err->pos = (usize)(_pos - hdr);                                                                            \
-			err->code = YYJSON_READ_ERROR_##_code;                                                                     \
-			err->msg = _msg;                                                                                           \
-		}                                                                                                              \
-		if (val_hdr)                                                                                                   \
-			alc.free(alc.ctx, (void *)val_hdr);                                                                        \
-		return NULL;                                                                                                   \
-	} while (false)
+#define val_incr() do { \
+    val++; \
+    if (unlikely(val >= val_end)) { \
+        usize alc_old = alc_len; \
+        alc_len += alc_len / 2; \
+        if ((sizeof(usize) < 8) && (alc_len >= alc_max)) goto fail_alloc; \
+        val_tmp = (yyjson_val *)alc.realloc(alc.ctx, (void *)val_hdr, \
+            alc_old * sizeof(yyjson_val), \
+            alc_len * sizeof(yyjson_val)); \
+        if ((!val_tmp)) goto fail_alloc; \
+        val = val_tmp + (usize)(val - val_hdr); \
+        ctn = val_tmp + (usize)(ctn - val_hdr); \
+        val_hdr = val_tmp; \
+        val_end = val_tmp + (alc_len - 2); \
+    } \
+} while (false)
 
-#define val_incr()                                                                                                     \
-	do {                                                                                                               \
-		val++;                                                                                                         \
-		if (unlikely(val >= val_end)) {                                                                                \
-			usize alc_old = alc_len;                                                                                   \
-			alc_len += alc_len / 2;                                                                                    \
-			if ((alc_len >= alc_max))                                                                                  \
-				goto fail_alloc;                                                                                       \
-			val_tmp = (yyjson_val *)alc.realloc(alc.ctx, (void *)val_hdr, alc_old * sizeof(yyjson_val),                \
-			                                    alc_len * sizeof(yyjson_val));                                         \
-			if ((!val_tmp))                                                                                            \
-				goto fail_alloc;                                                                                       \
-			val = val_tmp + (usize)(val - val_hdr);                                                                    \
-			ctn = val_tmp + (usize)(ctn - val_hdr);                                                                    \
-			val_hdr = val_tmp;                                                                                         \
-			val_end = val_tmp + (alc_len - 2);                                                                         \
-		}                                                                                                              \
-	} while (false)
+    usize dat_len; /* data length in bytes, hint for allocator */
+    usize hdr_len; /* value count used by yyjson_doc */
+    usize alc_len; /* value count allocated */
+    usize alc_max; /* maximum value count for allocator */
+    usize ctn_len; /* the number of elements in current container */
+    yyjson_val *val_hdr; /* the head of allocated values */
+    yyjson_val *val_end; /* the end of allocated values */
+    yyjson_val *val_tmp; /* temporary pointer for realloc */
+    yyjson_val *val; /* current JSON value */
+    yyjson_val *ctn; /* current container */
+    yyjson_val *ctn_parent; /* parent of current container */
+    yyjson_doc *doc; /* the JSON document, equals to val_hdr */
+    const char *msg; /* error message */
 
-	usize dat_len;          /* data length in bytes, hint for allocator */
-	usize hdr_len;          /* value count used by yyjson_doc */
-	usize alc_len;          /* value count allocated */
-	usize alc_max;          /* maximum value count for allocator */
-	usize ctn_len;          /* the number of elements in current container */
-	yyjson_val *val_hdr;    /* the head of allocated values */
-	yyjson_val *val_end;    /* the end of allocated values */
-	yyjson_val *val_tmp;    /* temporary pointer for realloc */
-	yyjson_val *val;        /* current JSON value */
-	yyjson_val *ctn;        /* current container */
-	yyjson_val *ctn_parent; /* parent of current container */
-	yyjson_doc *doc;        /* the JSON document, equals to val_hdr */
-	const char *msg;        /* error message */
+    bool raw; /* read number as raw */
+    bool inv; /* allow invalid unicode */
+    u8 *raw_end; /* raw end for null-terminator */
+    u8 **pre; /* previous raw end pointer */
 
-	bool raw;    /* read number as raw */
-	bool ext;    /* allow inf and nan */
-	bool inv;    /* allow invalid unicode */
-	u8 *raw_end; /* raw end for null-terminator */
-	u8 **pre;    /* previous raw end pointer */
+    dat_len = has_read_flag(STOP_WHEN_DONE) ? 256 : (usize)(end - cur);
+    hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
+    hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
+    alc_max = USIZE_MAX / sizeof(yyjson_val);
+    alc_len = hdr_len + (dat_len / YYJSON_READER_ESTIMATED_MINIFY_RATIO) + 4;
+    alc_len = yyjson_min(alc_len, alc_max);
 
-	dat_len = has_flag(STOP_WHEN_DONE) ? 256 : (usize)(end - cur);
-	hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
-	hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
-	alc_max = USIZE_MAX / sizeof(yyjson_val);
-	alc_len = hdr_len + (dat_len / YYJSON_READER_ESTIMATED_MINIFY_RATIO) + 4;
-	alc_len = yyjson_min(alc_len, alc_max);
+    val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_len * sizeof(yyjson_val));
+    if (unlikely(!val_hdr)) goto fail_alloc;
+    val_end = val_hdr + (alc_len - 2); /* padding for key-value pair reading */
+    val = val_hdr + hdr_len;
+    ctn = val;
+    ctn_len = 0;
+    raw = has_read_flag(NUMBER_AS_RAW) || has_read_flag(BIGNUM_AS_RAW);
+    inv = has_read_flag(ALLOW_INVALID_UNICODE) != 0;
+    raw_end = NULL;
+    pre = raw ? &raw_end : NULL;
 
-	val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_len * sizeof(yyjson_val));
-	if (unlikely(!val_hdr))
-		goto fail_alloc;
-	val_end = val_hdr + (alc_len - 2); /* padding for key-value pair reading */
-	val = val_hdr + hdr_len;
-	ctn = val;
-	ctn_len = 0;
-	raw = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
-	ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
-	inv = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
-	raw_end = NULL;
-	pre = raw ? &raw_end : NULL;
-
-	if (*cur++ == '{') {
-		ctn->tag = YYJSON_TYPE_OBJ;
-		ctn->uni.ofs = 0;
-		goto obj_key_begin;
-	} else {
-		ctn->tag = YYJSON_TYPE_ARR;
-		ctn->uni.ofs = 0;
-		goto arr_val_begin;
-	}
+    if (*cur++ == '{') {
+        ctn->tag = YYJSON_TYPE_OBJ;
+        ctn->uni.ofs = 0;
+        goto obj_key_begin;
+    } else {
+        ctn->tag = YYJSON_TYPE_ARR;
+        ctn->uni.ofs = 0;
+        goto arr_val_begin;
+    }
 
 arr_begin:
-	/* save current container */
-	ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) | (ctn->tag & YYJSON_TAG_MASK);
+    /* save current container */
+    ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
+               (ctn->tag & YYJSON_TAG_MASK);
 
-	/* create a new array value, save parent container offset */
-	val_incr();
-	val->tag = YYJSON_TYPE_ARR;
-	val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
+    /* create a new array value, save parent container offset */
+    val_incr();
+    val->tag = YYJSON_TYPE_ARR;
+    val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
 
-	/* push the new array value as current container */
-	ctn = val;
-	ctn_len = 0;
+    /* push the new array value as current container */
+    ctn = val;
+    ctn_len = 0;
 
 arr_val_begin:
-	if (*cur == '{') {
-		cur++;
-		goto obj_begin;
-	}
-	if (*cur == '[') {
-		cur++;
-		goto arr_begin;
-	}
-	if (char_is_number(*cur)) {
-		val_incr();
-		ctn_len++;
-		if (likely(read_number(&cur, pre, ext, val, &msg)))
-			goto arr_val_end;
-		goto fail_number;
-	}
-	if (*cur == '"') {
-		val_incr();
-		ctn_len++;
-		if (likely(read_string(&cur, end, inv, val, &msg)))
-			goto arr_val_end;
-		goto fail_string;
-	}
-	if (*cur == 't') {
-		val_incr();
-		ctn_len++;
-		if (likely(read_true(&cur, val)))
-			goto arr_val_end;
-		goto fail_literal;
-	}
-	if (*cur == 'f') {
-		val_incr();
-		ctn_len++;
-		if (likely(read_false(&cur, val)))
-			goto arr_val_end;
-		goto fail_literal;
-	}
-	if (*cur == 'n') {
-		val_incr();
-		ctn_len++;
-		if (likely(read_null(&cur, val)))
-			goto arr_val_end;
-		if (unlikely(ext)) {
-			if (read_nan(false, &cur, pre, val))
-				goto arr_val_end;
-		}
-		goto fail_literal;
-	}
-	if (*cur == ']') {
-		cur++;
-		if (likely(ctn_len == 0))
-			goto arr_end;
-		if (has_flag(ALLOW_TRAILING_COMMAS))
-			goto arr_end;
-		cur--;
-		goto fail_trailing_comma;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto arr_val_begin;
-	}
-	if (unlikely(ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
-		val_incr();
-		ctn_len++;
-		if (read_inf_or_nan(false, &cur, pre, val))
-			goto arr_val_end;
-		goto fail_character;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto arr_val_begin;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (*cur == '{') {
+        cur++;
+        goto obj_begin;
+    }
+    if (*cur == '[') {
+        cur++;
+        goto arr_begin;
+    }
+    if (char_is_number(*cur)) {
+        val_incr();
+        ctn_len++;
+        if (likely(read_number(&cur, pre, flg, val, &msg))) goto arr_val_end;
+        goto fail_number;
+    }
+    if (*cur == '"') {
+        val_incr();
+        ctn_len++;
+        if (likely(read_string(&cur, end, inv, val, &msg))) goto arr_val_end;
+        goto fail_string;
+    }
+    if (*cur == 't') {
+        val_incr();
+        ctn_len++;
+        if (likely(read_true(&cur, val))) goto arr_val_end;
+        goto fail_literal;
+    }
+    if (*cur == 'f') {
+        val_incr();
+        ctn_len++;
+        if (likely(read_false(&cur, val))) goto arr_val_end;
+        goto fail_literal;
+    }
+    if (*cur == 'n') {
+        val_incr();
+        ctn_len++;
+        if (likely(read_null(&cur, val))) goto arr_val_end;
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (read_nan(false, &cur, pre, val)) goto arr_val_end;
+        }
+        goto fail_literal;
+    }
+    if (*cur == ']') {
+        cur++;
+        if (likely(ctn_len == 0)) goto arr_end;
+        if (has_read_flag(ALLOW_TRAILING_COMMAS)) goto arr_end;
+        while (*cur != ',') cur--;
+        goto fail_trailing_comma;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto arr_val_begin;
+    }
+    if (has_read_flag(ALLOW_INF_AND_NAN) &&
+        (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
+        val_incr();
+        ctn_len++;
+        if (read_inf_or_nan(false, &cur, pre, val)) goto arr_val_end;
+        goto fail_character;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto arr_val_begin;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 arr_val_end:
-	if (*cur == ',') {
-		cur++;
-		goto arr_val_begin;
-	}
-	if (*cur == ']') {
-		cur++;
-		goto arr_end;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto arr_val_end;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto arr_val_end;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (*cur == ',') {
+        cur++;
+        goto arr_val_begin;
+    }
+    if (*cur == ']') {
+        cur++;
+        goto arr_end;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto arr_val_end;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto arr_val_end;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 arr_end:
-	/* get parent container */
-	ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
+    /* get parent container */
+    ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
 
-	/* save the next sibling value offset */
-	ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
-	ctn->tag = ((ctn_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;
-	if (unlikely(ctn == ctn_parent))
-		goto doc_end;
+    /* save the next sibling value offset */
+    ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
+    ctn->tag = ((ctn_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;
+    if (unlikely(ctn == ctn_parent)) goto doc_end;
 
-	/* pop parent as current container */
-	ctn = ctn_parent;
-	ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
-	if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
-		goto obj_val_end;
-	} else {
-		goto arr_val_end;
-	}
+    /* pop parent as current container */
+    ctn = ctn_parent;
+    ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
+    if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
+        goto obj_val_end;
+    } else {
+        goto arr_val_end;
+    }
 
 obj_begin:
-	/* push container */
-	ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) | (ctn->tag & YYJSON_TAG_MASK);
-	val_incr();
-	val->tag = YYJSON_TYPE_OBJ;
-	/* offset to the parent */
-	val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
-	ctn = val;
-	ctn_len = 0;
+    /* push container */
+    ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
+               (ctn->tag & YYJSON_TAG_MASK);
+    val_incr();
+    val->tag = YYJSON_TYPE_OBJ;
+    /* offset to the parent */
+    val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
+    ctn = val;
+    ctn_len = 0;
 
 obj_key_begin:
-	if (likely(*cur == '"')) {
-		val_incr();
-		ctn_len++;
-		if (likely(read_string(&cur, end, inv, val, &msg)))
-			goto obj_key_end;
-		goto fail_string;
-	}
-	if (likely(*cur == '}')) {
-		cur++;
-		if (likely(ctn_len == 0))
-			goto obj_end;
-		if (has_flag(ALLOW_TRAILING_COMMAS))
-			goto obj_end;
-		cur--;
-		goto fail_trailing_comma;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto obj_key_begin;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto obj_key_begin;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (likely(*cur == '"')) {
+        val_incr();
+        ctn_len++;
+        if (likely(read_string(&cur, end, inv, val, &msg))) goto obj_key_end;
+        goto fail_string;
+    }
+    if (likely(*cur == '}')) {
+        cur++;
+        if (likely(ctn_len == 0)) goto obj_end;
+        if (has_read_flag(ALLOW_TRAILING_COMMAS)) goto obj_end;
+        while (*cur != ',') cur--;
+        goto fail_trailing_comma;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto obj_key_begin;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto obj_key_begin;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 obj_key_end:
-	if (*cur == ':') {
-		cur++;
-		goto obj_val_begin;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto obj_key_end;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto obj_key_end;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (*cur == ':') {
+        cur++;
+        goto obj_val_begin;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto obj_key_end;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto obj_key_end;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 obj_val_begin:
-	if (*cur == '"') {
-		val++;
-		ctn_len++;
-		if (likely(read_string(&cur, end, inv, val, &msg)))
-			goto obj_val_end;
-		goto fail_string;
-	}
-	if (char_is_number(*cur)) {
-		val++;
-		ctn_len++;
-		if (likely(read_number(&cur, pre, ext, val, &msg)))
-			goto obj_val_end;
-		goto fail_number;
-	}
-	if (*cur == '{') {
-		cur++;
-		goto obj_begin;
-	}
-	if (*cur == '[') {
-		cur++;
-		goto arr_begin;
-	}
-	if (*cur == 't') {
-		val++;
-		ctn_len++;
-		if (likely(read_true(&cur, val)))
-			goto obj_val_end;
-		goto fail_literal;
-	}
-	if (*cur == 'f') {
-		val++;
-		ctn_len++;
-		if (likely(read_false(&cur, val)))
-			goto obj_val_end;
-		goto fail_literal;
-	}
-	if (*cur == 'n') {
-		val++;
-		ctn_len++;
-		if (likely(read_null(&cur, val)))
-			goto obj_val_end;
-		if (unlikely(ext)) {
-			if (read_nan(false, &cur, pre, val))
-				goto obj_val_end;
-		}
-		goto fail_literal;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto obj_val_begin;
-	}
-	if (unlikely(ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
-		val++;
-		ctn_len++;
-		if (read_inf_or_nan(false, &cur, pre, val))
-			goto obj_val_end;
-		goto fail_character;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto obj_val_begin;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (*cur == '"') {
+        val++;
+        ctn_len++;
+        if (likely(read_string(&cur, end, inv, val, &msg))) goto obj_val_end;
+        goto fail_string;
+    }
+    if (char_is_number(*cur)) {
+        val++;
+        ctn_len++;
+        if (likely(read_number(&cur, pre, flg, val, &msg))) goto obj_val_end;
+        goto fail_number;
+    }
+    if (*cur == '{') {
+        cur++;
+        goto obj_begin;
+    }
+    if (*cur == '[') {
+        cur++;
+        goto arr_begin;
+    }
+    if (*cur == 't') {
+        val++;
+        ctn_len++;
+        if (likely(read_true(&cur, val))) goto obj_val_end;
+        goto fail_literal;
+    }
+    if (*cur == 'f') {
+        val++;
+        ctn_len++;
+        if (likely(read_false(&cur, val))) goto obj_val_end;
+        goto fail_literal;
+    }
+    if (*cur == 'n') {
+        val++;
+        ctn_len++;
+        if (likely(read_null(&cur, val))) goto obj_val_end;
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (read_nan(false, &cur, pre, val)) goto obj_val_end;
+        }
+        goto fail_literal;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto obj_val_begin;
+    }
+    if (has_read_flag(ALLOW_INF_AND_NAN) &&
+        (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
+        val++;
+        ctn_len++;
+        if (read_inf_or_nan(false, &cur, pre, val)) goto obj_val_end;
+        goto fail_character;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto obj_val_begin;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 obj_val_end:
-	if (likely(*cur == ',')) {
-		cur++;
-		goto obj_key_begin;
-	}
-	if (likely(*cur == '}')) {
-		cur++;
-		goto obj_end;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto obj_val_end;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto obj_val_end;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (likely(*cur == ',')) {
+        cur++;
+        goto obj_key_begin;
+    }
+    if (likely(*cur == '}')) {
+        cur++;
+        goto obj_end;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto obj_val_end;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto obj_val_end;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 obj_end:
-	/* pop container */
-	ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
-	/* point to the next value */
-	ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
-	ctn->tag = (ctn_len << (YYJSON_TAG_BIT - 1)) | YYJSON_TYPE_OBJ;
-	if (unlikely(ctn == ctn_parent))
-		goto doc_end;
-	ctn = ctn_parent;
-	ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
-	if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
-		goto obj_val_end;
-	} else {
-		goto arr_val_end;
-	}
+    /* pop container */
+    ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
+    /* point to the next value */
+    ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
+    ctn->tag = (ctn_len << (YYJSON_TAG_BIT - 1)) | YYJSON_TYPE_OBJ;
+    if (unlikely(ctn == ctn_parent)) goto doc_end;
+    ctn = ctn_parent;
+    ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
+    if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
+        goto obj_val_end;
+    } else {
+        goto arr_val_end;
+    }
 
 doc_end:
-	/* check invalid contents after json document */
-	if (unlikely(cur < end) && !has_flag(STOP_WHEN_DONE)) {
-		if (has_flag(ALLOW_COMMENTS)) {
-			skip_spaces_and_comments(&cur);
-			if (byte_match_2(cur, "/*"))
-				goto fail_comment;
-		} else
-			while (char_is_space(*cur))
-				cur++;
-		if (unlikely(cur < end))
-			goto fail_garbage;
-	}
+    /* check invalid contents after json document */
+    if (unlikely(cur < end) && !has_read_flag(STOP_WHEN_DONE)) {
+        if (has_read_flag(ALLOW_COMMENTS)) {
+            skip_spaces_and_comments(&cur);
+            if (byte_match_2(cur, "/*")) goto fail_comment;
+        } else {
+            while (char_is_space(*cur)) cur++;
+        }
+        if (unlikely(cur < end)) goto fail_garbage;
+    }
 
-	if (pre && *pre)
-		**pre = '\0';
-	doc = (yyjson_doc *)val_hdr;
-	doc->root = val_hdr + hdr_len;
-	doc->alc = alc;
-	doc->dat_read = (usize)(cur - hdr);
-	doc->val_read = (usize)((val - doc->root) + 1);
-	doc->str_pool = has_flag(INSITU) ? NULL : (char *)hdr;
-	return doc;
+    if (pre && *pre) **pre = '\0';
+    doc = (yyjson_doc *)val_hdr;
+    doc->root = val_hdr + hdr_len;
+    doc->alc = alc;
+    doc->dat_read = (usize)(cur - hdr);
+    doc->val_read = (usize)((val - doc->root) + 1);
+    doc->str_pool = has_read_flag(INSITU) ? NULL : (char *)hdr;
+    return doc;
 
 fail_string:
-	return_err(cur, INVALID_STRING, msg);
+    return_err(cur, INVALID_STRING, msg);
 fail_number:
-	return_err(cur, INVALID_NUMBER, msg);
+    return_err(cur, INVALID_NUMBER, msg);
 fail_alloc:
-	return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
+    return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
 fail_trailing_comma:
-	return_err(cur, JSON_STRUCTURE, "trailing comma is not allowed");
+    return_err(cur, JSON_STRUCTURE, "trailing comma is not allowed");
 fail_literal:
-	return_err(cur, LITERAL, "invalid literal");
+    return_err(cur, LITERAL, "invalid literal");
 fail_comment:
-	return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
+    return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
 fail_character:
-	return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
+    return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
 fail_garbage:
-	return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
+    return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
 
-#undef has_flag
 #undef val_incr
 #undef return_err
 }
 
 /** Read JSON document (accept all style, but optimized for pretty). */
-static_inline yyjson_doc *read_root_pretty(u8 *hdr, u8 *cur, u8 *end, yyjson_alc alc, yyjson_read_flag flg,
+static_inline yyjson_doc *read_root_pretty(u8 *hdr,
+                                           u8 *cur,
+                                           u8 *end,
+                                           yyjson_alc alc,
+                                           yyjson_read_flag flg,
                                            yyjson_read_err *err) {
 
-#define has_flag(_flag) unlikely((flg & YYJSON_READ_##_flag) != 0)
+#define return_err(_pos, _code, _msg) do { \
+    if (is_truncated_end(hdr, _pos, end, YYJSON_READ_ERROR_##_code, flg)) { \
+        err->pos = (usize)(end - hdr); \
+        err->code = YYJSON_READ_ERROR_UNEXPECTED_END; \
+        err->msg = "unexpected end of data"; \
+    } else { \
+        err->pos = (usize)(_pos - hdr); \
+        err->code = YYJSON_READ_ERROR_##_code; \
+        err->msg = _msg; \
+    } \
+    if (val_hdr) alc.free(alc.ctx, (void *)val_hdr); \
+    return NULL; \
+} while (false)
 
-#define return_err(_pos, _code, _msg)                                                                                  \
-	do {                                                                                                               \
-		if (_pos >= end) {                                                                                             \
-			err->pos = (usize)(end - hdr);                                                                             \
-			err->code = YYJSON_READ_ERROR_UNEXPECTED_END;                                                              \
-			err->msg = "unexpected end of data";                                                                       \
-		} else {                                                                                                       \
-			err->pos = (usize)(_pos - hdr);                                                                            \
-			err->code = YYJSON_READ_ERROR_##_code;                                                                     \
-			err->msg = _msg;                                                                                           \
-		}                                                                                                              \
-		if (val_hdr)                                                                                                   \
-			alc.free(alc.ctx, (void *)val_hdr);                                                                        \
-		return NULL;                                                                                                   \
-	} while (false)
+#define val_incr() do { \
+    val++; \
+    if (unlikely(val >= val_end)) { \
+        usize alc_old = alc_len; \
+        alc_len += alc_len / 2; \
+        if ((sizeof(usize) < 8) && (alc_len >= alc_max)) goto fail_alloc; \
+        val_tmp = (yyjson_val *)alc.realloc(alc.ctx, (void *)val_hdr, \
+            alc_old * sizeof(yyjson_val), \
+            alc_len * sizeof(yyjson_val)); \
+        if ((!val_tmp)) goto fail_alloc; \
+        val = val_tmp + (usize)(val - val_hdr); \
+        ctn = val_tmp + (usize)(ctn - val_hdr); \
+        val_hdr = val_tmp; \
+        val_end = val_tmp + (alc_len - 2); \
+    } \
+} while (false)
 
-#define val_incr()                                                                                                     \
-	do {                                                                                                               \
-		val++;                                                                                                         \
-		if (unlikely(val >= val_end)) {                                                                                \
-			usize alc_old = alc_len;                                                                                   \
-			alc_len += alc_len / 2;                                                                                    \
-			if ((alc_len >= alc_max))                                                                                  \
-				goto fail_alloc;                                                                                       \
-			val_tmp = (yyjson_val *)alc.realloc(alc.ctx, (void *)val_hdr, alc_old * sizeof(yyjson_val),                \
-			                                    alc_len * sizeof(yyjson_val));                                         \
-			if ((!val_tmp))                                                                                            \
-				goto fail_alloc;                                                                                       \
-			val = val_tmp + (usize)(val - val_hdr);                                                                    \
-			ctn = val_tmp + (usize)(ctn - val_hdr);                                                                    \
-			val_hdr = val_tmp;                                                                                         \
-			val_end = val_tmp + (alc_len - 2);                                                                         \
-		}                                                                                                              \
-	} while (false)
+    usize dat_len; /* data length in bytes, hint for allocator */
+    usize hdr_len; /* value count used by yyjson_doc */
+    usize alc_len; /* value count allocated */
+    usize alc_max; /* maximum value count for allocator */
+    usize ctn_len; /* the number of elements in current container */
+    yyjson_val *val_hdr; /* the head of allocated values */
+    yyjson_val *val_end; /* the end of allocated values */
+    yyjson_val *val_tmp; /* temporary pointer for realloc */
+    yyjson_val *val; /* current JSON value */
+    yyjson_val *ctn; /* current container */
+    yyjson_val *ctn_parent; /* parent of current container */
+    yyjson_doc *doc; /* the JSON document, equals to val_hdr */
+    const char *msg; /* error message */
 
-	usize dat_len;          /* data length in bytes, hint for allocator */
-	usize hdr_len;          /* value count used by yyjson_doc */
-	usize alc_len;          /* value count allocated */
-	usize alc_max;          /* maximum value count for allocator */
-	usize ctn_len;          /* the number of elements in current container */
-	yyjson_val *val_hdr;    /* the head of allocated values */
-	yyjson_val *val_end;    /* the end of allocated values */
-	yyjson_val *val_tmp;    /* temporary pointer for realloc */
-	yyjson_val *val;        /* current JSON value */
-	yyjson_val *ctn;        /* current container */
-	yyjson_val *ctn_parent; /* parent of current container */
-	yyjson_doc *doc;        /* the JSON document, equals to val_hdr */
-	const char *msg;        /* error message */
+    bool raw; /* read number as raw */
+    bool inv; /* allow invalid unicode */
+    u8 *raw_end; /* raw end for null-terminator */
+    u8 **pre; /* previous raw end pointer */
 
-	bool raw;    /* read number as raw */
-	bool ext;    /* allow inf and nan */
-	bool inv;    /* allow invalid unicode */
-	u8 *raw_end; /* raw end for null-terminator */
-	u8 **pre;    /* previous raw end pointer */
+    dat_len = has_read_flag(STOP_WHEN_DONE) ? 256 : (usize)(end - cur);
+    hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
+    hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
+    alc_max = USIZE_MAX / sizeof(yyjson_val);
+    alc_len = hdr_len + (dat_len / YYJSON_READER_ESTIMATED_PRETTY_RATIO) + 4;
+    alc_len = yyjson_min(alc_len, alc_max);
 
-	dat_len = has_flag(STOP_WHEN_DONE) ? 256 : (usize)(end - cur);
-	hdr_len = sizeof(yyjson_doc) / sizeof(yyjson_val);
-	hdr_len += (sizeof(yyjson_doc) % sizeof(yyjson_val)) > 0;
-	alc_max = USIZE_MAX / sizeof(yyjson_val);
-	alc_len = hdr_len + (dat_len / YYJSON_READER_ESTIMATED_PRETTY_RATIO) + 4;
-	alc_len = yyjson_min(alc_len, alc_max);
+    val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_len * sizeof(yyjson_val));
+    if (unlikely(!val_hdr)) goto fail_alloc;
+    val_end = val_hdr + (alc_len - 2); /* padding for key-value pair reading */
+    val = val_hdr + hdr_len;
+    ctn = val;
+    ctn_len = 0;
+    raw = has_read_flag(NUMBER_AS_RAW) || has_read_flag(BIGNUM_AS_RAW);
+    inv = has_read_flag(ALLOW_INVALID_UNICODE) != 0;
+    raw_end = NULL;
+    pre = raw ? &raw_end : NULL;
 
-	val_hdr = (yyjson_val *)alc.malloc(alc.ctx, alc_len * sizeof(yyjson_val));
-	if (unlikely(!val_hdr))
-		goto fail_alloc;
-	val_end = val_hdr + (alc_len - 2); /* padding for key-value pair reading */
-	val = val_hdr + hdr_len;
-	ctn = val;
-	ctn_len = 0;
-	raw = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
-	ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
-	inv = (flg & YYJSON_READ_ALLOW_INVALID_UNICODE) != 0;
-	raw_end = NULL;
-	pre = raw ? &raw_end : NULL;
-
-	if (*cur++ == '{') {
-		ctn->tag = YYJSON_TYPE_OBJ;
-		ctn->uni.ofs = 0;
-		if (*cur == '\n')
-			cur++;
-		goto obj_key_begin;
-	} else {
-		ctn->tag = YYJSON_TYPE_ARR;
-		ctn->uni.ofs = 0;
-		if (*cur == '\n')
-			cur++;
-		goto arr_val_begin;
-	}
+    if (*cur++ == '{') {
+        ctn->tag = YYJSON_TYPE_OBJ;
+        ctn->uni.ofs = 0;
+        if (*cur == '\n') cur++;
+        goto obj_key_begin;
+    } else {
+        ctn->tag = YYJSON_TYPE_ARR;
+        ctn->uni.ofs = 0;
+        if (*cur == '\n') cur++;
+        goto arr_val_begin;
+    }
 
 arr_begin:
-	/* save current container */
-	ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) | (ctn->tag & YYJSON_TAG_MASK);
+    /* save current container */
+    ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
+               (ctn->tag & YYJSON_TAG_MASK);
 
-	/* create a new array value, save parent container offset */
-	val_incr();
-	val->tag = YYJSON_TYPE_ARR;
-	val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
+    /* create a new array value, save parent container offset */
+    val_incr();
+    val->tag = YYJSON_TYPE_ARR;
+    val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
 
-	/* push the new array value as current container */
-	ctn = val;
-	ctn_len = 0;
-	if (*cur == '\n')
-		cur++;
+    /* push the new array value as current container */
+    ctn = val;
+    ctn_len = 0;
+    if (*cur == '\n') cur++;
 
 arr_val_begin:
 #if YYJSON_IS_REAL_GCC
-	while (true)
-		repeat16({
-			if (byte_match_2(cur, "  "))
-				cur += 2;
-			else
-				break;
-		});
+    while (true) repeat16({
+        if (byte_match_2(cur, "  ")) cur += 2;
+        else break;
+    })
 #else
-	while (true)
-		repeat16({
-			if (likely(byte_match_2(cur, "  ")))
-				cur += 2;
-			else
-				break;
-		});
+    while (true) repeat16({
+        if (likely(byte_match_2(cur, "  "))) cur += 2;
+        else break;
+    })
 #endif
 
-	if (*cur == '{') {
-		cur++;
-		goto obj_begin;
-	}
-	if (*cur == '[') {
-		cur++;
-		goto arr_begin;
-	}
-	if (char_is_number(*cur)) {
-		val_incr();
-		ctn_len++;
-		if (likely(read_number(&cur, pre, ext, val, &msg)))
-			goto arr_val_end;
-		goto fail_number;
-	}
-	if (*cur == '"') {
-		val_incr();
-		ctn_len++;
-		if (likely(read_string(&cur, end, inv, val, &msg)))
-			goto arr_val_end;
-		goto fail_string;
-	}
-	if (*cur == 't') {
-		val_incr();
-		ctn_len++;
-		if (likely(read_true(&cur, val)))
-			goto arr_val_end;
-		goto fail_literal;
-	}
-	if (*cur == 'f') {
-		val_incr();
-		ctn_len++;
-		if (likely(read_false(&cur, val)))
-			goto arr_val_end;
-		goto fail_literal;
-	}
-	if (*cur == 'n') {
-		val_incr();
-		ctn_len++;
-		if (likely(read_null(&cur, val)))
-			goto arr_val_end;
-		if (unlikely(ext)) {
-			if (read_nan(false, &cur, pre, val))
-				goto arr_val_end;
-		}
-		goto fail_literal;
-	}
-	if (*cur == ']') {
-		cur++;
-		if (likely(ctn_len == 0))
-			goto arr_end;
-		if (has_flag(ALLOW_TRAILING_COMMAS))
-			goto arr_end;
-		cur--;
-		goto fail_trailing_comma;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto arr_val_begin;
-	}
-	if (unlikely(ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
-		val_incr();
-		ctn_len++;
-		if (read_inf_or_nan(false, &cur, pre, val))
-			goto arr_val_end;
-		goto fail_character;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto arr_val_begin;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (*cur == '{') {
+        cur++;
+        goto obj_begin;
+    }
+    if (*cur == '[') {
+        cur++;
+        goto arr_begin;
+    }
+    if (char_is_number(*cur)) {
+        val_incr();
+        ctn_len++;
+        if (likely(read_number(&cur, pre, flg, val, &msg))) goto arr_val_end;
+        goto fail_number;
+    }
+    if (*cur == '"') {
+        val_incr();
+        ctn_len++;
+        if (likely(read_string(&cur, end, inv, val, &msg))) goto arr_val_end;
+        goto fail_string;
+    }
+    if (*cur == 't') {
+        val_incr();
+        ctn_len++;
+        if (likely(read_true(&cur, val))) goto arr_val_end;
+        goto fail_literal;
+    }
+    if (*cur == 'f') {
+        val_incr();
+        ctn_len++;
+        if (likely(read_false(&cur, val))) goto arr_val_end;
+        goto fail_literal;
+    }
+    if (*cur == 'n') {
+        val_incr();
+        ctn_len++;
+        if (likely(read_null(&cur, val))) goto arr_val_end;
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (read_nan(false, &cur, pre, val)) goto arr_val_end;
+        }
+        goto fail_literal;
+    }
+    if (*cur == ']') {
+        cur++;
+        if (likely(ctn_len == 0)) goto arr_end;
+        if (has_read_flag(ALLOW_TRAILING_COMMAS)) goto arr_end;
+        while (*cur != ',') cur--;
+        goto fail_trailing_comma;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto arr_val_begin;
+    }
+    if (has_read_flag(ALLOW_INF_AND_NAN) &&
+        (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
+        val_incr();
+        ctn_len++;
+        if (read_inf_or_nan(false, &cur, pre, val)) goto arr_val_end;
+        goto fail_character;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto arr_val_begin;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 arr_val_end:
-	if (byte_match_2(cur, ",\n")) {
-		cur += 2;
-		goto arr_val_begin;
-	}
-	if (*cur == ',') {
-		cur++;
-		goto arr_val_begin;
-	}
-	if (*cur == ']') {
-		cur++;
-		goto arr_end;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto arr_val_end;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto arr_val_end;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (byte_match_2(cur, ",\n")) {
+        cur += 2;
+        goto arr_val_begin;
+    }
+    if (*cur == ',') {
+        cur++;
+        goto arr_val_begin;
+    }
+    if (*cur == ']') {
+        cur++;
+        goto arr_end;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto arr_val_end;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto arr_val_end;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 arr_end:
-	/* get parent container */
-	ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
+    /* get parent container */
+    ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
 
-	/* save the next sibling value offset */
-	ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
-	ctn->tag = ((ctn_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;
-	if (unlikely(ctn == ctn_parent))
-		goto doc_end;
+    /* save the next sibling value offset */
+    ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
+    ctn->tag = ((ctn_len) << YYJSON_TAG_BIT) | YYJSON_TYPE_ARR;
+    if (unlikely(ctn == ctn_parent)) goto doc_end;
 
-	/* pop parent as current container */
-	ctn = ctn_parent;
-	ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
-	if (*cur == '\n')
-		cur++;
-	if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
-		goto obj_val_end;
-	} else {
-		goto arr_val_end;
-	}
+    /* pop parent as current container */
+    ctn = ctn_parent;
+    ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
+    if (*cur == '\n') cur++;
+    if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
+        goto obj_val_end;
+    } else {
+        goto arr_val_end;
+    }
 
 obj_begin:
-	/* push container */
-	ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) | (ctn->tag & YYJSON_TAG_MASK);
-	val_incr();
-	val->tag = YYJSON_TYPE_OBJ;
-	/* offset to the parent */
-	val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
-	ctn = val;
-	ctn_len = 0;
-	if (*cur == '\n')
-		cur++;
+    /* push container */
+    ctn->tag = (((u64)ctn_len + 1) << YYJSON_TAG_BIT) |
+               (ctn->tag & YYJSON_TAG_MASK);
+    val_incr();
+    val->tag = YYJSON_TYPE_OBJ;
+    /* offset to the parent */
+    val->uni.ofs = (usize)((u8 *)val - (u8 *)ctn);
+    ctn = val;
+    ctn_len = 0;
+    if (*cur == '\n') cur++;
 
 obj_key_begin:
 #if YYJSON_IS_REAL_GCC
-	while (true)
-		repeat16({
-			if (byte_match_2(cur, "  "))
-				cur += 2;
-			else
-				break;
-		});
+    while (true) repeat16({
+        if (byte_match_2(cur, "  ")) cur += 2;
+        else break;
+    })
 #else
-	while (true)
-		repeat16({
-			if (likely(byte_match_2(cur, "  ")))
-				cur += 2;
-			else
-				break;
-		});
+    while (true) repeat16({
+        if (likely(byte_match_2(cur, "  "))) cur += 2;
+        else break;
+    })
 #endif
-	if (likely(*cur == '"')) {
-		val_incr();
-		ctn_len++;
-		if (likely(read_string(&cur, end, inv, val, &msg)))
-			goto obj_key_end;
-		goto fail_string;
-	}
-	if (likely(*cur == '}')) {
-		cur++;
-		if (likely(ctn_len == 0))
-			goto obj_end;
-		if (has_flag(ALLOW_TRAILING_COMMAS))
-			goto obj_end;
-		cur--;
-		goto fail_trailing_comma;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto obj_key_begin;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto obj_key_begin;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (likely(*cur == '"')) {
+        val_incr();
+        ctn_len++;
+        if (likely(read_string(&cur, end, inv, val, &msg))) goto obj_key_end;
+        goto fail_string;
+    }
+    if (likely(*cur == '}')) {
+        cur++;
+        if (likely(ctn_len == 0)) goto obj_end;
+        if (has_read_flag(ALLOW_TRAILING_COMMAS)) goto obj_end;
+        while (*cur != ',') cur--;
+        goto fail_trailing_comma;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto obj_key_begin;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto obj_key_begin;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 obj_key_end:
-	if (byte_match_2(cur, ": ")) {
-		cur += 2;
-		goto obj_val_begin;
-	}
-	if (*cur == ':') {
-		cur++;
-		goto obj_val_begin;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto obj_key_end;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto obj_key_end;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (byte_match_2(cur, ": ")) {
+        cur += 2;
+        goto obj_val_begin;
+    }
+    if (*cur == ':') {
+        cur++;
+        goto obj_val_begin;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto obj_key_end;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto obj_key_end;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 obj_val_begin:
-	if (*cur == '"') {
-		val++;
-		ctn_len++;
-		if (likely(read_string(&cur, end, inv, val, &msg)))
-			goto obj_val_end;
-		goto fail_string;
-	}
-	if (char_is_number(*cur)) {
-		val++;
-		ctn_len++;
-		if (likely(read_number(&cur, pre, ext, val, &msg)))
-			goto obj_val_end;
-		goto fail_number;
-	}
-	if (*cur == '{') {
-		cur++;
-		goto obj_begin;
-	}
-	if (*cur == '[') {
-		cur++;
-		goto arr_begin;
-	}
-	if (*cur == 't') {
-		val++;
-		ctn_len++;
-		if (likely(read_true(&cur, val)))
-			goto obj_val_end;
-		goto fail_literal;
-	}
-	if (*cur == 'f') {
-		val++;
-		ctn_len++;
-		if (likely(read_false(&cur, val)))
-			goto obj_val_end;
-		goto fail_literal;
-	}
-	if (*cur == 'n') {
-		val++;
-		ctn_len++;
-		if (likely(read_null(&cur, val)))
-			goto obj_val_end;
-		if (unlikely(ext)) {
-			if (read_nan(false, &cur, pre, val))
-				goto obj_val_end;
-		}
-		goto fail_literal;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto obj_val_begin;
-	}
-	if (unlikely(ext) && (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
-		val++;
-		ctn_len++;
-		if (read_inf_or_nan(false, &cur, pre, val))
-			goto obj_val_end;
-		goto fail_character;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto obj_val_begin;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (*cur == '"') {
+        val++;
+        ctn_len++;
+        if (likely(read_string(&cur, end, inv, val, &msg))) goto obj_val_end;
+        goto fail_string;
+    }
+    if (char_is_number(*cur)) {
+        val++;
+        ctn_len++;
+        if (likely(read_number(&cur, pre, flg, val, &msg))) goto obj_val_end;
+        goto fail_number;
+    }
+    if (*cur == '{') {
+        cur++;
+        goto obj_begin;
+    }
+    if (*cur == '[') {
+        cur++;
+        goto arr_begin;
+    }
+    if (*cur == 't') {
+        val++;
+        ctn_len++;
+        if (likely(read_true(&cur, val))) goto obj_val_end;
+        goto fail_literal;
+    }
+    if (*cur == 'f') {
+        val++;
+        ctn_len++;
+        if (likely(read_false(&cur, val))) goto obj_val_end;
+        goto fail_literal;
+    }
+    if (*cur == 'n') {
+        val++;
+        ctn_len++;
+        if (likely(read_null(&cur, val))) goto obj_val_end;
+        if (has_read_flag(ALLOW_INF_AND_NAN)) {
+            if (read_nan(false, &cur, pre, val)) goto obj_val_end;
+        }
+        goto fail_literal;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto obj_val_begin;
+    }
+    if (has_read_flag(ALLOW_INF_AND_NAN) &&
+        (*cur == 'i' || *cur == 'I' || *cur == 'N')) {
+        val++;
+        ctn_len++;
+        if (read_inf_or_nan(false, &cur, pre, val)) goto obj_val_end;
+        goto fail_character;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto obj_val_begin;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 obj_val_end:
-	if (byte_match_2(cur, ",\n")) {
-		cur += 2;
-		goto obj_key_begin;
-	}
-	if (likely(*cur == ',')) {
-		cur++;
-		goto obj_key_begin;
-	}
-	if (likely(*cur == '}')) {
-		cur++;
-		goto obj_end;
-	}
-	if (char_is_space(*cur)) {
-		while (char_is_space(*++cur))
-			;
-		goto obj_val_end;
-	}
-	if (has_flag(ALLOW_COMMENTS)) {
-		if (skip_spaces_and_comments(&cur))
-			goto obj_val_end;
-		if (byte_match_2(cur, "/*"))
-			goto fail_comment;
-	}
-	goto fail_character;
+    if (byte_match_2(cur, ",\n")) {
+        cur += 2;
+        goto obj_key_begin;
+    }
+    if (likely(*cur == ',')) {
+        cur++;
+        goto obj_key_begin;
+    }
+    if (likely(*cur == '}')) {
+        cur++;
+        goto obj_end;
+    }
+    if (char_is_space(*cur)) {
+        while (char_is_space(*++cur));
+        goto obj_val_end;
+    }
+    if (has_read_flag(ALLOW_COMMENTS)) {
+        if (skip_spaces_and_comments(&cur)) goto obj_val_end;
+        if (byte_match_2(cur, "/*")) goto fail_comment;
+    }
+    goto fail_character;
 
 obj_end:
-	/* pop container */
-	ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
-	/* point to the next value */
-	ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
-	ctn->tag = (ctn_len << (YYJSON_TAG_BIT - 1)) | YYJSON_TYPE_OBJ;
-	if (unlikely(ctn == ctn_parent))
-		goto doc_end;
-	ctn = ctn_parent;
-	ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
-	if (*cur == '\n')
-		cur++;
-	if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
-		goto obj_val_end;
-	} else {
-		goto arr_val_end;
-	}
+    /* pop container */
+    ctn_parent = (yyjson_val *)(void *)((u8 *)ctn - ctn->uni.ofs);
+    /* point to the next value */
+    ctn->uni.ofs = (usize)((u8 *)val - (u8 *)ctn) + sizeof(yyjson_val);
+    ctn->tag = (ctn_len << (YYJSON_TAG_BIT - 1)) | YYJSON_TYPE_OBJ;
+    if (unlikely(ctn == ctn_parent)) goto doc_end;
+    ctn = ctn_parent;
+    ctn_len = (usize)(ctn->tag >> YYJSON_TAG_BIT);
+    if (*cur == '\n') cur++;
+    if ((ctn->tag & YYJSON_TYPE_MASK) == YYJSON_TYPE_OBJ) {
+        goto obj_val_end;
+    } else {
+        goto arr_val_end;
+    }
 
 doc_end:
-	/* check invalid contents after json document */
-	if (unlikely(cur < end) && !has_flag(STOP_WHEN_DONE)) {
-		if (has_flag(ALLOW_COMMENTS)) {
-			skip_spaces_and_comments(&cur);
-			if (byte_match_2(cur, "/*"))
-				goto fail_comment;
-		} else
-			while (char_is_space(*cur))
-				cur++;
-		if (unlikely(cur < end))
-			goto fail_garbage;
-	}
+    /* check invalid contents after json document */
+    if (unlikely(cur < end) && !has_read_flag(STOP_WHEN_DONE)) {
+        if (has_read_flag(ALLOW_COMMENTS)) {
+            skip_spaces_and_comments(&cur);
+            if (byte_match_2(cur, "/*")) goto fail_comment;
+        } else {
+            while (char_is_space(*cur)) cur++;
+        }
+        if (unlikely(cur < end)) goto fail_garbage;
+    }
 
-	if (pre && *pre)
-		**pre = '\0';
-	doc = (yyjson_doc *)val_hdr;
-	doc->root = val_hdr + hdr_len;
-	doc->alc = alc;
-	doc->dat_read = (usize)(cur - hdr);
-	doc->val_read = (usize)((val - val_hdr)) - hdr_len + 1;
-	doc->str_pool = has_flag(INSITU) ? NULL : (char *)hdr;
-	return doc;
+    if (pre && *pre) **pre = '\0';
+    doc = (yyjson_doc *)val_hdr;
+    doc->root = val_hdr + hdr_len;
+    doc->alc = alc;
+    doc->dat_read = (usize)(cur - hdr);
+    doc->val_read = (usize)((val - val_hdr)) - hdr_len + 1;
+    doc->str_pool = has_read_flag(INSITU) ? NULL : (char *)hdr;
+    return doc;
 
 fail_string:
-	return_err(cur, INVALID_STRING, msg);
+    return_err(cur, INVALID_STRING, msg);
 fail_number:
-	return_err(cur, INVALID_NUMBER, msg);
+    return_err(cur, INVALID_NUMBER, msg);
 fail_alloc:
-	return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
+    return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
 fail_trailing_comma:
-	return_err(cur, JSON_STRUCTURE, "trailing comma is not allowed");
+    return_err(cur, JSON_STRUCTURE, "trailing comma is not allowed");
 fail_literal:
-	return_err(cur, LITERAL, "invalid literal");
+    return_err(cur, LITERAL, "invalid literal");
 fail_comment:
-	return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
+    return_err(cur, INVALID_COMMENT, "unclosed multiline comment");
 fail_character:
-	return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
+    return_err(cur, UNEXPECTED_CHARACTER, "unexpected character");
 fail_garbage:
-	return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
+    return_err(cur, UNEXPECTED_CONTENT, "unexpected content after document");
 
-#undef has_flag
 #undef val_incr
 #undef return_err
 }
+
+
 
 /*==============================================================================
  * JSON Reader Entrance
  *============================================================================*/
 
-yyjson_doc *yyjson_read_opts(char *dat, usize len, yyjson_read_flag flg, const yyjson_alc *alc_ptr,
+yyjson_doc *yyjson_read_opts(char *dat,
+                             usize len,
+                             yyjson_read_flag flg,
+                             const yyjson_alc *alc_ptr,
                              yyjson_read_err *err) {
 
-#define has_flag(_flag) unlikely((flg & YYJSON_READ_##_flag) != 0)
+#define return_err(_pos, _code, _msg) do { \
+    err->pos = (usize)(_pos); \
+    err->msg = _msg; \
+    err->code = YYJSON_READ_ERROR_##_code; \
+    if (!has_read_flag(INSITU) && hdr) alc.free(alc.ctx, (void *)hdr); \
+    return NULL; \
+} while (false)
 
-#define return_err(_pos, _code, _msg)                                                                                  \
-	do {                                                                                                               \
-		err->pos = (usize)(_pos);                                                                                      \
-		err->msg = _msg;                                                                                               \
-		err->code = YYJSON_READ_ERROR_##_code;                                                                         \
-		if (!has_flag(INSITU) && hdr)                                                                                  \
-			alc.free(alc.ctx, (void *)hdr);                                                                            \
-		return NULL;                                                                                                   \
-	} while (false)
+    yyjson_read_err dummy_err;
+    yyjson_alc alc;
+    yyjson_doc *doc;
+    u8 *hdr = NULL, *end, *cur;
 
-	yyjson_read_err dummy_err;
-	yyjson_alc alc;
-	yyjson_doc *doc;
-	u8 *hdr = NULL, *end, *cur;
+    /* validate input parameters */
+    if (!err) err = &dummy_err;
+    if (likely(!alc_ptr)) {
+        alc = YYJSON_DEFAULT_ALC;
+    } else {
+        alc = *alc_ptr;
+    }
+    if (unlikely(!dat)) {
+        return_err(0, INVALID_PARAMETER, "input data is NULL");
+    }
+    if (unlikely(!len)) {
+        return_err(0, INVALID_PARAMETER, "input length is 0");
+    }
 
-#if YYJSON_DISABLE_NON_STANDARD
-	flg &= ~YYJSON_READ_ALLOW_TRAILING_COMMAS;
-	flg &= ~YYJSON_READ_ALLOW_COMMENTS;
-	flg &= ~YYJSON_READ_ALLOW_INF_AND_NAN;
-	flg &= ~YYJSON_READ_ALLOW_INVALID_UNICODE;
-#endif
+    /* add 4-byte zero padding for input data if necessary */
+    if (has_read_flag(INSITU)) {
+        hdr = (u8 *)dat;
+        end = (u8 *)dat + len;
+        cur = (u8 *)dat;
+    } else {
+        if (unlikely(len >= USIZE_MAX - YYJSON_PADDING_SIZE)) {
+            return_err(0, MEMORY_ALLOCATION, "memory allocation failed");
+        }
+        hdr = (u8 *)alc.malloc(alc.ctx, len + YYJSON_PADDING_SIZE);
+        if (unlikely(!hdr)) {
+            return_err(0, MEMORY_ALLOCATION, "memory allocation failed");
+        }
+        end = hdr + len;
+        cur = hdr;
+        memcpy(hdr, dat, len);
+        memset(end, 0, YYJSON_PADDING_SIZE);
+    }
 
-	/* validate input parameters */
-	if (!err)
-		err = &dummy_err;
-	if (likely(!alc_ptr)) {
-		alc = YYJSON_DEFAULT_ALC;
-	} else {
-		alc = *alc_ptr;
-	}
-	if (unlikely(!dat)) {
-		return_err(0, INVALID_PARAMETER, "input data is NULL");
-	}
-	if (unlikely(!len)) {
-		return_err(0, INVALID_PARAMETER, "input length is 0");
-	}
+    /* skip empty contents before json document */
+    if (unlikely(char_is_space_or_comment(*cur))) {
+        if (has_read_flag(ALLOW_COMMENTS)) {
+            if (!skip_spaces_and_comments(&cur)) {
+                return_err(cur - hdr, INVALID_COMMENT,
+                           "unclosed multiline comment");
+            }
+        } else {
+            if (likely(char_is_space(*cur))) {
+                while (char_is_space(*++cur));
+            }
+        }
+        if (unlikely(cur >= end)) {
+            return_err(0, EMPTY_CONTENT, "input data is empty");
+        }
+    }
 
-	/* add 4-byte zero padding for input data if necessary */
-	if (has_flag(INSITU)) {
-		hdr = (u8 *)dat;
-		end = (u8 *)dat + len;
-		cur = (u8 *)dat;
-	} else {
-		if (unlikely(len >= USIZE_MAX - YYJSON_PADDING_SIZE)) {
-			return_err(0, MEMORY_ALLOCATION, "memory allocation failed");
-		}
-		hdr = (u8 *)alc.malloc(alc.ctx, len + YYJSON_PADDING_SIZE);
-		if (unlikely(!hdr)) {
-			return_err(0, MEMORY_ALLOCATION, "memory allocation failed");
-		}
-		end = hdr + len;
-		cur = hdr;
-		memcpy(hdr, dat, len);
-		memset(end, 0, YYJSON_PADDING_SIZE);
-	}
+    /* read json document */
+    if (likely(char_is_container(*cur))) {
+        if (char_is_space(cur[1]) && char_is_space(cur[2])) {
+            doc = read_root_pretty(hdr, cur, end, alc, flg, err);
+        } else {
+            doc = read_root_minify(hdr, cur, end, alc, flg, err);
+        }
+    } else {
+        doc = read_root_single(hdr, cur, end, alc, flg, err);
+    }
 
-	/* skip empty contents before json document */
-	if (unlikely(char_is_space_or_comment(*cur))) {
-		if (has_flag(ALLOW_COMMENTS)) {
-			if (!skip_spaces_and_comments(&cur)) {
-				return_err(cur - hdr, INVALID_COMMENT, "unclosed multiline comment");
-			}
-		} else {
-			if (likely(char_is_space(*cur))) {
-				while (char_is_space(*++cur))
-					;
-			}
-		}
-		if (unlikely(cur >= end)) {
-			return_err(0, EMPTY_CONTENT, "input data is empty");
-		}
-	}
-
-	/* read json document */
-	if (likely(char_is_container(*cur))) {
-		if (char_is_space(cur[1]) && char_is_space(cur[2])) {
-			doc = read_root_pretty(hdr, cur, end, alc, flg, err);
-		} else {
-			doc = read_root_minify(hdr, cur, end, alc, flg, err);
-		}
-	} else {
-		doc = read_root_single(hdr, cur, end, alc, flg, err);
-	}
-
-	/* check result */
-	if (likely(doc)) {
-		memset(err, 0, sizeof(yyjson_read_err));
-	} else {
-		/* RFC 8259: JSON text MUST be encoded using UTF-8 */
-		if (err->pos == 0 && err->code != YYJSON_READ_ERROR_MEMORY_ALLOCATION) {
-			if ((hdr[0] == 0xEF && hdr[1] == 0xBB && hdr[2] == 0xBF)) {
-				err->msg = "byte order mark (BOM) is not supported";
-			} else if (len >= 4 && ((hdr[0] == 0x00 && hdr[1] == 0x00 && hdr[2] == 0xFE && hdr[3] == 0xFF) ||
-			                        (hdr[0] == 0xFF && hdr[1] == 0xFE && hdr[2] == 0x00 && hdr[3] == 0x00))) {
-				err->msg = "UTF-32 encoding is not supported";
-			} else if (len >= 2 && ((hdr[0] == 0xFE && hdr[1] == 0xFF) || (hdr[0] == 0xFF && hdr[1] == 0xFE))) {
-				err->msg = "UTF-16 encoding is not supported";
-			}
-		}
-		if (!has_flag(INSITU))
-			alc.free(alc.ctx, (void *)hdr);
-	}
-	return doc;
-
-#undef has_flag
-#undef return_err
-}
-
-yyjson_doc *yyjson_read_file(const char *path, yyjson_read_flag flg, const yyjson_alc *alc_ptr, yyjson_read_err *err) {
-
-#define return_err(_code, _msg)                                                                                        \
-	do {                                                                                                               \
-		err->pos = 0;                                                                                                  \
-		err->msg = _msg;                                                                                               \
-		err->code = YYJSON_READ_ERROR_##_code;                                                                         \
-		if (file)                                                                                                      \
-			fclose(file);                                                                                              \
-		if (buf)                                                                                                       \
-			alc.free(alc.ctx, buf);                                                                                    \
-		return NULL;                                                                                                   \
-	} while (false)
-
-	yyjson_read_err dummy_err;
-	yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
-	yyjson_doc *doc;
-
-	FILE *file = NULL;
-	long file_size = 0;
-	void *buf = NULL;
-	usize buf_size = 0;
-
-	/* validate input parameters */
-	if (!err)
-		err = &dummy_err;
-	if (unlikely(!path))
-		return_err(INVALID_PARAMETER, "input path is NULL");
-
-	/* open file */
-	file = fopen_readonly(path);
-	if (file == NULL)
-		return_err(FILE_OPEN, "file opening failed");
-
-	/* get file size */
-	if (fseek(file, 0, SEEK_END) == 0)
-		file_size = ftell(file);
-	rewind(file);
-
-	/* read file */
-	if (file_size > 0) {
-		/* read the entire file in one call */
-		buf_size = (usize)file_size + YYJSON_PADDING_SIZE;
-		buf = alc.malloc(alc.ctx, buf_size);
-		if (buf == NULL) {
-			return_err(MEMORY_ALLOCATION, "fail to alloc memory");
-		}
-		if (fread_safe(buf, (usize)file_size, file) != (usize)file_size) {
-			return_err(FILE_READ, "file reading failed");
-		}
-	} else {
-		/* failed to get file size, read it as a stream */
-		usize chunk_min = (usize)64;
-		usize chunk_max = (usize)512 * 1024 * 1024;
-		usize chunk_now = chunk_min;
-		usize read_size;
-		void *tmp;
-
-		buf_size = YYJSON_PADDING_SIZE;
-		while (true) {
-			if (buf_size + chunk_now < buf_size) { /* overflow */
-				return_err(MEMORY_ALLOCATION, "fail to alloc memory");
-			}
-			buf_size += chunk_now;
-			if (!buf) {
-				buf = alc.malloc(alc.ctx, buf_size);
-				if (!buf)
-					return_err(MEMORY_ALLOCATION, "fail to alloc memory");
-			} else {
-				tmp = alc.realloc(alc.ctx, buf, buf_size - chunk_now, buf_size);
-				if (!tmp)
-					return_err(MEMORY_ALLOCATION, "fail to alloc memory");
-				buf = tmp;
-			}
-			tmp = ((u8 *)buf) + buf_size - YYJSON_PADDING_SIZE - chunk_now;
-			read_size = fread_safe(tmp, chunk_now, file);
-			file_size += (long)read_size;
-			if (read_size != chunk_now)
-				break;
-
-			chunk_now *= 2;
-			if (chunk_now > chunk_max)
-				chunk_now = chunk_max;
-		}
-	}
-	fclose(file);
-
-	/* read JSON */
-	memset((u8 *)buf + file_size, 0, YYJSON_PADDING_SIZE);
-	flg |= YYJSON_READ_INSITU;
-	doc = yyjson_read_opts((char *)buf, (usize)file_size, flg, &alc, err);
-	if (doc) {
-		doc->str_pool = (char *)buf;
-		return doc;
-	} else {
-		alc.free(alc.ctx, buf);
-		return NULL;
-	}
+    /* check result */
+    if (likely(doc)) {
+        memset(err, 0, sizeof(yyjson_read_err));
+    } else {
+        /* RFC 8259: JSON text MUST be encoded using UTF-8 */
+        if (err->pos == 0 && err->code != YYJSON_READ_ERROR_MEMORY_ALLOCATION) {
+            if ((hdr[0] == 0xEF && hdr[1] == 0xBB && hdr[2] == 0xBF)) {
+                err->msg = "byte order mark (BOM) is not supported";
+            } else if (len >= 4 &&
+                       ((hdr[0] == 0x00 && hdr[1] == 0x00 &&
+                         hdr[2] == 0xFE && hdr[3] == 0xFF) ||
+                        (hdr[0] == 0xFF && hdr[1] == 0xFE &&
+                         hdr[2] == 0x00 && hdr[3] == 0x00))) {
+                err->msg = "UTF-32 encoding is not supported";
+            } else if (len >= 2 &&
+                       ((hdr[0] == 0xFE && hdr[1] == 0xFF) ||
+                        (hdr[0] == 0xFF && hdr[1] == 0xFE))) {
+                err->msg = "UTF-16 encoding is not supported";
+            }
+        }
+        if (!has_read_flag(INSITU)) alc.free(alc.ctx, (void *)hdr);
+    }
+    return doc;
 
 #undef return_err
 }
 
-const char *yyjson_read_number(const char *dat, yyjson_val *val, yyjson_read_flag flg, const yyjson_alc *alc,
+yyjson_doc *yyjson_read_file(const char *path,
+                             yyjson_read_flag flg,
+                             const yyjson_alc *alc_ptr,
+                             yyjson_read_err *err) {
+#define return_err(_code, _msg) do { \
+    err->pos = 0; \
+    err->msg = _msg; \
+    err->code = YYJSON_READ_ERROR_##_code; \
+    return NULL; \
+} while (false)
+
+    yyjson_read_err dummy_err;
+    yyjson_doc *doc;
+    FILE *file;
+
+    if (!err) err = &dummy_err;
+    if (unlikely(!path)) return_err(INVALID_PARAMETER, "input path is NULL");
+
+    file = fopen_readonly(path);
+    if (unlikely(!file)) return_err(FILE_OPEN, "file opening failed");
+
+    doc = yyjson_read_fp(file, flg, alc_ptr, err);
+    fclose(file);
+    return doc;
+
+#undef return_err
+}
+
+yyjson_doc *yyjson_read_fp(FILE *file,
+                           yyjson_read_flag flg,
+                           const yyjson_alc *alc_ptr,
+                           yyjson_read_err *err) {
+#define return_err(_code, _msg) do { \
+    err->pos = 0; \
+    err->msg = _msg; \
+    err->code = YYJSON_READ_ERROR_##_code; \
+    if (buf) alc.free(alc.ctx, buf); \
+    return NULL; \
+} while (false)
+
+    yyjson_read_err dummy_err;
+    yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
+    yyjson_doc *doc;
+
+    long file_size = 0, file_pos;
+    void *buf = NULL;
+    usize buf_size = 0;
+
+    /* validate input parameters */
+    if (!err) err = &dummy_err;
+    if (unlikely(!file)) return_err(INVALID_PARAMETER, "input file is NULL");
+
+    /* get current position */
+    file_pos = ftell(file);
+    if (file_pos != -1) {
+        /* get total file size, may fail */
+        if (fseek(file, 0, SEEK_END) == 0) file_size = ftell(file);
+        /* reset to original position, may fail */
+        if (fseek(file, file_pos, SEEK_SET) != 0) file_size = 0;
+        /* get file size from current postion to end */
+        if (file_size > 0) file_size -= file_pos;
+    }
+
+    /* read file */
+    if (file_size > 0) {
+        /* read the entire file in one call */
+        buf_size = (usize)file_size + YYJSON_PADDING_SIZE;
+        buf = alc.malloc(alc.ctx, buf_size);
+        if (buf == NULL) {
+            return_err(MEMORY_ALLOCATION, "fail to alloc memory");
+        }
+        if (fread_safe(buf, (usize)file_size, file) != (usize)file_size) {
+            return_err(FILE_READ, "file reading failed");
+        }
+    } else {
+        /* failed to get file size, read it as a stream */
+        usize chunk_min = (usize)64;
+        usize chunk_max = (usize)512 * 1024 * 1024;
+        usize chunk_now = chunk_min;
+        usize read_size;
+        void *tmp;
+
+        buf_size = YYJSON_PADDING_SIZE;
+        while (true) {
+            if (buf_size + chunk_now < buf_size) { /* overflow */
+                return_err(MEMORY_ALLOCATION, "fail to alloc memory");
+            }
+            buf_size += chunk_now;
+            if (!buf) {
+                buf = alc.malloc(alc.ctx, buf_size);
+                if (!buf) return_err(MEMORY_ALLOCATION, "fail to alloc memory");
+            } else {
+                tmp = alc.realloc(alc.ctx, buf, buf_size - chunk_now, buf_size);
+                if (!tmp) return_err(MEMORY_ALLOCATION, "fail to alloc memory");
+                buf = tmp;
+            }
+            tmp = ((u8 *)buf) + buf_size - YYJSON_PADDING_SIZE - chunk_now;
+            read_size = fread_safe(tmp, chunk_now, file);
+            file_size += (long)read_size;
+            if (read_size != chunk_now) break;
+
+            chunk_now *= 2;
+            if (chunk_now > chunk_max) chunk_now = chunk_max;
+        }
+    }
+
+    /* read JSON */
+    memset((u8 *)buf + file_size, 0, YYJSON_PADDING_SIZE);
+    flg |= YYJSON_READ_INSITU;
+    doc = yyjson_read_opts((char *)buf, (usize)file_size, flg, &alc, err);
+    if (doc) {
+        doc->str_pool = (char *)buf;
+        return doc;
+    } else {
+        alc.free(alc.ctx, buf);
+        return NULL;
+    }
+
+#undef return_err
+}
+
+const char *yyjson_read_number(const char *dat,
+                               yyjson_val *val,
+                               yyjson_read_flag flg,
+                               const yyjson_alc *alc,
                                yyjson_read_err *err) {
-#define return_err(_pos, _code, _msg)                                                                                  \
-	do {                                                                                                               \
-		err->pos = _pos > hdr ? (usize)(_pos - hdr) : 0;                                                               \
-		err->msg = _msg;                                                                                               \
-		err->code = YYJSON_READ_ERROR_##_code;                                                                         \
-		return NULL;                                                                                                   \
-	} while (false)
+#define return_err(_pos, _code, _msg) do { \
+    err->pos = _pos > hdr ? (usize)(_pos - hdr) : 0; \
+    err->msg = _msg; \
+    err->code = YYJSON_READ_ERROR_##_code; \
+    return NULL; \
+} while (false)
 
-	u8 *hdr = (u8 *)dat, *cur = hdr;
-	bool raw;    /* read number as raw */
-	bool ext;    /* allow inf and nan */
-	u8 *raw_end; /* raw end for null-terminator */
-	u8 **pre;    /* previous raw end pointer */
-	const char *msg;
-	yyjson_read_err dummy_err;
+    u8 *hdr = constcast(u8 *)dat, *cur = hdr;
+    bool raw; /* read number as raw */
+    u8 *raw_end; /* raw end for null-terminator */
+    u8 **pre; /* previous raw end pointer */
+    const char *msg;
+    yyjson_read_err dummy_err;
 
 #if !YYJSON_HAS_IEEE_754 || YYJSON_DISABLE_FAST_FP_CONV
-	u8 buf[128];
-	usize dat_len;
+    u8 buf[128];
+    usize dat_len;
 #endif
 
-	if (!err)
-		err = &dummy_err;
-	if (unlikely(!dat)) {
-		return_err(cur, INVALID_PARAMETER, "input data is NULL");
-	}
-	if (unlikely(!val)) {
-		return_err(cur, INVALID_PARAMETER, "output value is NULL");
-	}
+    if (!err) err = &dummy_err;
+    if (unlikely(!dat)) {
+        return_err(cur, INVALID_PARAMETER, "input data is NULL");
+    }
+    if (unlikely(!val)) {
+        return_err(cur, INVALID_PARAMETER, "output value is NULL");
+    }
 
 #if !YYJSON_HAS_IEEE_754 || YYJSON_DISABLE_FAST_FP_CONV
-	if (!alc)
-		alc = &YYJSON_DEFAULT_ALC;
-	dat_len = strlen(dat);
-	if (dat_len < sizeof(buf)) {
-		memcpy(buf, dat, dat_len + 1);
-		hdr = buf;
-		cur = hdr;
-	} else {
-		hdr = (u8 *)alc->malloc(alc->ctx, dat_len + 1);
-		cur = hdr;
-		if (unlikely(!hdr)) {
-			return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
-		}
-		memcpy(hdr, dat, dat_len + 1);
-	}
+    if (!alc) alc = &YYJSON_DEFAULT_ALC;
+    dat_len = strlen(dat);
+    if (dat_len < sizeof(buf)) {
+        memcpy(buf, dat, dat_len + 1);
+        hdr = buf;
+        cur = hdr;
+    } else {
+        hdr = (u8 *)alc->malloc(alc->ctx, dat_len + 1);
+        cur = hdr;
+        if (unlikely(!hdr)) {
+            return_err(cur, MEMORY_ALLOCATION, "memory allocation failed");
+        }
+        memcpy(hdr, dat, dat_len + 1);
+    }
+    hdr[dat_len] = 0;
 #endif
 
-#if YYJSON_DISABLE_NON_STANDARD
-	ext = false;
+    raw = (flg & (YYJSON_READ_NUMBER_AS_RAW | YYJSON_READ_BIGNUM_AS_RAW)) != 0;
+    raw_end = NULL;
+    pre = raw ? &raw_end : NULL;
+
+#if !YYJSON_HAS_IEEE_754 || YYJSON_DISABLE_FAST_FP_CONV
+    if (!read_number(&cur, pre, flg, val, &msg)) {
+        if (dat_len >= sizeof(buf)) alc->free(alc->ctx, hdr);
+        return_err(cur, INVALID_NUMBER, msg);
+    }
+    if (dat_len >= sizeof(buf)) alc->free(alc->ctx, hdr);
+    if (yyjson_is_raw(val)) val->uni.str = dat;
+    return dat + (cur - hdr);
 #else
-	ext = (flg & YYJSON_READ_ALLOW_INF_AND_NAN) != 0;
-#endif
-
-	raw = (flg & YYJSON_READ_NUMBER_AS_RAW) != 0;
-	raw_end = NULL;
-	pre = raw ? &raw_end : NULL;
-
-#if !YYJSON_HAS_IEEE_754 || YYJSON_DISABLE_FAST_FP_CONV
-	if (!read_number(&cur, pre, ext, val, &msg)) {
-		if (dat_len >= sizeof(buf))
-			alc->free(alc->ctx, hdr);
-		return_err(cur, INVALID_NUMBER, msg);
-	}
-	if (dat_len >= sizeof(buf))
-		alc->free(alc->ctx, hdr);
-	if (raw)
-		val->uni.str = dat;
-	return dat + (cur - hdr);
-#else
-	if (!read_number(&cur, pre, ext, val, &msg)) {
-		return_err(cur, INVALID_NUMBER, msg);
-	}
-	return (const char *)cur;
+    if (!read_number(&cur, pre, flg, val, &msg)) {
+        return_err(cur, INVALID_NUMBER, msg);
+    }
+    return (const char *)cur;
 #endif
 
 #undef return_err
 }
 
 #endif /* YYJSON_DISABLE_READER */
+
+
 
 #if !YYJSON_DISABLE_WRITER
 
@@ -5925,200 +6949,223 @@ const char *yyjson_read_number(const char *dat, yyjson_val *val, yyjson_read_fla
  *============================================================================*/
 
 /** Digit table from 00 to 99. */
-yyjson_align(2) static const char digit_table[200] = {
-    '0', '0', '0', '1', '0', '2', '0', '3', '0', '4', '0', '5', '0', '6', '0', '7', '0', '8', '0', '9', '1', '0', '1',
-    '1', '1', '2', '1', '3', '1', '4', '1', '5', '1', '6', '1', '7', '1', '8', '1', '9', '2', '0', '2', '1', '2', '2',
-    '2', '3', '2', '4', '2', '5', '2', '6', '2', '7', '2', '8', '2', '9', '3', '0', '3', '1', '3', '2', '3', '3', '3',
-    '4', '3', '5', '3', '6', '3', '7', '3', '8', '3', '9', '4', '0', '4', '1', '4', '2', '4', '3', '4', '4', '4', '5',
-    '4', '6', '4', '7', '4', '8', '4', '9', '5', '0', '5', '1', '5', '2', '5', '3', '5', '4', '5', '5', '5', '6', '5',
-    '7', '5', '8', '5', '9', '6', '0', '6', '1', '6', '2', '6', '3', '6', '4', '6', '5', '6', '6', '6', '7', '6', '8',
-    '6', '9', '7', '0', '7', '1', '7', '2', '7', '3', '7', '4', '7', '5', '7', '6', '7', '7', '7', '8', '7', '9', '8',
-    '0', '8', '1', '8', '2', '8', '3', '8', '4', '8', '5', '8', '6', '8', '7', '8', '8', '8', '9', '9', '0', '9', '1',
-    '9', '2', '9', '3', '9', '4', '9', '5', '9', '6', '9', '7', '9', '8', '9', '9'};
+yyjson_align(2)
+static const char digit_table[200] = {
+    '0', '0', '0', '1', '0', '2', '0', '3', '0', '4',
+    '0', '5', '0', '6', '0', '7', '0', '8', '0', '9',
+    '1', '0', '1', '1', '1', '2', '1', '3', '1', '4',
+    '1', '5', '1', '6', '1', '7', '1', '8', '1', '9',
+    '2', '0', '2', '1', '2', '2', '2', '3', '2', '4',
+    '2', '5', '2', '6', '2', '7', '2', '8', '2', '9',
+    '3', '0', '3', '1', '3', '2', '3', '3', '3', '4',
+    '3', '5', '3', '6', '3', '7', '3', '8', '3', '9',
+    '4', '0', '4', '1', '4', '2', '4', '3', '4', '4',
+    '4', '5', '4', '6', '4', '7', '4', '8', '4', '9',
+    '5', '0', '5', '1', '5', '2', '5', '3', '5', '4',
+    '5', '5', '5', '6', '5', '7', '5', '8', '5', '9',
+    '6', '0', '6', '1', '6', '2', '6', '3', '6', '4',
+    '6', '5', '6', '6', '6', '7', '6', '8', '6', '9',
+    '7', '0', '7', '1', '7', '2', '7', '3', '7', '4',
+    '7', '5', '7', '6', '7', '7', '7', '8', '7', '9',
+    '8', '0', '8', '1', '8', '2', '8', '3', '8', '4',
+    '8', '5', '8', '6', '8', '7', '8', '8', '8', '9',
+    '9', '0', '9', '1', '9', '2', '9', '3', '9', '4',
+    '9', '5', '9', '6', '9', '7', '9', '8', '9', '9'
+};
 
 static_inline u8 *write_u32_len_8(u32 val, u8 *buf) {
-	u32 aa, bb, cc, dd, aabb, ccdd;             /* 8 digits: aabbccdd */
-	aabb = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
-	ccdd = val - aabb * 10000;                  /* (val % 10000) */
-	aa = (aabb * 5243) >> 19;                   /* (aabb / 100) */
-	cc = (ccdd * 5243) >> 19;                   /* (ccdd / 100) */
-	bb = aabb - aa * 100;                       /* (aabb % 100) */
-	dd = ccdd - cc * 100;                       /* (ccdd % 100) */
-	((v16 *)buf)[0] = ((const v16 *)digit_table)[aa];
-	((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-	((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-	((v16 *)buf)[3] = ((const v16 *)digit_table)[dd];
-	return buf + 8;
+    u32 aa, bb, cc, dd, aabb, ccdd;                 /* 8 digits: aabbccdd */
+    aabb = (u32)(((u64)val * 109951163) >> 40);     /* (val / 10000) */
+    ccdd = val - aabb * 10000;                      /* (val % 10000) */
+    aa = (aabb * 5243) >> 19;                       /* (aabb / 100) */
+    cc = (ccdd * 5243) >> 19;                       /* (ccdd / 100) */
+    bb = aabb - aa * 100;                           /* (aabb % 100) */
+    dd = ccdd - cc * 100;                           /* (ccdd % 100) */
+    byte_copy_2(buf + 0, digit_table + aa * 2);
+    byte_copy_2(buf + 2, digit_table + bb * 2);
+    byte_copy_2(buf + 4, digit_table + cc * 2);
+    byte_copy_2(buf + 6, digit_table + dd * 2);
+    return buf + 8;
 }
 
 static_inline u8 *write_u32_len_4(u32 val, u8 *buf) {
-	u32 aa, bb;              /* 4 digits: aabb */
-	aa = (val * 5243) >> 19; /* (val / 100) */
-	bb = val - aa * 100;     /* (val % 100) */
-	((v16 *)buf)[0] = ((const v16 *)digit_table)[aa];
-	((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-	return buf + 4;
+    u32 aa, bb;                                     /* 4 digits: aabb */
+    aa = (val * 5243) >> 19;                        /* (val / 100) */
+    bb = val - aa * 100;                            /* (val % 100) */
+    byte_copy_2(buf + 0, digit_table + aa * 2);
+    byte_copy_2(buf + 2, digit_table + bb * 2);
+    return buf + 4;
 }
 
 static_inline u8 *write_u32_len_1_8(u32 val, u8 *buf) {
-	u32 aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
+    u32 aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
 
-	if (val < 100) {   /* 1-2 digits: aa */
-		lz = val < 10; /* leading zero: 0 or 1 */
-		((v16 *)buf)[0] = *(const v16 *)(digit_table + (val * 2 + lz));
-		buf -= lz;
-		return buf + 2;
+    if (val < 100) {                                /* 1-2 digits: aa */
+        lz = val < 10;                              /* leading zero: 0 or 1 */
+        byte_copy_2(buf + 0, digit_table + val * 2 + lz);
+        buf -= lz;
+        return buf + 2;
 
-	} else if (val < 10000) {    /* 3-4 digits: aabb */
-		aa = (val * 5243) >> 19; /* (val / 100) */
-		bb = val - aa * 100;     /* (val % 100) */
-		lz = aa < 10;            /* leading zero: 0 or 1 */
-		((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-		buf -= lz;
-		((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-		return buf + 4;
+    } else if (val < 10000) {                       /* 3-4 digits: aabb */
+        aa = (val * 5243) >> 19;                    /* (val / 100) */
+        bb = val - aa * 100;                        /* (val % 100) */
+        lz = aa < 10;                               /* leading zero: 0 or 1 */
+        byte_copy_2(buf + 0, digit_table + aa * 2 + lz);
+        buf -= lz;
+        byte_copy_2(buf + 2, digit_table + bb * 2);
+        return buf + 4;
 
-	} else if (val < 1000000) {                /* 5-6 digits: aabbcc */
-		aa = (u32)(((u64)val * 429497) >> 32); /* (val / 10000) */
-		bbcc = val - aa * 10000;               /* (val % 10000) */
-		bb = (bbcc * 5243) >> 19;              /* (bbcc / 100) */
-		cc = bbcc - bb * 100;                  /* (bbcc % 100) */
-		lz = aa < 10;                          /* leading zero: 0 or 1 */
-		((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-		buf -= lz;
-		((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-		((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-		return buf + 6;
+    } else if (val < 1000000) {                     /* 5-6 digits: aabbcc */
+        aa = (u32)(((u64)val * 429497) >> 32);      /* (val / 10000) */
+        bbcc = val - aa * 10000;                    /* (val % 10000) */
+        bb = (bbcc * 5243) >> 19;                   /* (bbcc / 100) */
+        cc = bbcc - bb * 100;                       /* (bbcc % 100) */
+        lz = aa < 10;                               /* leading zero: 0 or 1 */
+        byte_copy_2(buf + 0, digit_table + aa * 2 + lz);
+        buf -= lz;
+        byte_copy_2(buf + 2, digit_table + bb * 2);
+        byte_copy_2(buf + 4, digit_table + cc * 2);
+        return buf + 6;
 
-	} else {                                        /* 7-8 digits: aabbccdd */
-		aabb = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
-		ccdd = val - aabb * 10000;                  /* (val % 10000) */
-		aa = (aabb * 5243) >> 19;                   /* (aabb / 100) */
-		cc = (ccdd * 5243) >> 19;                   /* (ccdd / 100) */
-		bb = aabb - aa * 100;                       /* (aabb % 100) */
-		dd = ccdd - cc * 100;                       /* (ccdd % 100) */
-		lz = aa < 10;                               /* leading zero: 0 or 1 */
-		((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-		buf -= lz;
-		((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-		((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-		((v16 *)buf)[3] = ((const v16 *)digit_table)[dd];
-		return buf + 8;
-	}
+    } else {                                        /* 7-8 digits: aabbccdd */
+        aabb = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
+        ccdd = val - aabb * 10000;                  /* (val % 10000) */
+        aa = (aabb * 5243) >> 19;                   /* (aabb / 100) */
+        cc = (ccdd * 5243) >> 19;                   /* (ccdd / 100) */
+        bb = aabb - aa * 100;                       /* (aabb % 100) */
+        dd = ccdd - cc * 100;                       /* (ccdd % 100) */
+        lz = aa < 10;                               /* leading zero: 0 or 1 */
+        byte_copy_2(buf + 0, digit_table + aa * 2 + lz);
+        buf -= lz;
+        byte_copy_2(buf + 2, digit_table + bb * 2);
+        byte_copy_2(buf + 4, digit_table + cc * 2);
+        byte_copy_2(buf + 6, digit_table + dd * 2);
+        return buf + 8;
+    }
 }
 
 static_inline u8 *write_u64_len_5_8(u32 val, u8 *buf) {
-	u32 aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
+    u32 aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
 
-	if (val < 1000000) {                       /* 5-6 digits: aabbcc */
-		aa = (u32)(((u64)val * 429497) >> 32); /* (val / 10000) */
-		bbcc = val - aa * 10000;               /* (val % 10000) */
-		bb = (bbcc * 5243) >> 19;              /* (bbcc / 100) */
-		cc = bbcc - bb * 100;                  /* (bbcc % 100) */
-		lz = aa < 10;                          /* leading zero: 0 or 1 */
-		((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-		buf -= lz;
-		((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-		((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-		return buf + 6;
+    if (val < 1000000) {                            /* 5-6 digits: aabbcc */
+        aa = (u32)(((u64)val * 429497) >> 32);      /* (val / 10000) */
+        bbcc = val - aa * 10000;                    /* (val % 10000) */
+        bb = (bbcc * 5243) >> 19;                   /* (bbcc / 100) */
+        cc = bbcc - bb * 100;                       /* (bbcc % 100) */
+        lz = aa < 10;                               /* leading zero: 0 or 1 */
+        byte_copy_2(buf + 0, digit_table + aa * 2 + lz);
+        buf -= lz;
+        byte_copy_2(buf + 2, digit_table + bb * 2);
+        byte_copy_2(buf + 4, digit_table + cc * 2);
+        return buf + 6;
 
-	} else {                                        /* 7-8 digits: aabbccdd */
-		aabb = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
-		ccdd = val - aabb * 10000;                  /* (val % 10000) */
-		aa = (aabb * 5243) >> 19;                   /* (aabb / 100) */
-		cc = (ccdd * 5243) >> 19;                   /* (ccdd / 100) */
-		bb = aabb - aa * 100;                       /* (aabb % 100) */
-		dd = ccdd - cc * 100;                       /* (ccdd % 100) */
-		lz = aa < 10;                               /* leading zero: 0 or 1 */
-		((v16 *)buf)[0] = *(const v16 *)(digit_table + (aa * 2 + lz));
-		buf -= lz;
-		((v16 *)buf)[1] = ((const v16 *)digit_table)[bb];
-		((v16 *)buf)[2] = ((const v16 *)digit_table)[cc];
-		((v16 *)buf)[3] = ((const v16 *)digit_table)[dd];
-		return buf + 8;
-	}
+    } else {                                        /* 7-8 digits: aabbccdd */
+        aabb = (u32)(((u64)val * 109951163) >> 40); /* (val / 10000) */
+        ccdd = val - aabb * 10000;                  /* (val % 10000) */
+        aa = (aabb * 5243) >> 19;                   /* (aabb / 100) */
+        cc = (ccdd * 5243) >> 19;                   /* (ccdd / 100) */
+        bb = aabb - aa * 100;                       /* (aabb % 100) */
+        dd = ccdd - cc * 100;                       /* (ccdd % 100) */
+        lz = aa < 10;                               /* leading zero: 0 or 1 */
+        byte_copy_2(buf + 0, digit_table + aa * 2 + lz);
+        buf -= lz;
+        byte_copy_2(buf + 2, digit_table + bb * 2);
+        byte_copy_2(buf + 4, digit_table + cc * 2);
+        byte_copy_2(buf + 6, digit_table + dd * 2);
+        return buf + 8;
+    }
 }
 
 static_inline u8 *write_u64(u64 val, u8 *buf) {
-	u64 tmp, hgh;
-	u32 mid, low;
+    u64 tmp, hgh;
+    u32 mid, low;
 
-	if (val < 100000000) { /* 1-8 digits */
-		buf = write_u32_len_1_8((u32)val, buf);
-		return buf;
+    if (val < 100000000) {                          /* 1-8 digits */
+        buf = write_u32_len_1_8((u32)val, buf);
+        return buf;
 
-	} else if (val < (u64)100000000 * 100000000) { /* 9-16 digits */
-		hgh = val / 100000000;                     /* (val / 100000000) */
-		low = (u32)(val - hgh * 100000000);        /* (val % 100000000) */
-		buf = write_u32_len_1_8((u32)hgh, buf);
-		buf = write_u32_len_8(low, buf);
-		return buf;
+    } else if (val < (u64)100000000 * 100000000) {  /* 9-16 digits */
+        hgh = val / 100000000;                      /* (val / 100000000) */
+        low = (u32)(val - hgh * 100000000);         /* (val % 100000000) */
+        buf = write_u32_len_1_8((u32)hgh, buf);
+        buf = write_u32_len_8(low, buf);
+        return buf;
 
-	} else {                                /* 17-20 digits */
-		tmp = val / 100000000;              /* (val / 100000000) */
-		low = (u32)(val - tmp * 100000000); /* (val % 100000000) */
-		hgh = (u32)(tmp / 10000);           /* (tmp / 10000) */
-		mid = (u32)(tmp - hgh * 10000);     /* (tmp % 10000) */
-		buf = write_u64_len_5_8((u32)hgh, buf);
-		buf = write_u32_len_4(mid, buf);
-		buf = write_u32_len_8(low, buf);
-		return buf;
-	}
+    } else {                                        /* 17-20 digits */
+        tmp = val / 100000000;                      /* (val / 100000000) */
+        low = (u32)(val - tmp * 100000000);         /* (val % 100000000) */
+        hgh = (u32)(tmp / 10000);                   /* (tmp / 10000) */
+        mid = (u32)(tmp - hgh * 10000);             /* (tmp % 10000) */
+        buf = write_u64_len_5_8((u32)hgh, buf);
+        buf = write_u32_len_4(mid, buf);
+        buf = write_u32_len_8(low, buf);
+        return buf;
+    }
 }
+
+
 
 /*==============================================================================
  * Number Writer
  *============================================================================*/
 
-#if YYJSON_HAS_IEEE_754 && !YYJSON_DISABLE_FAST_FP_CONV /* FP_WRITER */
+#if YYJSON_HAS_IEEE_754 && !YYJSON_DISABLE_FAST_FP_CONV  /* FP_WRITER */
 
 /** Trailing zero count table for number 0 to 99.
     (generate with misc/make_tables.c) */
-static const u8 dec_trailing_zero_table[] = {2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-                                             0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-                                             0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+static const u8 dec_trailing_zero_table[] = {
+    2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
 
 /** Write an unsigned integer with a length of 1 to 16. */
 static_inline u8 *write_u64_len_1_to_16(u64 val, u8 *buf) {
-	u64 hgh;
-	u32 low;
-	if (val < 100000000) { /* 1-8 digits */
-		buf = write_u32_len_1_8((u32)val, buf);
-		return buf;
-	} else {                                /* 9-16 digits */
-		hgh = val / 100000000;              /* (val / 100000000) */
-		low = (u32)(val - hgh * 100000000); /* (val % 100000000) */
-		buf = write_u32_len_1_8((u32)hgh, buf);
-		buf = write_u32_len_8(low, buf);
-		return buf;
-	}
+    u64 hgh;
+    u32 low;
+    if (val < 100000000) {                          /* 1-8 digits */
+        buf = write_u32_len_1_8((u32)val, buf);
+        return buf;
+    } else {                                        /* 9-16 digits */
+        hgh = val / 100000000;                      /* (val / 100000000) */
+        low = (u32)(val - hgh * 100000000);         /* (val % 100000000) */
+        buf = write_u32_len_1_8((u32)hgh, buf);
+        buf = write_u32_len_8(low, buf);
+        return buf;
+    }
 }
 
 /** Write an unsigned integer with a length of 1 to 17. */
 static_inline u8 *write_u64_len_1_to_17(u64 val, u8 *buf) {
-	u64 hgh;
-	u32 mid, low, one;
-	if (val >= (u64)100000000 * 10000000) {      /* len: 16 to 17 */
-		hgh = val / 100000000;                   /* (val / 100000000) */
-		low = (u32)(val - hgh * 100000000);      /* (val % 100000000) */
-		one = (u32)(hgh / 100000000);            /* (hgh / 100000000) */
-		mid = (u32)(hgh - (u64)one * 100000000); /* (hgh % 100000000) */
-		*buf = (u8)((u8)one + (u8)'0');
-		buf += one > 0;
-		buf = write_u32_len_8(mid, buf);
-		buf = write_u32_len_8(low, buf);
-		return buf;
-	} else if (val >= (u64)100000000) {     /* len: 9 to 15 */
-		hgh = val / 100000000;              /* (val / 100000000) */
-		low = (u32)(val - hgh * 100000000); /* (val % 100000000) */
-		buf = write_u32_len_1_8((u32)hgh, buf);
-		buf = write_u32_len_8(low, buf);
-		return buf;
-	} else { /* len: 1 to 8 */
-		buf = write_u32_len_1_8((u32)val, buf);
-		return buf;
-	}
+    u64 hgh;
+    u32 mid, low, one;
+    if (val >= (u64)100000000 * 10000000) {         /* len: 16 to 17 */
+        hgh = val / 100000000;                      /* (val / 100000000) */
+        low = (u32)(val - hgh * 100000000);         /* (val % 100000000) */
+        one = (u32)(hgh / 100000000);               /* (hgh / 100000000) */
+        mid = (u32)(hgh - (u64)one * 100000000);    /* (hgh % 100000000) */
+        *buf = (u8)((u8)one + (u8)'0');
+        buf += one > 0;
+        buf = write_u32_len_8(mid, buf);
+        buf = write_u32_len_8(low, buf);
+        return buf;
+    } else if (val >= (u64)100000000){              /* len: 9 to 15 */
+        hgh = val / 100000000;                      /* (val / 100000000) */
+        low = (u32)(val - hgh * 100000000);         /* (val % 100000000) */
+        buf = write_u32_len_1_8((u32)hgh, buf);
+        buf = write_u32_len_8(low, buf);
+        return buf;
+    } else { /* len: 1 to 8 */
+        buf = write_u32_len_1_8((u32)val, buf);
+        return buf;
+    }
 }
 
 /**
@@ -6127,99 +7174,99 @@ static_inline u8 *write_u64_len_1_to_17(u64 val, u8 *buf) {
  For example, input 1234567890123000, output "1234567890123".
  */
 static_inline u8 *write_u64_len_15_to_17_trim(u8 *buf, u64 sig) {
-	bool lz;          /* leading zero */
-	u32 tz1, tz2, tz; /* trailing zero */
+    bool lz;                                        /* leading zero */
+    u32 tz1, tz2, tz;                               /* trailing zero */
 
-	u32 abbccddee = (u32)(sig / 100000000);
-	u32 ffgghhii = (u32)(sig - (u64)abbccddee * 100000000);
-	u32 abbcc = abbccddee / 10000;                /* (abbccddee / 10000) */
-	u32 ddee = abbccddee - abbcc * 10000;         /* (abbccddee % 10000) */
-	u32 abb = (u32)(((u64)abbcc * 167773) >> 24); /* (abbcc / 100) */
-	u32 a = (abb * 41) >> 12;                     /* (abb / 100) */
-	u32 bb = abb - a * 100;                       /* (abb % 100) */
-	u32 cc = abbcc - abb * 100;                   /* (abbcc % 100) */
+    u32 abbccddee = (u32)(sig / 100000000);
+    u32 ffgghhii = (u32)(sig - (u64)abbccddee * 100000000);
+    u32 abbcc = abbccddee / 10000;                  /* (abbccddee / 10000) */
+    u32 ddee = abbccddee - abbcc * 10000;           /* (abbccddee % 10000) */
+    u32 abb = (u32)(((u64)abbcc * 167773) >> 24);   /* (abbcc / 100) */
+    u32 a = (abb * 41) >> 12;                       /* (abb / 100) */
+    u32 bb = abb - a * 100;                         /* (abb % 100) */
+    u32 cc = abbcc - abb * 100;                     /* (abbcc % 100) */
 
-	/* write abbcc */
-	buf[0] = (u8)(a + '0');
-	buf += a > 0;
-	lz = bb < 10 && a == 0;
-	((v16 *)buf)[0] = *(const v16 *)(digit_table + (bb * 2 + lz));
-	buf -= lz;
-	((v16 *)buf)[1] = ((const v16 *)digit_table)[cc];
+    /* write abbcc */
+    buf[0] = (u8)(a + '0');
+    buf += a > 0;
+    lz = bb < 10 && a == 0;
+    byte_copy_2(buf + 0, digit_table + bb * 2 + lz);
+    buf -= lz;
+    byte_copy_2(buf + 2, digit_table + cc * 2);
 
-	if (ffgghhii) {
-		u32 dd = (ddee * 5243) >> 19;                        /* (ddee / 100) */
-		u32 ee = ddee - dd * 100;                            /* (ddee % 100) */
-		u32 ffgg = (u32)(((u64)ffgghhii * 109951163) >> 40); /* (val / 10000) */
-		u32 hhii = ffgghhii - ffgg * 10000;                  /* (val % 10000) */
-		u32 ff = (ffgg * 5243) >> 19;                        /* (aabb / 100) */
-		u32 gg = ffgg - ff * 100;                            /* (aabb % 100) */
-		((v16 *)buf)[2] = ((const v16 *)digit_table)[dd];
-		((v16 *)buf)[3] = ((const v16 *)digit_table)[ee];
-		((v16 *)buf)[4] = ((const v16 *)digit_table)[ff];
-		((v16 *)buf)[5] = ((const v16 *)digit_table)[gg];
-		if (hhii) {
-			u32 hh = (hhii * 5243) >> 19; /* (ccdd / 100) */
-			u32 ii = hhii - hh * 100;     /* (ccdd % 100) */
-			((v16 *)buf)[6] = ((const v16 *)digit_table)[hh];
-			((v16 *)buf)[7] = ((const v16 *)digit_table)[ii];
-			tz1 = dec_trailing_zero_table[hh];
-			tz2 = dec_trailing_zero_table[ii];
-			tz = ii ? tz2 : (tz1 + 2);
-			buf += 16 - tz;
-			return buf;
-		} else {
-			tz1 = dec_trailing_zero_table[ff];
-			tz2 = dec_trailing_zero_table[gg];
-			tz = gg ? tz2 : (tz1 + 2);
-			buf += 12 - tz;
-			return buf;
-		}
-	} else {
-		if (ddee) {
-			u32 dd = (ddee * 5243) >> 19; /* (ddee / 100) */
-			u32 ee = ddee - dd * 100;     /* (ddee % 100) */
-			((v16 *)buf)[2] = ((const v16 *)digit_table)[dd];
-			((v16 *)buf)[3] = ((const v16 *)digit_table)[ee];
-			tz1 = dec_trailing_zero_table[dd];
-			tz2 = dec_trailing_zero_table[ee];
-			tz = ee ? tz2 : (tz1 + 2);
-			buf += 8 - tz;
-			return buf;
-		} else {
-			tz1 = dec_trailing_zero_table[bb];
-			tz2 = dec_trailing_zero_table[cc];
-			tz = cc ? tz2 : (tz1 + tz2);
-			buf += 4 - tz;
-			return buf;
-		}
-	}
+    if (ffgghhii) {
+        u32 dd = (ddee * 5243) >> 19;               /* (ddee / 100) */
+        u32 ee = ddee - dd * 100;                   /* (ddee % 100) */
+        u32 ffgg = (u32)(((u64)ffgghhii * 109951163) >> 40); /* (val / 10000) */
+        u32 hhii = ffgghhii - ffgg * 10000;         /* (val % 10000) */
+        u32 ff = (ffgg * 5243) >> 19;               /* (aabb / 100) */
+        u32 gg = ffgg - ff * 100;                   /* (aabb % 100) */
+        byte_copy_2(buf + 4, digit_table + dd * 2);
+        byte_copy_2(buf + 6, digit_table + ee * 2);
+        byte_copy_2(buf + 8, digit_table + ff * 2);
+        byte_copy_2(buf + 10, digit_table + gg * 2);
+        if (hhii) {
+            u32 hh = (hhii * 5243) >> 19;           /* (ccdd / 100) */
+            u32 ii = hhii - hh * 100;               /* (ccdd % 100) */
+            byte_copy_2(buf + 12, digit_table + hh * 2);
+            byte_copy_2(buf + 14, digit_table + ii * 2);
+            tz1 = dec_trailing_zero_table[hh];
+            tz2 = dec_trailing_zero_table[ii];
+            tz = ii ? tz2 : (tz1 + 2);
+            buf += 16 - tz;
+            return buf;
+        } else {
+            tz1 = dec_trailing_zero_table[ff];
+            tz2 = dec_trailing_zero_table[gg];
+            tz = gg ? tz2 : (tz1 + 2);
+            buf += 12 - tz;
+            return buf;
+        }
+    } else {
+        if (ddee) {
+            u32 dd = (ddee * 5243) >> 19;           /* (ddee / 100) */
+            u32 ee = ddee - dd * 100;               /* (ddee % 100) */
+            byte_copy_2(buf + 4, digit_table + dd * 2);
+            byte_copy_2(buf + 6, digit_table + ee * 2);
+            tz1 = dec_trailing_zero_table[dd];
+            tz2 = dec_trailing_zero_table[ee];
+            tz = ee ? tz2 : (tz1 + 2);
+            buf += 8 - tz;
+            return buf;
+        } else {
+            tz1 = dec_trailing_zero_table[bb];
+            tz2 = dec_trailing_zero_table[cc];
+            tz = cc ? tz2 : (tz1 + tz2);
+            buf += 4 - tz;
+            return buf;
+        }
+    }
 }
 
 /** Write a signed integer in the range -324 to 308. */
 static_inline u8 *write_f64_exp(i32 exp, u8 *buf) {
-	buf[0] = '-';
-	buf += exp < 0;
-	exp = exp < 0 ? -exp : exp;
-	if (exp < 100) {
-		u32 lz = exp < 10;
-		*(v16 *)&buf[0] = *(const v16 *)(digit_table + ((u32)exp * 2 + lz));
-		return buf + 2 - lz;
-	} else {
-		u32 hi = ((u32)exp * 656) >> 16; /* exp / 100 */
-		u32 lo = (u32)exp - hi * 100;    /* exp % 100 */
-		buf[0] = (u8)((u8)hi + (u8)'0');
-		*(v16 *)&buf[1] = *(const v16 *)(digit_table + (lo * 2));
-		return buf + 3;
-	}
+    buf[0] = '-';
+    buf += exp < 0;
+    exp = exp < 0 ? -exp : exp;
+    if (exp < 100) {
+        u32 lz = exp < 10;
+        byte_copy_2(buf + 0, digit_table + (u32)exp * 2 + lz);
+        return buf + 2 - lz;
+    } else {
+        u32 hi = ((u32)exp * 656) >> 16;            /* exp / 100 */
+        u32 lo = (u32)exp - hi * 100;               /* exp % 100 */
+        buf[0] = (u8)((u8)hi + (u8)'0');
+        byte_copy_2(buf + 1, digit_table + lo * 2);
+        return buf + 3;
+    }
 }
 
 /** Multiplies 128-bit integer and returns highest 64-bit rounded value. */
 static_inline u64 round_to_odd(u64 hi, u64 lo, u64 cp) {
-	u64 x_hi, x_lo, y_hi, y_lo;
-	u128_mul(cp, lo, &x_hi, &x_lo);
-	u128_mul_add(cp, hi, x_hi, &y_hi, &y_lo);
-	return y_hi | (y_lo > 1);
+    u64 x_hi, x_lo, y_hi, y_lo;
+    u128_mul(cp, lo, &x_hi, &x_lo);
+    u128_mul_add(cp, hi, x_hi, &y_hi, &y_lo);
+    return y_hi | (y_lo > 1);
 }
 
 /**
@@ -6246,61 +7293,64 @@ static_inline u64 round_to_odd(u64 hi, u64 lo, u64 cp) {
  @param exp_dec The output value of exponent in decimal.
  @warning The input double number should not be 0, inf, nan.
  */
-static_inline void f64_bin_to_dec(u64 sig_raw, u32 exp_raw, u64 sig_bin, i32 exp_bin, u64 *sig_dec, i32 *exp_dec) {
+static_inline void f64_bin_to_dec(u64 sig_raw, u32 exp_raw,
+                                  u64 sig_bin, i32 exp_bin,
+                                  u64 *sig_dec, i32 *exp_dec) {
 
-	bool is_even, regular_spacing, u_inside, w_inside, round_up;
-	u64 s, sp, cb, cbl, cbr, vb, vbl, vbr, pow10hi, pow10lo, upper, lower, mid;
-	i32 k, h, exp10;
+    bool is_even, regular_spacing, u_inside, w_inside, round_up;
+    u64 s, sp, cb, cbl, cbr, vb, vbl, vbr, pow10hi, pow10lo, upper, lower, mid;
+    i32 k, h, exp10;
 
-	is_even = !(sig_bin & 1);
-	regular_spacing = (sig_raw == 0 && exp_raw > 1);
+    is_even = !(sig_bin & 1);
+    regular_spacing = (sig_raw == 0 && exp_raw > 1);
 
-	cbl = 4 * sig_bin - 2 + regular_spacing;
-	cb = 4 * sig_bin;
-	cbr = 4 * sig_bin + 2;
+    cbl = 4 * sig_bin - 2 + regular_spacing;
+    cb  = 4 * sig_bin;
+    cbr = 4 * sig_bin + 2;
 
-	/* exp_bin: [-1074, 971]                                                  */
-	/* k = regular_spacing ? floor(log10(pow(2, exp_bin)))                    */
-	/*                     : floor(log10(pow(2, exp_bin) * 3.0 / 4.0))        */
-	/*   = regular_spacing ? floor(exp_bin * log10(2))                        */
-	/*                     : floor(exp_bin * log10(2) + log10(3.0 / 4.0))     */
-	k = (i32)(exp_bin * 315653 - (regular_spacing ? 131237 : 0)) >> 20;
+    /* exp_bin: [-1074, 971]                                                  */
+    /* k = regular_spacing ? floor(log10(pow(2, exp_bin)))                    */
+    /*                     : floor(log10(pow(2, exp_bin) * 3.0 / 4.0))        */
+    /*   = regular_spacing ? floor(exp_bin * log10(2))                        */
+    /*                     : floor(exp_bin * log10(2) + log10(3.0 / 4.0))     */
+    k = (i32)(exp_bin * 315653 - (regular_spacing ? 131237 : 0)) >> 20;
 
-	/* k: [-324, 292]                                                         */
-	/* h = exp_bin + floor(log2(pow(10, e)))                                  */
-	/*   = exp_bin + floor(log2(10) * e)                                      */
-	exp10 = -k;
-	h = exp_bin + ((exp10 * 217707) >> 16) + 1;
+    /* k: [-324, 292]                                                         */
+    /* h = exp_bin + floor(log2(pow(10, e)))                                  */
+    /*   = exp_bin + floor(log2(10) * e)                                      */
+    exp10 = -k;
+    h = exp_bin + ((exp10 * 217707) >> 16) + 1;
 
-	pow10_table_get_sig(exp10, &pow10hi, &pow10lo);
-	pow10lo += (exp10 < POW10_SIG_TABLE_MIN_EXACT_EXP || exp10 > POW10_SIG_TABLE_MAX_EXACT_EXP);
-	vbl = round_to_odd(pow10hi, pow10lo, cbl << h);
-	vb = round_to_odd(pow10hi, pow10lo, cb << h);
-	vbr = round_to_odd(pow10hi, pow10lo, cbr << h);
+    pow10_table_get_sig(exp10, &pow10hi, &pow10lo);
+    pow10lo += (exp10 < POW10_SIG_TABLE_MIN_EXACT_EXP ||
+                exp10 > POW10_SIG_TABLE_MAX_EXACT_EXP);
+    vbl = round_to_odd(pow10hi, pow10lo, cbl << h);
+    vb  = round_to_odd(pow10hi, pow10lo, cb  << h);
+    vbr = round_to_odd(pow10hi, pow10lo, cbr << h);
 
-	lower = vbl + !is_even;
-	upper = vbr - !is_even;
+    lower = vbl + !is_even;
+    upper = vbr - !is_even;
 
-	s = vb / 4;
-	if (s >= 10) {
-		sp = s / 10;
-		u_inside = (lower <= 40 * sp);
-		w_inside = (upper >= 40 * sp + 40);
-		if (u_inside != w_inside) {
-			*sig_dec = sp + w_inside;
-			*exp_dec = k + 1;
-			return;
-		}
-	}
+    s = vb / 4;
+    if (s >= 10) {
+        sp = s / 10;
+        u_inside = (lower <= 40 * sp);
+        w_inside = (upper >= 40 * sp + 40);
+        if (u_inside != w_inside) {
+            *sig_dec = sp + w_inside;
+            *exp_dec = k + 1;
+            return;
+        }
+    }
 
-	u_inside = (lower <= 4 * s);
-	w_inside = (upper >= 4 * s + 4);
+    u_inside = (lower <= 4 * s);
+    w_inside = (upper >= 4 * s + 4);
 
-	mid = 4 * s + 2;
-	round_up = (vb > mid) || (vb == mid && (s & 1) != 0);
+    mid = 4 * s + 2;
+    round_up = (vb > mid) || (vb == mid && (s & 1) != 0);
 
-	*sig_dec = s + ((u_inside != w_inside) ? w_inside : round_up);
-	*exp_dec = k;
+    *sig_dec = s + ((u_inside != w_inside) ? w_inside : round_up);
+    *exp_dec = k;
 }
 
 /**
@@ -6312,237 +7362,236 @@ static_inline void f64_bin_to_dec(u64 sig_raw, u32 exp_raw, u64 sig_bin, i32 exp
  2. Keep decimal point to indicate the number is floating point.
  3. Remove positive sign of exponent part.
  */
-static_noinline u8 *write_f64_raw(u8 *buf, u64 raw, yyjson_write_flag flg) {
-	u64 sig_bin, sig_dec, sig_raw;
-	i32 exp_bin, exp_dec, sig_len, dot_pos, i, max;
-	u32 exp_raw, hi, lo;
-	u8 *hdr, *num_hdr, *num_end, *dot_end;
-	bool sign;
+static_inline u8 *write_f64_raw(u8 *buf, u64 raw, yyjson_write_flag flg) {
+    u64 sig_bin, sig_dec, sig_raw;
+    i32 exp_bin, exp_dec, sig_len, dot_pos, i, max;
+    u32 exp_raw, hi, lo;
+    u8 *hdr, *num_hdr, *num_end, *dot_end;
+    bool sign;
 
-	/* decode raw bytes from IEEE-754 double format. */
-	sign = (bool)(raw >> (F64_BITS - 1));
-	sig_raw = raw & F64_SIG_MASK;
-	exp_raw = (u32)((raw & F64_EXP_MASK) >> F64_SIG_BITS);
+    /* decode raw bytes from IEEE-754 double format. */
+    sign = (bool)(raw >> (F64_BITS - 1));
+    sig_raw = raw & F64_SIG_MASK;
+    exp_raw = (u32)((raw & F64_EXP_MASK) >> F64_SIG_BITS);
 
-	/* return inf and nan */
-	if (unlikely(exp_raw == ((u32)1 << F64_EXP_BITS) - 1)) {
-		if (flg & YYJSON_WRITE_INF_AND_NAN_AS_NULL) {
-			byte_copy_4(buf, "null");
-			return buf + 4;
-		} else if (flg & YYJSON_WRITE_ALLOW_INF_AND_NAN) {
-			if (sig_raw == 0) {
-				buf[0] = '-';
-				buf += sign;
-				byte_copy_8(buf, "Infinity");
-				buf += 8;
-				return buf;
-			} else {
-				byte_copy_4(buf, "NaN");
-				return buf + 3;
-			}
-		} else {
-			return NULL;
-		}
-	}
+    /* return inf and nan */
+    if (unlikely(exp_raw == ((u32)1 << F64_EXP_BITS) - 1)) {
+        if (has_write_flag(INF_AND_NAN_AS_NULL)) {
+            byte_copy_4(buf, "null");
+            return buf + 4;
+        }
+        else if (has_write_flag(ALLOW_INF_AND_NAN)) {
+            if (sig_raw == 0) {
+                buf[0] = '-';
+                buf += sign;
+                byte_copy_8(buf, "Infinity");
+                buf += 8;
+                return buf;
+            } else {
+                byte_copy_4(buf, "NaN");
+                return buf + 3;
+            }
+        }
+        return NULL;
+    }
 
-	/* add sign for all finite double value, including 0.0 and inf */
-	buf[0] = '-';
-	buf += sign;
-	hdr = buf;
+    /* add sign for all finite double value, including 0.0 and inf */
+    buf[0] = '-';
+    buf += sign;
+    hdr = buf;
 
-	/* return zero */
-	if ((raw << 1) == 0) {
-		byte_copy_4(buf, "0.0");
-		buf += 3;
-		return buf;
-	}
+    /* return zero */
+    if ((raw << 1) == 0) {
+        byte_copy_4(buf, "0.0");
+        buf += 3;
+        return buf;
+    }
 
-	if (likely(exp_raw != 0)) {
-		/* normal number */
-		sig_bin = sig_raw | ((u64)1 << F64_SIG_BITS);
-		exp_bin = (i32)exp_raw - F64_EXP_BIAS - F64_SIG_BITS;
+    if (likely(exp_raw != 0)) {
+        /* normal number */
+        sig_bin = sig_raw | ((u64)1 << F64_SIG_BITS);
+        exp_bin = (i32)exp_raw - F64_EXP_BIAS - F64_SIG_BITS;
 
-		/* fast path for small integer number without fraction */
-		if (-F64_SIG_BITS <= exp_bin && exp_bin <= 0) {
-			if (u64_tz_bits(sig_bin) >= (u32)-exp_bin) {
-				/* number is integer in range 1 to 0x1FFFFFFFFFFFFF */
-				sig_dec = sig_bin >> -exp_bin;
-				buf = write_u64_len_1_to_16(sig_dec, buf);
-				byte_copy_2(buf, ".0");
-				buf += 2;
-				return buf;
-			}
-		}
+        /* fast path for small integer number without fraction */
+        if (-F64_SIG_BITS <= exp_bin && exp_bin <= 0) {
+            if (u64_tz_bits(sig_bin) >= (u32)-exp_bin) {
+                /* number is integer in range 1 to 0x1FFFFFFFFFFFFF */
+                sig_dec = sig_bin >> -exp_bin;
+                buf = write_u64_len_1_to_16(sig_dec, buf);
+                byte_copy_2(buf, ".0");
+                buf += 2;
+                return buf;
+            }
+        }
 
-		/* binary to decimal */
-		f64_bin_to_dec(sig_raw, exp_raw, sig_bin, exp_bin, &sig_dec, &exp_dec);
+        /* binary to decimal */
+        f64_bin_to_dec(sig_raw, exp_raw, sig_bin, exp_bin, &sig_dec, &exp_dec);
 
-		/* the sig length is 15 to 17 */
-		sig_len = 17;
-		sig_len -= (sig_dec < (u64)100000000 * 100000000);
-		sig_len -= (sig_dec < (u64)100000000 * 10000000);
+        /* the sig length is 15 to 17 */
+        sig_len = 17;
+        sig_len -= (sig_dec < (u64)100000000 * 100000000);
+        sig_len -= (sig_dec < (u64)100000000 * 10000000);
 
-		/* the decimal point position relative to the first digit */
-		dot_pos = sig_len + exp_dec;
+        /* the decimal point position relative to the first digit */
+        dot_pos = sig_len + exp_dec;
 
-		if (-6 < dot_pos && dot_pos <= 21) {
-			/* no need to write exponent part */
-			if (dot_pos <= 0) {
-				/* dot before first digit */
-				/* such as 0.1234, 0.000001234 */
-				num_hdr = hdr + (2 - dot_pos);
-				num_end = write_u64_len_15_to_17_trim(num_hdr, sig_dec);
-				hdr[0] = '0';
-				hdr[1] = '.';
-				hdr += 2;
-				max = -dot_pos;
-				for (i = 0; i < max; i++)
-					hdr[i] = '0';
-				return num_end;
-			} else {
-				/* dot after first digit */
-				/* such as 1.234, 1234.0, 123400000000000000000.0 */
-				memset(hdr + 0, '0', 8);
-				memset(hdr + 8, '0', 8);
-				memset(hdr + 16, '0', 8);
-				num_hdr = hdr + 1;
-				num_end = write_u64_len_15_to_17_trim(num_hdr, sig_dec);
-				for (i = 0; i < dot_pos; i++)
-					hdr[i] = hdr[i + 1];
-				hdr[dot_pos] = '.';
-				dot_end = hdr + dot_pos + 2;
-				return dot_end < num_end ? num_end : dot_end;
-			}
-		} else {
-			/* write with scientific notation */
-			/* such as 1.234e56 */
-			u8 *end = write_u64_len_15_to_17_trim(buf + 1, sig_dec);
-			end -= (end == buf + 2); /* remove '.0', e.g. 2.0e34 -> 2e34 */
-			exp_dec += sig_len - 1;
-			hdr[0] = hdr[1];
-			hdr[1] = '.';
-			end[0] = 'e';
-			buf = write_f64_exp(exp_dec, end + 1);
-			return buf;
-		}
+        if (-6 < dot_pos && dot_pos <= 21) {
+            /* no need to write exponent part */
+            if (dot_pos <= 0) {
+                /* dot before first digit */
+                /* such as 0.1234, 0.000001234 */
+                num_hdr = hdr + (2 - dot_pos);
+                num_end = write_u64_len_15_to_17_trim(num_hdr, sig_dec);
+                hdr[0] = '0';
+                hdr[1] = '.';
+                hdr += 2;
+                max = -dot_pos;
+                for (i = 0; i < max; i++) hdr[i] = '0';
+                return num_end;
+            } else {
+                /* dot after first digit */
+                /* such as 1.234, 1234.0, 123400000000000000000.0 */
+                memset(hdr +  0, '0', 8);
+                memset(hdr +  8, '0', 8);
+                memset(hdr + 16, '0', 8);
+                num_hdr = hdr + 1;
+                num_end = write_u64_len_15_to_17_trim(num_hdr, sig_dec);
+                for (i = 0; i < dot_pos; i++) hdr[i] = hdr[i + 1];
+                hdr[dot_pos] = '.';
+                dot_end = hdr + dot_pos + 2;
+                return dot_end < num_end ? num_end : dot_end;
+            }
+        } else {
+            /* write with scientific notation */
+            /* such as 1.234e56 */
+            u8 *end = write_u64_len_15_to_17_trim(buf + 1, sig_dec);
+            end -= (end == buf + 2); /* remove '.0', e.g. 2.0e34 -> 2e34 */
+            exp_dec += sig_len - 1;
+            hdr[0] = hdr[1];
+            hdr[1] = '.';
+            end[0] = 'e';
+            buf = write_f64_exp(exp_dec, end + 1);
+            return buf;
+        }
 
-	} else {
-		/* subnormal number */
-		sig_bin = sig_raw;
-		exp_bin = 1 - F64_EXP_BIAS - F64_SIG_BITS;
+    } else {
+        /* subnormal number */
+        sig_bin = sig_raw;
+        exp_bin = 1 - F64_EXP_BIAS - F64_SIG_BITS;
 
-		/* binary to decimal */
-		f64_bin_to_dec(sig_raw, exp_raw, sig_bin, exp_bin, &sig_dec, &exp_dec);
+        /* binary to decimal */
+        f64_bin_to_dec(sig_raw, exp_raw, sig_bin, exp_bin, &sig_dec, &exp_dec);
 
-		/* write significand part */
-		buf = write_u64_len_1_to_17(sig_dec, buf + 1);
-		hdr[0] = hdr[1];
-		hdr[1] = '.';
-		do {
-			buf--;
-			exp_dec++;
-		} while (*buf == '0');
-		exp_dec += (i32)(buf - hdr - 2);
-		buf += (*buf != '.');
-		buf[0] = 'e';
-		buf++;
+        /* write significand part */
+        buf = write_u64_len_1_to_17(sig_dec, buf + 1);
+        hdr[0] = hdr[1];
+        hdr[1] = '.';
+        do {
+            buf--;
+            exp_dec++;
+        } while (*buf == '0');
+        exp_dec += (i32)(buf - hdr - 2);
+        buf += (*buf != '.');
+        buf[0] = 'e';
+        buf++;
 
-		/* write exponent part */
-		buf[0] = '-';
-		buf++;
-		exp_dec = -exp_dec;
-		hi = ((u32)exp_dec * 656) >> 16; /* exp / 100 */
-		lo = (u32)exp_dec - hi * 100;    /* exp % 100 */
-		buf[0] = (u8)((u8)hi + (u8)'0');
-		*(v16 *)&buf[1] = *(const v16 *)(digit_table + (lo * 2));
-		buf += 3;
-		return buf;
-	}
+        /* write exponent part */
+        buf[0] = '-';
+        buf++;
+        exp_dec = -exp_dec;
+        hi = ((u32)exp_dec * 656) >> 16; /* exp / 100 */
+        lo = (u32)exp_dec - hi * 100; /* exp % 100 */
+        buf[0] = (u8)((u8)hi + (u8)'0');
+        byte_copy_2(buf + 1, digit_table + lo * 2);
+        buf += 3;
+        return buf;
+    }
 }
 
 #else /* FP_WRITER */
 
 /** Write a double number (requires 32 bytes buffer). */
-static_noinline u8 *write_f64_raw(u8 *buf, u64 raw, yyjson_write_flag flg) {
-	/*
-	 For IEEE 754, `DBL_DECIMAL_DIG` is 17 for round-trip.
-	 For non-IEEE formats, 17 is used to avoid buffer overflow,
-	 round-trip is not guaranteed.
-	 */
-#if defined(DBL_DECIMAL_DIG)
-	int dig = DBL_DECIMAL_DIG > 17 ? 17 : DBL_DECIMAL_DIG;
+static_inline u8 *write_f64_raw(u8 *buf, u64 raw, yyjson_write_flag flg) {
+    /*
+     For IEEE 754, `DBL_DECIMAL_DIG` is 17 for round-trip.
+     For non-IEEE formats, 17 is used to avoid buffer overflow,
+     round-trip is not guaranteed.
+     */
+#if defined(DBL_DECIMAL_DIG) && DBL_DECIMAL_DIG != 17
+    int dig = DBL_DECIMAL_DIG > 17 ? 17 : DBL_DECIMAL_DIG;
 #else
-	int dig = 17;
+    int dig = 17;
 #endif
 
-	/*
-	 The snprintf() function is locale-dependent. For currently known locales,
-	 (en, zh, ja, ko, am, he, hi) use '.' as the decimal point, while other
-	 locales use ',' as the decimal point. we need to replace ',' with '.'
-	 to avoid the locale setting.
-	 */
-	f64 val = f64_from_raw(raw);
+    /*
+     The snprintf() function is locale-dependent. For currently known locales,
+     (en, zh, ja, ko, am, he, hi) use '.' as the decimal point, while other
+     locales use ',' as the decimal point. we need to replace ',' with '.'
+     to avoid the locale setting.
+     */
+    f64 val = f64_from_raw(raw);
 #if YYJSON_MSC_VER >= 1400
-	int len = sprintf_s((char *)buf, 32, "%.*g", dig, val);
+    int len = sprintf_s((char *)buf, 32, "%.*g", dig, val);
 #elif defined(snprintf) || (YYJSON_STDC_VER >= 199901L)
-	int len = snprintf((char *)buf, 32, "%.*g", dig, val);
+    int len = snprintf((char *)buf, 32, "%.*g", dig, val);
 #else
-	int len = sprintf((char *)buf, "%.*g", dig, val);
+    int len = sprintf((char *)buf, "%.*g", dig, val);
 #endif
 
-	u8 *cur = buf;
-	if (unlikely(len < 1))
-		return NULL;
-	cur += (*cur == '-');
-	if (unlikely(!digi_is_digit(*cur))) {
-		/* nan, inf, or bad output */
-		if (flg & YYJSON_WRITE_INF_AND_NAN_AS_NULL) {
-			byte_copy_4(buf, "null");
-			return buf + 4;
-		} else if (flg & YYJSON_WRITE_ALLOW_INF_AND_NAN) {
-			if (*cur == 'i') {
-				byte_copy_8(cur, "Infinity");
-				cur += 8;
-				return cur;
-			} else if (*cur == 'n') {
-				byte_copy_4(buf, "NaN");
-				return buf + 3;
-			}
-		}
-		return NULL;
-	} else {
-		/* finite number */
-		int i = 0;
-		bool fp = false;
-		for (; i < len; i++) {
-			if (buf[i] == ',')
-				buf[i] = '.';
-			if (digi_is_fp((u8)buf[i]))
-				fp = true;
-		}
-		if (!fp) {
-			buf[len++] = '.';
-			buf[len++] = '0';
-		}
-	}
-	return buf + len;
+    u8 *cur = buf;
+    if (unlikely(len < 1)) return NULL;
+    cur += (*cur == '-');
+    if (unlikely(!digi_is_digit(*cur))) {
+        /* nan, inf, or bad output */
+        if (has_write_flag(INF_AND_NAN_AS_NULL)) {
+            byte_copy_4(buf, "null");
+            return buf + 4;
+        }
+        else if (has_write_flag(ALLOW_INF_AND_NAN)) {
+            if (*cur == 'i') {
+                byte_copy_8(cur, "Infinity");
+                cur += 8;
+                return cur;
+            } else if (*cur == 'n') {
+                byte_copy_4(buf, "NaN");
+                return buf + 3;
+            }
+        }
+        return NULL;
+    } else {
+        /* finite number */
+        int i = 0;
+        bool fp = false;
+        for (; i < len; i++) {
+            if (buf[i] == ',') buf[i] = '.';
+            if (digi_is_fp((u8)buf[i])) fp = true;
+        }
+        if (!fp) {
+            buf[len++] = '.';
+            buf[len++] = '0';
+        }
+    }
+    return buf + len;
 }
 
 #endif /* FP_WRITER */
 
 /** Write a JSON number (requires 32 bytes buffer). */
-static_inline u8 *write_number(u8 *cur, yyjson_val *val, yyjson_write_flag flg) {
-	if (val->tag & YYJSON_SUBTYPE_REAL) {
-		u64 raw = val->uni.u64;
-		return write_f64_raw(cur, raw, flg);
-	} else {
-		u64 pos = val->uni.u64;
-		u64 neg = ~pos + 1;
-		usize sgn = ((val->tag & YYJSON_SUBTYPE_SINT) > 0) & ((i64)pos < 0);
-		*cur = '-';
-		return write_u64(sgn ? neg : pos, cur + sgn);
-	}
+static_inline u8 *write_number(u8 *cur, yyjson_val *val,
+                               yyjson_write_flag flg) {
+    if (val->tag & YYJSON_SUBTYPE_REAL) {
+        u64 raw = val->uni.u64;
+        return write_f64_raw(cur, raw, flg);
+    } else {
+        u64 pos = val->uni.u64;
+        u64 neg = ~pos + 1;
+        usize sgn = ((val->tag & YYJSON_SUBTYPE_SINT) > 0) & ((i64)pos < 0);
+        *cur = '-';
+        return write_u64(sgn ? neg : pos, cur + sgn);
+    }
 }
+
+
 
 /*==============================================================================
  * String Writer
@@ -6550,137 +7599,291 @@ static_inline u8 *write_number(u8 *cur, yyjson_val *val, yyjson_write_flag flg) 
 
 /** Character encode type, if (type > CHAR_ENC_ERR_1) bytes = type / 2; */
 typedef u8 char_enc_type;
-#define CHAR_ENC_CPY_1 0 /* 1-byte UTF-8, copy. */
-#define CHAR_ENC_ERR_1 1 /* 1-byte UTF-8, error. */
-#define CHAR_ENC_ESC_A 2 /* 1-byte ASCII, escaped as '\x'. */
-#define CHAR_ENC_ESC_1 3 /* 1-byte UTF-8, escaped as '\uXXXX'. */
-#define CHAR_ENC_CPY_2 4 /* 2-byte UTF-8, copy. */
-#define CHAR_ENC_ESC_2 5 /* 2-byte UTF-8, escaped as '\uXXXX'. */
-#define CHAR_ENC_CPY_3 6 /* 3-byte UTF-8, copy. */
-#define CHAR_ENC_ESC_3 7 /* 3-byte UTF-8, escaped as '\uXXXX'. */
-#define CHAR_ENC_CPY_4 8 /* 4-byte UTF-8, copy. */
-#define CHAR_ENC_ESC_4 9 /* 4-byte UTF-8, escaped as '\uXXXX\uXXXX'. */
+#define CHAR_ENC_CPY_1  0 /* 1-byte UTF-8, copy. */
+#define CHAR_ENC_ERR_1  1 /* 1-byte UTF-8, error. */
+#define CHAR_ENC_ESC_A  2 /* 1-byte ASCII, escaped as '\x'. */
+#define CHAR_ENC_ESC_1  3 /* 1-byte UTF-8, escaped as '\uXXXX'. */
+#define CHAR_ENC_CPY_2  4 /* 2-byte UTF-8, copy. */
+#define CHAR_ENC_ESC_2  5 /* 2-byte UTF-8, escaped as '\uXXXX'. */
+#define CHAR_ENC_CPY_3  6 /* 3-byte UTF-8, copy. */
+#define CHAR_ENC_ESC_3  7 /* 3-byte UTF-8, escaped as '\uXXXX'. */
+#define CHAR_ENC_CPY_4  8 /* 4-byte UTF-8, copy. */
+#define CHAR_ENC_ESC_4  9 /* 4-byte UTF-8, escaped as '\uXXXX\uXXXX'. */
 
 /** Character encode type table: don't escape unicode, don't escape '/'.
     (generate with misc/make_tables.c) */
 static const char_enc_type enc_table_cpy[256] = {
-    3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 3, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 2, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1};
+    3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 3, 2, 2, 3, 3,
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1
+};
 
 /** Character encode type table: don't escape unicode, escape '/'.
     (generate with misc/make_tables.c) */
 static const char_enc_type enc_table_cpy_slash[256] = {
-    3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 3, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 2, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1};
+    3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 3, 2, 2, 3, 3,
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    8, 8, 8, 8, 8, 8, 8, 8, 1, 1, 1, 1, 1, 1, 1, 1
+};
 
 /** Character encode type table: escape unicode, don't escape '/'.
     (generate with misc/make_tables.c) */
 static const char_enc_type enc_table_esc[256] = {
-    3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 3, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 2, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
-    5, 5, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 9, 9, 9, 9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1};
+    3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 3, 2, 2, 3, 3,
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    9, 9, 9, 9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1
+};
 
 /** Character encode type table: escape unicode, escape '/'.
     (generate with misc/make_tables.c) */
 static const char_enc_type enc_table_esc_slash[256] = {
-    3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 3, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 2, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
-    5, 5, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 9, 9, 9, 9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1};
+    3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 3, 2, 2, 3, 3,
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    9, 9, 9, 9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1
+};
 
 /** Escaped hex character table: ["00" "01" "02" ... "FD" "FE" "FF"].
     (generate with misc/make_tables.c) */
-yyjson_align(2) static const u8 esc_hex_char_table[512] = {
-    '0', '0', '0', '1', '0', '2', '0', '3', '0', '4', '0', '5', '0', '6', '0', '7', '0', '8', '0', '9', '0', 'A', '0',
-    'B', '0', 'C', '0', 'D', '0', 'E', '0', 'F', '1', '0', '1', '1', '1', '2', '1', '3', '1', '4', '1', '5', '1', '6',
-    '1', '7', '1', '8', '1', '9', '1', 'A', '1', 'B', '1', 'C', '1', 'D', '1', 'E', '1', 'F', '2', '0', '2', '1', '2',
-    '2', '2', '3', '2', '4', '2', '5', '2', '6', '2', '7', '2', '8', '2', '9', '2', 'A', '2', 'B', '2', 'C', '2', 'D',
-    '2', 'E', '2', 'F', '3', '0', '3', '1', '3', '2', '3', '3', '3', '4', '3', '5', '3', '6', '3', '7', '3', '8', '3',
-    '9', '3', 'A', '3', 'B', '3', 'C', '3', 'D', '3', 'E', '3', 'F', '4', '0', '4', '1', '4', '2', '4', '3', '4', '4',
-    '4', '5', '4', '6', '4', '7', '4', '8', '4', '9', '4', 'A', '4', 'B', '4', 'C', '4', 'D', '4', 'E', '4', 'F', '5',
-    '0', '5', '1', '5', '2', '5', '3', '5', '4', '5', '5', '5', '6', '5', '7', '5', '8', '5', '9', '5', 'A', '5', 'B',
-    '5', 'C', '5', 'D', '5', 'E', '5', 'F', '6', '0', '6', '1', '6', '2', '6', '3', '6', '4', '6', '5', '6', '6', '6',
-    '7', '6', '8', '6', '9', '6', 'A', '6', 'B', '6', 'C', '6', 'D', '6', 'E', '6', 'F', '7', '0', '7', '1', '7', '2',
-    '7', '3', '7', '4', '7', '5', '7', '6', '7', '7', '7', '8', '7', '9', '7', 'A', '7', 'B', '7', 'C', '7', 'D', '7',
-    'E', '7', 'F', '8', '0', '8', '1', '8', '2', '8', '3', '8', '4', '8', '5', '8', '6', '8', '7', '8', '8', '8', '9',
-    '8', 'A', '8', 'B', '8', 'C', '8', 'D', '8', 'E', '8', 'F', '9', '0', '9', '1', '9', '2', '9', '3', '9', '4', '9',
-    '5', '9', '6', '9', '7', '9', '8', '9', '9', '9', 'A', '9', 'B', '9', 'C', '9', 'D', '9', 'E', '9', 'F', 'A', '0',
-    'A', '1', 'A', '2', 'A', '3', 'A', '4', 'A', '5', 'A', '6', 'A', '7', 'A', '8', 'A', '9', 'A', 'A', 'A', 'B', 'A',
-    'C', 'A', 'D', 'A', 'E', 'A', 'F', 'B', '0', 'B', '1', 'B', '2', 'B', '3', 'B', '4', 'B', '5', 'B', '6', 'B', '7',
-    'B', '8', 'B', '9', 'B', 'A', 'B', 'B', 'B', 'C', 'B', 'D', 'B', 'E', 'B', 'F', 'C', '0', 'C', '1', 'C', '2', 'C',
-    '3', 'C', '4', 'C', '5', 'C', '6', 'C', '7', 'C', '8', 'C', '9', 'C', 'A', 'C', 'B', 'C', 'C', 'C', 'D', 'C', 'E',
-    'C', 'F', 'D', '0', 'D', '1', 'D', '2', 'D', '3', 'D', '4', 'D', '5', 'D', '6', 'D', '7', 'D', '8', 'D', '9', 'D',
-    'A', 'D', 'B', 'D', 'C', 'D', 'D', 'D', 'E', 'D', 'F', 'E', '0', 'E', '1', 'E', '2', 'E', '3', 'E', '4', 'E', '5',
-    'E', '6', 'E', '7', 'E', '8', 'E', '9', 'E', 'A', 'E', 'B', 'E', 'C', 'E', 'D', 'E', 'E', 'E', 'F', 'F', '0', 'F',
-    '1', 'F', '2', 'F', '3', 'F', '4', 'F', '5', 'F', '6', 'F', '7', 'F', '8', 'F', '9', 'F', 'A', 'F', 'B', 'F', 'C',
-    'F', 'D', 'F', 'E', 'F', 'F'};
+yyjson_align(2)
+static const u8 esc_hex_char_table[512] = {
+    '0', '0', '0', '1', '0', '2', '0', '3',
+    '0', '4', '0', '5', '0', '6', '0', '7',
+    '0', '8', '0', '9', '0', 'A', '0', 'B',
+    '0', 'C', '0', 'D', '0', 'E', '0', 'F',
+    '1', '0', '1', '1', '1', '2', '1', '3',
+    '1', '4', '1', '5', '1', '6', '1', '7',
+    '1', '8', '1', '9', '1', 'A', '1', 'B',
+    '1', 'C', '1', 'D', '1', 'E', '1', 'F',
+    '2', '0', '2', '1', '2', '2', '2', '3',
+    '2', '4', '2', '5', '2', '6', '2', '7',
+    '2', '8', '2', '9', '2', 'A', '2', 'B',
+    '2', 'C', '2', 'D', '2', 'E', '2', 'F',
+    '3', '0', '3', '1', '3', '2', '3', '3',
+    '3', '4', '3', '5', '3', '6', '3', '7',
+    '3', '8', '3', '9', '3', 'A', '3', 'B',
+    '3', 'C', '3', 'D', '3', 'E', '3', 'F',
+    '4', '0', '4', '1', '4', '2', '4', '3',
+    '4', '4', '4', '5', '4', '6', '4', '7',
+    '4', '8', '4', '9', '4', 'A', '4', 'B',
+    '4', 'C', '4', 'D', '4', 'E', '4', 'F',
+    '5', '0', '5', '1', '5', '2', '5', '3',
+    '5', '4', '5', '5', '5', '6', '5', '7',
+    '5', '8', '5', '9', '5', 'A', '5', 'B',
+    '5', 'C', '5', 'D', '5', 'E', '5', 'F',
+    '6', '0', '6', '1', '6', '2', '6', '3',
+    '6', '4', '6', '5', '6', '6', '6', '7',
+    '6', '8', '6', '9', '6', 'A', '6', 'B',
+    '6', 'C', '6', 'D', '6', 'E', '6', 'F',
+    '7', '0', '7', '1', '7', '2', '7', '3',
+    '7', '4', '7', '5', '7', '6', '7', '7',
+    '7', '8', '7', '9', '7', 'A', '7', 'B',
+    '7', 'C', '7', 'D', '7', 'E', '7', 'F',
+    '8', '0', '8', '1', '8', '2', '8', '3',
+    '8', '4', '8', '5', '8', '6', '8', '7',
+    '8', '8', '8', '9', '8', 'A', '8', 'B',
+    '8', 'C', '8', 'D', '8', 'E', '8', 'F',
+    '9', '0', '9', '1', '9', '2', '9', '3',
+    '9', '4', '9', '5', '9', '6', '9', '7',
+    '9', '8', '9', '9', '9', 'A', '9', 'B',
+    '9', 'C', '9', 'D', '9', 'E', '9', 'F',
+    'A', '0', 'A', '1', 'A', '2', 'A', '3',
+    'A', '4', 'A', '5', 'A', '6', 'A', '7',
+    'A', '8', 'A', '9', 'A', 'A', 'A', 'B',
+    'A', 'C', 'A', 'D', 'A', 'E', 'A', 'F',
+    'B', '0', 'B', '1', 'B', '2', 'B', '3',
+    'B', '4', 'B', '5', 'B', '6', 'B', '7',
+    'B', '8', 'B', '9', 'B', 'A', 'B', 'B',
+    'B', 'C', 'B', 'D', 'B', 'E', 'B', 'F',
+    'C', '0', 'C', '1', 'C', '2', 'C', '3',
+    'C', '4', 'C', '5', 'C', '6', 'C', '7',
+    'C', '8', 'C', '9', 'C', 'A', 'C', 'B',
+    'C', 'C', 'C', 'D', 'C', 'E', 'C', 'F',
+    'D', '0', 'D', '1', 'D', '2', 'D', '3',
+    'D', '4', 'D', '5', 'D', '6', 'D', '7',
+    'D', '8', 'D', '9', 'D', 'A', 'D', 'B',
+    'D', 'C', 'D', 'D', 'D', 'E', 'D', 'F',
+    'E', '0', 'E', '1', 'E', '2', 'E', '3',
+    'E', '4', 'E', '5', 'E', '6', 'E', '7',
+    'E', '8', 'E', '9', 'E', 'A', 'E', 'B',
+    'E', 'C', 'E', 'D', 'E', 'E', 'E', 'F',
+    'F', '0', 'F', '1', 'F', '2', 'F', '3',
+    'F', '4', 'F', '5', 'F', '6', 'F', '7',
+    'F', '8', 'F', '9', 'F', 'A', 'F', 'B',
+    'F', 'C', 'F', 'D', 'F', 'E', 'F', 'F'
+};
 
 /** Escaped single character table. (generate with misc/make_tables.c) */
-yyjson_align(2) static const u8 esc_single_char_table[512] = {
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', '\\', 'b',  '\\', 't', '\\',
-    'n', ' ', ' ', '\\', 'f', '\\', 'r', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', '\\', '"', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', '\\', '/', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', '\\', '\\', ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' ', ' ', ' ', ' ',  ' ', ' ', ' ', ' ', ' ', ' ',  ' ',  ' ',  ' ', ' ',
-    ' ', ' ', ' ', ' ',  ' ', ' ',  ' ', ' '};
+yyjson_align(2)
+static const u8 esc_single_char_table[512] = {
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    '\\', 'b', '\\', 't', '\\', 'n', ' ', ' ',
+    '\\', 'f', '\\', 'r', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', '\\', '"', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', '\\', '/',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    '\\', '\\', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '
+};
 
 /** Returns the encode table with options. */
-static_inline const char_enc_type *get_enc_table_with_flag(yyjson_read_flag flg) {
-	if (unlikely(flg & YYJSON_WRITE_ESCAPE_UNICODE)) {
-		if (unlikely(flg & YYJSON_WRITE_ESCAPE_SLASHES)) {
-			return enc_table_esc_slash;
-		} else {
-			return enc_table_esc;
-		}
-	} else {
-		if (unlikely(flg & YYJSON_WRITE_ESCAPE_SLASHES)) {
-			return enc_table_cpy_slash;
-		} else {
-			return enc_table_cpy;
-		}
-	}
+static_inline const char_enc_type *get_enc_table_with_flag(
+    yyjson_read_flag flg) {
+    if (has_write_flag(ESCAPE_UNICODE)) {
+        if (has_write_flag(ESCAPE_SLASHES)) {
+            return enc_table_esc_slash;
+        } else {
+            return enc_table_esc;
+        }
+    } else {
+        if (has_write_flag(ESCAPE_SLASHES)) {
+            return enc_table_cpy_slash;
+        } else {
+            return enc_table_cpy;
+        }
+    }
 }
 
 /** Write raw string. */
 static_inline u8 *write_raw(u8 *cur, const u8 *raw, usize raw_len) {
-	memcpy(cur, raw, raw_len);
-	return cur + raw_len;
+    memcpy(cur, raw, raw_len);
+    return cur + raw_len;
+}
+
+/**
+ Write string no-escape.
+ @param cur Buffer cursor.
+ @param str A UTF-8 string, null-terminator is not required.
+ @param str_len Length of string in bytes.
+ @return The buffer cursor after string.
+ */
+static_inline u8 *write_string_noesc(u8 *cur, const u8 *str, usize str_len) {
+    *cur++ = '"';
+    while (str_len >= 16) {
+        byte_copy_16(cur, str);
+        cur += 16;
+        str += 16;
+        str_len -= 16;
+    }
+    while (str_len >= 4) {
+        byte_copy_4(cur, str);
+        cur += 4;
+        str += 4;
+        str_len -= 4;
+    }
+    while (str_len) {
+        *cur++ = *str++;
+        str_len -= 1;
+    }
+    *cur++ = '"';
+    return cur;
 }
 
 /**
@@ -6693,274 +7896,293 @@ static_inline u8 *write_raw(u8 *cur, const u8 *raw, usize raw_len) {
  @param enc_table Encode type table for character.
  @return The buffer cursor after string, or NULL on invalid unicode.
  */
-static_inline u8 *write_string(u8 *cur, bool esc, bool inv, const u8 *str, usize str_len,
+static_inline u8 *write_string(u8 *cur, bool esc, bool inv,
+                               const u8 *str, usize str_len,
                                const char_enc_type *enc_table) {
 
-	/* UTF-8 character mask and pattern, see `read_string` for details. */
+    /* UTF-8 character mask and pattern, see `read_string()` for details. */
 #if YYJSON_ENDIAN == YYJSON_BIG_ENDIAN
-	const u16 b2_mask = 0xE0C0UL;
-	const u16 b2_patt = 0xC080UL;
-	const u16 b2_requ = 0x1E00UL;
-	const u32 b3_mask = 0xF0C0C000UL;
-	const u32 b3_patt = 0xE0808000UL;
-	const u32 b3_requ = 0x0F200000UL;
-	const u32 b3_erro = 0x0D200000UL;
-	const u32 b4_mask = 0xF8C0C0C0UL;
-	const u32 b4_patt = 0xF0808080UL;
-	const u32 b4_requ = 0x07300000UL;
-	const u32 b4_err0 = 0x04000000UL;
-	const u32 b4_err1 = 0x03300000UL;
+    const u16 b2_mask = 0xE0C0UL;
+    const u16 b2_patt = 0xC080UL;
+    const u16 b2_requ = 0x1E00UL;
+    const u32 b3_mask = 0xF0C0C000UL;
+    const u32 b3_patt = 0xE0808000UL;
+    const u32 b3_requ = 0x0F200000UL;
+    const u32 b3_erro = 0x0D200000UL;
+    const u32 b4_mask = 0xF8C0C0C0UL;
+    const u32 b4_patt = 0xF0808080UL;
+    const u32 b4_requ = 0x07300000UL;
+    const u32 b4_err0 = 0x04000000UL;
+    const u32 b4_err1 = 0x03300000UL;
 #elif YYJSON_ENDIAN == YYJSON_LITTLE_ENDIAN
-	const u16 b2_mask = 0xC0E0UL;
-	const u16 b2_patt = 0x80C0UL;
-	const u16 b2_requ = 0x001EUL;
-	const u32 b3_mask = 0x00C0C0F0UL;
-	const u32 b3_patt = 0x008080E0UL;
-	const u32 b3_requ = 0x0000200FUL;
-	const u32 b3_erro = 0x0000200DUL;
-	const u32 b4_mask = 0xC0C0C0F8UL;
-	const u32 b4_patt = 0x808080F0UL;
-	const u32 b4_requ = 0x00003007UL;
-	const u32 b4_err0 = 0x00000004UL;
-	const u32 b4_err1 = 0x00003003UL;
+    const u16 b2_mask = 0xC0E0UL;
+    const u16 b2_patt = 0x80C0UL;
+    const u16 b2_requ = 0x001EUL;
+    const u32 b3_mask = 0x00C0C0F0UL;
+    const u32 b3_patt = 0x008080E0UL;
+    const u32 b3_requ = 0x0000200FUL;
+    const u32 b3_erro = 0x0000200DUL;
+    const u32 b4_mask = 0xC0C0C0F8UL;
+    const u32 b4_patt = 0x808080F0UL;
+    const u32 b4_requ = 0x00003007UL;
+    const u32 b4_err0 = 0x00000004UL;
+    const u32 b4_err1 = 0x00003003UL;
 #else
-	v16_uni b2_mask_uni = {{0xE0, 0xC0}};
-	v16_uni b2_patt_uni = {{0xC0, 0x80}};
-	v16_uni b2_requ_uni = {{0x1E, 0x00}};
-	v32_uni b3_mask_uni = {{0xF0, 0xC0, 0xC0, 0x00}};
-	v32_uni b3_patt_uni = {{0xE0, 0x80, 0x80, 0x00}};
-	v32_uni b3_requ_uni = {{0x0F, 0x20, 0x00, 0x00}};
-	v32_uni b3_erro_uni = {{0x0D, 0x20, 0x00, 0x00}};
-	v32_uni b4_mask_uni = {{0xF8, 0xC0, 0xC0, 0xC0}};
-	v32_uni b4_patt_uni = {{0xF0, 0x80, 0x80, 0x80}};
-	v32_uni b4_requ_uni = {{0x07, 0x30, 0x00, 0x00}};
-	v32_uni b4_err0_uni = {{0x04, 0x00, 0x00, 0x00}};
-	v32_uni b4_err1_uni = {{0x03, 0x30, 0x00, 0x00}};
-	u16 b2_mask = b2_mask_uni.u;
-	u16 b2_patt = b2_patt_uni.u;
-	u16 b2_requ = b2_requ_uni.u;
-	u32 b3_mask = b3_mask_uni.u;
-	u32 b3_patt = b3_patt_uni.u;
-	u32 b3_requ = b3_requ_uni.u;
-	u32 b3_erro = b3_erro_uni.u;
-	u32 b4_mask = b4_mask_uni.u;
-	u32 b4_patt = b4_patt_uni.u;
-	u32 b4_requ = b4_requ_uni.u;
-	u32 b4_err0 = b4_err0_uni.u;
-	u32 b4_err1 = b4_err1_uni.u;
+    /* this should be evaluated at compile-time */
+    v16_uni b2_mask_uni = {{ 0xE0, 0xC0 }};
+    v16_uni b2_patt_uni = {{ 0xC0, 0x80 }};
+    v16_uni b2_requ_uni = {{ 0x1E, 0x00 }};
+    v32_uni b3_mask_uni = {{ 0xF0, 0xC0, 0xC0, 0x00 }};
+    v32_uni b3_patt_uni = {{ 0xE0, 0x80, 0x80, 0x00 }};
+    v32_uni b3_requ_uni = {{ 0x0F, 0x20, 0x00, 0x00 }};
+    v32_uni b3_erro_uni = {{ 0x0D, 0x20, 0x00, 0x00 }};
+    v32_uni b4_mask_uni = {{ 0xF8, 0xC0, 0xC0, 0xC0 }};
+    v32_uni b4_patt_uni = {{ 0xF0, 0x80, 0x80, 0x80 }};
+    v32_uni b4_requ_uni = {{ 0x07, 0x30, 0x00, 0x00 }};
+    v32_uni b4_err0_uni = {{ 0x04, 0x00, 0x00, 0x00 }};
+    v32_uni b4_err1_uni = {{ 0x03, 0x30, 0x00, 0x00 }};
+    u16 b2_mask = b2_mask_uni.u;
+    u16 b2_patt = b2_patt_uni.u;
+    u16 b2_requ = b2_requ_uni.u;
+    u32 b3_mask = b3_mask_uni.u;
+    u32 b3_patt = b3_patt_uni.u;
+    u32 b3_requ = b3_requ_uni.u;
+    u32 b3_erro = b3_erro_uni.u;
+    u32 b4_mask = b4_mask_uni.u;
+    u32 b4_patt = b4_patt_uni.u;
+    u32 b4_requ = b4_requ_uni.u;
+    u32 b4_err0 = b4_err0_uni.u;
+    u32 b4_err1 = b4_err1_uni.u;
 #endif
 
-#define is_valid_seq_2(uni) (((uni & b2_mask) == b2_patt) && ((uni & b2_requ)))
+#define is_valid_seq_2(uni) ( \
+    ((uni & b2_mask) == b2_patt) && \
+    ((uni & b2_requ)) \
+)
 
-#define is_valid_seq_3(uni) (((uni & b3_mask) == b3_patt) && ((tmp = (uni & b3_requ))) && ((tmp != b3_erro)))
+#define is_valid_seq_3(uni) ( \
+    ((uni & b3_mask) == b3_patt) && \
+    ((tmp = (uni & b3_requ))) && \
+    ((tmp != b3_erro)) \
+)
 
-#define is_valid_seq_4(uni)                                                                                            \
-	(((uni & b4_mask) == b4_patt) && ((tmp = (uni & b4_requ))) && ((tmp & b4_err0) == 0 || (tmp & b4_err1) == 0))
+#define is_valid_seq_4(uni) ( \
+    ((uni & b4_mask) == b4_patt) && \
+    ((tmp = (uni & b4_requ))) && \
+    ((tmp & b4_err0) == 0 || (tmp & b4_err1) == 0) \
+)
 
-	/* The replacement character U+FFFD, used to indicate invalid character. */
-	const v32 rep = {'F', 'F', 'F', 'D'};
-	const v32 pre = {'\\', 'u', '0', '0'};
+    /* The replacement character U+FFFD, used to indicate invalid character. */
+    const v32 rep = {{ 'F', 'F', 'F', 'D' }};
+    const v32 pre = {{ '\\', 'u', '0', '0' }};
 
-	const u8 *src = str;
-	const u8 *end = str + str_len;
-	*cur++ = '"';
+    const u8 *src = str;
+    const u8 *end = str + str_len;
+    *cur++ = '"';
 
 copy_ascii:
-	/*
-	 Copy continuous ASCII, loop unrolling, same as the following code:
+    /*
+     Copy continuous ASCII, loop unrolling, same as the following code:
 
-	     while (end > src) (
-	        if (unlikely(enc_table[*src])) break;
-	        *cur++ = *src++;
-	     );
-	 */
-#define expr_jump(i)                                                                                                   \
-	if (unlikely(enc_table[src[i]]))                                                                                   \
-		goto stop_char_##i;
+         while (end > src) (
+            if (unlikely(enc_table[*src])) break;
+            *cur++ = *src++;
+         );
+     */
+#define expr_jump(i) \
+    if (unlikely(enc_table[src[i]])) goto stop_char_##i;
 
-#define expr_stop(i)                                                                                                   \
-	stop_char_##i : memcpy(cur, src, i);                                                                               \
-	cur += i;                                                                                                          \
-	src += i;                                                                                                          \
-	goto copy_utf8;
+#define expr_stop(i) \
+    stop_char_##i: \
+    memcpy(cur, src, i); \
+    cur += i; src += i; goto copy_utf8;
 
-	while (end - src >= 16) {
-		repeat16_incr(expr_jump);
-		byte_copy_16(cur, src);
-		cur += 16;
-		src += 16;
-	}
+    while (end - src >= 16) {
+        repeat16_incr(expr_jump)
+        byte_copy_16(cur, src);
+        cur += 16; src += 16;
+    }
 
-	while (end - src >= 4) {
-		repeat4_incr(expr_jump);
-		byte_copy_4(cur, src);
-		cur += 4;
-		src += 4;
-	}
+    while (end - src >= 4) {
+        repeat4_incr(expr_jump)
+        byte_copy_4(cur, src);
+        cur += 4; src += 4;
+    }
 
-	while (end > src) {
-		expr_jump(0);
-		*cur++ = *src++;
-	}
+    while (end > src) {
+        expr_jump(0)
+        *cur++ = *src++;
+    }
 
-	*cur++ = '"';
-	return cur;
+    *cur++ = '"';
+    return cur;
 
-	repeat16_incr(expr_stop);
+    repeat16_incr(expr_stop)
 
 #undef expr_jump
 #undef expr_stop
 
 copy_utf8:
-	if (unlikely(src + 4 > end)) {
-		if (end == src)
-			goto copy_end;
-		if (end - src < enc_table[*src] / 2)
-			goto err_one;
-	}
-	switch (enc_table[*src]) {
-	case CHAR_ENC_CPY_1: {
-		*cur++ = *src++;
-		goto copy_ascii;
-	}
-	case CHAR_ENC_CPY_2: {
-		u16 v;
-		v = byte_load_2(src);
-		if (unlikely(!is_valid_seq_2(v)))
-			goto err_cpy;
-
-		byte_copy_2(cur, src);
-		cur += 2;
-		src += 2;
-		goto copy_utf8;
-	}
-	case CHAR_ENC_CPY_3: {
-		u32 v, tmp;
-		if (likely(src + 4 <= end)) {
-			v = byte_load_4(src);
-			if (unlikely(!is_valid_seq_3(v)))
-				goto err_cpy;
-			byte_copy_4(cur, src);
-		} else {
-			v = byte_load_3(src);
-			if (unlikely(!is_valid_seq_3(v)))
-				goto err_cpy;
-			byte_copy_4(cur, &v);
-		}
-		cur += 3;
-		src += 3;
-		goto copy_utf8;
-	}
-	case CHAR_ENC_CPY_4: {
-		u32 v, tmp;
-		v = byte_load_4(src);
-		if (unlikely(!is_valid_seq_4(v)))
-			goto err_cpy;
-
-		byte_copy_4(cur, src);
-		cur += 4;
-		src += 4;
-		goto copy_utf8;
-	}
-	case CHAR_ENC_ESC_A: {
-		byte_move_2(cur, &esc_single_char_table[*src * 2]);
-		cur += 2;
-		src += 1;
-		goto copy_utf8;
-	}
-	case CHAR_ENC_ESC_1: {
-		byte_copy_4(cur + 0, &pre);
-		byte_copy_2(cur + 4, &esc_hex_char_table[*src * 2]);
-		cur += 6;
-		src += 1;
-		goto copy_utf8;
-	}
-	case CHAR_ENC_ESC_2: {
-		u16 u, v;
-		v = byte_load_2(src);
-		if (unlikely(!is_valid_seq_2(v)))
-			goto err_esc;
-
-		u = (u16)(((u16)(src[0] & 0x1F) << 6) | ((u16)(src[1] & 0x3F) << 0));
-		byte_copy_2(cur + 0, &pre);
-		byte_copy_2(cur + 2, &esc_hex_char_table[(u >> 8) * 2]);
-		byte_copy_2(cur + 4, &esc_hex_char_table[(u & 0xFF) * 2]);
-		cur += 6;
-		src += 2;
-		goto copy_utf8;
-	}
-	case CHAR_ENC_ESC_3: {
-		u16 u;
-		u32 v, tmp;
-		v = byte_load_3(src);
-		if (unlikely(!is_valid_seq_3(v)))
-			goto err_esc;
-
-		u = (u16)(((u16)(src[0] & 0x0F) << 12) | ((u16)(src[1] & 0x3F) << 6) | ((u16)(src[2] & 0x3F) << 0));
-		byte_copy_2(cur + 0, &pre);
-		byte_copy_2(cur + 2, &esc_hex_char_table[(u >> 8) * 2]);
-		byte_copy_2(cur + 4, &esc_hex_char_table[(u & 0xFF) * 2]);
-		cur += 6;
-		src += 3;
-		goto copy_utf8;
-	}
-	case CHAR_ENC_ESC_4: {
-		u32 hi, lo, u, v, tmp;
-		v = byte_load_4(src);
-		if (unlikely(!is_valid_seq_4(v)))
-			goto err_esc;
-
-		u = ((u32)(src[0] & 0x07) << 18) | ((u32)(src[1] & 0x3F) << 12) | ((u32)(src[2] & 0x3F) << 6) |
-		    ((u32)(src[3] & 0x3F) << 0);
-		u -= 0x10000;
-		hi = (u >> 10) + 0xD800;
-		lo = (u & 0x3FF) + 0xDC00;
-		byte_copy_2(cur + 0, &pre);
-		byte_copy_2(cur + 2, &esc_hex_char_table[(hi >> 8) * 2]);
-		byte_copy_2(cur + 4, &esc_hex_char_table[(hi & 0xFF) * 2]);
-		byte_copy_2(cur + 6, &pre);
-		byte_copy_2(cur + 8, &esc_hex_char_table[(lo >> 8) * 2]);
-		byte_copy_2(cur + 10, &esc_hex_char_table[(lo & 0xFF) * 2]);
-		cur += 12;
-		src += 4;
-		goto copy_utf8;
-	}
-	case CHAR_ENC_ERR_1: {
-		goto err_one;
-	}
-	default:
-		break;
-	}
+    if (unlikely(src + 4 > end)) {
+        if (end == src) goto copy_end;
+        if (end - src < enc_table[*src] / 2) goto err_one;
+    }
+    switch (enc_table[*src]) {
+        case CHAR_ENC_CPY_1: {
+            *cur++ = *src++;
+            goto copy_ascii;
+        }
+        case CHAR_ENC_CPY_2: {
+            u16 v;
+#if YYJSON_DISABLE_UTF8_VALIDATION
+            byte_copy_2(cur, src);
+#else
+            v = byte_load_2(src);
+            if (unlikely(!is_valid_seq_2(v))) goto err_cpy;
+            byte_copy_2(cur, src);
+#endif
+            cur += 2;
+            src += 2;
+            goto copy_utf8;
+        }
+        case CHAR_ENC_CPY_3: {
+            u32 v, tmp;
+#if YYJSON_DISABLE_UTF8_VALIDATION
+            if (likely(src + 4 <= end)) {
+                byte_copy_4(cur, src);
+            } else {
+                byte_copy_2(cur, src);
+                cur[2] = src[2];
+            }
+#else
+            if (likely(src + 4 <= end)) {
+                v = byte_load_4(src);
+                if (unlikely(!is_valid_seq_3(v))) goto err_cpy;
+                byte_copy_4(cur, src);
+            } else {
+                v = byte_load_3(src);
+                if (unlikely(!is_valid_seq_3(v))) goto err_cpy;
+                byte_copy_4(cur, &v);
+            }
+#endif
+            cur += 3;
+            src += 3;
+            goto copy_utf8;
+        }
+        case CHAR_ENC_CPY_4: {
+            u32 v, tmp;
+#if YYJSON_DISABLE_UTF8_VALIDATION
+            byte_copy_4(cur, src);
+#else
+            v = byte_load_4(src);
+            if (unlikely(!is_valid_seq_4(v))) goto err_cpy;
+            byte_copy_4(cur, src);
+#endif
+            cur += 4;
+            src += 4;
+            goto copy_utf8;
+        }
+        case CHAR_ENC_ESC_A: {
+            byte_copy_2(cur, &esc_single_char_table[*src * 2]);
+            cur += 2;
+            src += 1;
+            goto copy_utf8;
+        }
+        case CHAR_ENC_ESC_1: {
+            byte_copy_4(cur + 0, &pre);
+            byte_copy_2(cur + 4, &esc_hex_char_table[*src * 2]);
+            cur += 6;
+            src += 1;
+            goto copy_utf8;
+        }
+        case CHAR_ENC_ESC_2: {
+            u16 u, v;
+#if !YYJSON_DISABLE_UTF8_VALIDATION
+            v = byte_load_2(src);
+            if (unlikely(!is_valid_seq_2(v))) goto err_esc;
+#endif
+            u = (u16)(((u16)(src[0] & 0x1F) << 6) |
+                      ((u16)(src[1] & 0x3F) << 0));
+            byte_copy_2(cur + 0, &pre);
+            byte_copy_2(cur + 2, &esc_hex_char_table[(u >> 8) * 2]);
+            byte_copy_2(cur + 4, &esc_hex_char_table[(u & 0xFF) * 2]);
+            cur += 6;
+            src += 2;
+            goto copy_utf8;
+        }
+        case CHAR_ENC_ESC_3: {
+            u16 u;
+            u32 v, tmp;
+#if !YYJSON_DISABLE_UTF8_VALIDATION
+            v = byte_load_3(src);
+            if (unlikely(!is_valid_seq_3(v))) goto err_esc;
+#endif
+            u = (u16)(((u16)(src[0] & 0x0F) << 12) |
+                      ((u16)(src[1] & 0x3F) << 6) |
+                      ((u16)(src[2] & 0x3F) << 0));
+            byte_copy_2(cur + 0, &pre);
+            byte_copy_2(cur + 2, &esc_hex_char_table[(u >> 8) * 2]);
+            byte_copy_2(cur + 4, &esc_hex_char_table[(u & 0xFF) * 2]);
+            cur += 6;
+            src += 3;
+            goto copy_utf8;
+        }
+        case CHAR_ENC_ESC_4: {
+            u32 hi, lo, u, v, tmp;
+#if !YYJSON_DISABLE_UTF8_VALIDATION
+            v = byte_load_4(src);
+            if (unlikely(!is_valid_seq_4(v))) goto err_esc;
+#endif
+            u = ((u32)(src[0] & 0x07) << 18) |
+                ((u32)(src[1] & 0x3F) << 12) |
+                ((u32)(src[2] & 0x3F) << 6) |
+                ((u32)(src[3] & 0x3F) << 0);
+            u -= 0x10000;
+            hi = (u >> 10) + 0xD800;
+            lo = (u & 0x3FF) + 0xDC00;
+            byte_copy_2(cur + 0, &pre);
+            byte_copy_2(cur + 2, &esc_hex_char_table[(hi >> 8) * 2]);
+            byte_copy_2(cur + 4, &esc_hex_char_table[(hi & 0xFF) * 2]);
+            byte_copy_2(cur + 6, &pre);
+            byte_copy_2(cur + 8, &esc_hex_char_table[(lo >> 8) * 2]);
+            byte_copy_2(cur + 10, &esc_hex_char_table[(lo & 0xFF) * 2]);
+            cur += 12;
+            src += 4;
+            goto copy_utf8;
+        }
+        case CHAR_ENC_ERR_1: {
+            goto err_one;
+        }
+        default: break;
+    }
 
 copy_end:
-	*cur++ = '"';
-	return cur;
+    *cur++ = '"';
+    return cur;
 
 err_one:
-	if (esc)
-		goto err_esc;
-	else
-		goto err_cpy;
+    if (esc) goto err_esc;
+    else goto err_cpy;
 
 err_cpy:
-	if (!inv)
-		return NULL;
-	*cur++ = *src++;
-	goto copy_utf8;
+    if (!inv) return NULL;
+    *cur++ = *src++;
+    goto copy_utf8;
 
 err_esc:
-	if (!inv)
-		return NULL;
-	byte_copy_2(cur + 0, &pre);
-	byte_copy_4(cur + 2, &rep);
-	cur += 6;
-	src += 1;
-	goto copy_utf8;
+    if (!inv) return NULL;
+    byte_copy_2(cur + 0, &pre);
+    byte_copy_4(cur + 2, &rep);
+    cur += 6;
+    src += 1;
+    goto copy_utf8;
 
 #undef is_valid_seq_2
 #undef is_valid_seq_3
 #undef is_valid_seq_4
 }
+
+
 
 /*==============================================================================
  * Writer Utilities
@@ -6968,179 +8190,197 @@ err_esc:
 
 /** Write null (requires 8 bytes buffer). */
 static_inline u8 *write_null(u8 *cur) {
-	v64 v = {'n', 'u', 'l', 'l', ',', '\n', 0, 0};
-	byte_copy_8(cur, &v);
-	return cur + 4;
+    v64 v = {{ 'n', 'u', 'l', 'l', ',', '\n', 0, 0 }};
+    byte_copy_8(cur, &v);
+    return cur + 4;
 }
 
 /** Write bool (requires 8 bytes buffer). */
 static_inline u8 *write_bool(u8 *cur, bool val) {
-	v64 v0 = {'f', 'a', 'l', 's', 'e', ',', '\n', 0};
-	v64 v1 = {'t', 'r', 'u', 'e', ',', '\n', 0, 0};
-	if (val) {
-		byte_copy_8(cur, &v1);
-	} else {
-		byte_copy_8(cur, &v0);
-	}
-	return cur + 5 - val;
+    v64 v0 = {{ 'f', 'a', 'l', 's', 'e', ',', '\n', 0 }};
+    v64 v1 = {{ 't', 'r', 'u', 'e', ',', '\n', 0, 0 }};
+    if (val) {
+        byte_copy_8(cur, &v1);
+    } else {
+        byte_copy_8(cur, &v0);
+    }
+    return cur + 5 - val;
 }
 
 /** Write indent (requires level x 4 bytes buffer).
     Param spaces should not larger than 4. */
 static_inline u8 *write_indent(u8 *cur, usize level, usize spaces) {
-	while (level-- > 0) {
-		byte_copy_4(cur, "    ");
-		cur += spaces;
-	}
-	return cur;
+    while (level-- > 0) {
+        byte_copy_4(cur, "    ");
+        cur += spaces;
+    }
+    return cur;
+}
+
+/** Write data to file pointer. */
+static bool write_dat_to_fp(FILE *fp, u8 *dat, usize len,
+                            yyjson_write_err *err) {
+    if (fwrite(dat, len, 1, fp) != 1) {
+        err->msg = "file writing failed";
+        err->code = YYJSON_WRITE_ERROR_FILE_WRITE;
+        return false;
+    }
+    return true;
 }
 
 /** Write data to file. */
-static bool write_dat_to_file(const char *path, u8 *dat, usize len, yyjson_write_err *err) {
+static bool write_dat_to_file(const char *path, u8 *dat, usize len,
+                              yyjson_write_err *err) {
 
-#define return_err(_code, _msg)                                                                                        \
-	do {                                                                                                               \
-		err->msg = _msg;                                                                                               \
-		err->code = YYJSON_WRITE_ERROR_##_code;                                                                        \
-		if (file)                                                                                                      \
-			fclose(file);                                                                                              \
-		return false;                                                                                                  \
-	} while (false)
+#define return_err(_code, _msg) do { \
+    err->msg = _msg; \
+    err->code = YYJSON_WRITE_ERROR_##_code; \
+    if (file) fclose(file); \
+    return false; \
+} while (false)
 
-	FILE *file = fopen_writeonly(path);
-	if (file == NULL) {
-		return_err(FILE_OPEN, "file opening failed");
-	}
-	if (fwrite(dat, len, 1, file) != 1) {
-		return_err(FILE_WRITE, "file writing failed");
-	}
-	if (fclose(file) != 0) {
-		file = NULL;
-		return_err(FILE_WRITE, "file closing failed");
-	}
-	return true;
+    FILE *file = fopen_writeonly(path);
+    if (file == NULL) {
+        return_err(FILE_OPEN, "file opening failed");
+    }
+    if (fwrite(dat, len, 1, file) != 1) {
+        return_err(FILE_WRITE, "file writing failed");
+    }
+    if (fclose(file) != 0) {
+        file = NULL;
+        return_err(FILE_WRITE, "file closing failed");
+    }
+    return true;
 
 #undef return_err
 }
+
+
 
 /*==============================================================================
  * JSON Writer Implementation
  *============================================================================*/
 
 typedef struct yyjson_write_ctx {
-	usize tag;
+    usize tag;
 } yyjson_write_ctx;
 
-static_inline void yyjson_write_ctx_set(yyjson_write_ctx *ctx, usize size, bool is_obj) {
-	ctx->tag = (size << 1) | (usize)is_obj;
+static_inline void yyjson_write_ctx_set(yyjson_write_ctx *ctx,
+                                        usize size, bool is_obj) {
+    ctx->tag = (size << 1) | (usize)is_obj;
 }
 
-static_inline void yyjson_write_ctx_get(yyjson_write_ctx *ctx, usize *size, bool *is_obj) {
-	usize tag = ctx->tag;
-	*size = tag >> 1;
-	*is_obj = (bool)(tag & 1);
+static_inline void yyjson_write_ctx_get(yyjson_write_ctx *ctx,
+                                        usize *size, bool *is_obj) {
+    usize tag = ctx->tag;
+    *size = tag >> 1;
+    *is_obj = (bool)(tag & 1);
 }
 
 /** Write single JSON value. */
-static_inline u8 *yyjson_write_single(yyjson_val *val, yyjson_write_flag flg, yyjson_alc alc, usize *dat_len,
+static_inline u8 *yyjson_write_single(yyjson_val *val,
+                                      yyjson_write_flag flg,
+                                      yyjson_alc alc,
+                                      usize *dat_len,
                                       yyjson_write_err *err) {
 
-#define return_err(_code, _msg)                                                                                        \
-	do {                                                                                                               \
-		if (hdr)                                                                                                       \
-			alc.free(alc.ctx, (void *)hdr);                                                                            \
-		*dat_len = 0;                                                                                                  \
-		err->code = YYJSON_WRITE_ERROR_##_code;                                                                        \
-		err->msg = _msg;                                                                                               \
-		return NULL;                                                                                                   \
-	} while (false)
+#define return_err(_code, _msg) do { \
+    if (hdr) alc.free(alc.ctx, (void *)hdr); \
+    *dat_len = 0; \
+    err->code = YYJSON_WRITE_ERROR_##_code; \
+    err->msg = _msg; \
+    return NULL; \
+} while (false)
 
-#define incr_len(_len)                                                                                                 \
-	do {                                                                                                               \
-		hdr = (u8 *)alc.malloc(alc.ctx, _len);                                                                         \
-		if (!hdr)                                                                                                      \
-			goto fail_alloc;                                                                                           \
-		cur = hdr;                                                                                                     \
-	} while (false)
+#define incr_len(_len) do { \
+    hdr = (u8 *)alc.malloc(alc.ctx, _len); \
+    if (!hdr) goto fail_alloc; \
+    cur = hdr; \
+} while (false)
 
-#define check_str_len(_len)                                                                                            \
-	do {                                                                                                               \
-		if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6))                                                   \
-			goto fail_alloc;                                                                                           \
-	} while (false)
+#define check_str_len(_len) do { \
+    if ((sizeof(usize) < 8) && (_len >= (USIZE_MAX - 16) / 6)) \
+        goto fail_alloc; \
+} while (false)
 
-	u8 *hdr = NULL, *cur;
-	usize str_len;
-	const u8 *str_ptr;
-	const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-	bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-	bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
+    u8 *hdr = NULL, *cur;
+    usize str_len;
+    const u8 *str_ptr;
+    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
+    bool cpy = (enc_table == enc_table_cpy);
+    bool esc = has_write_flag(ESCAPE_UNICODE) != 0;
+    bool inv = has_write_flag(ALLOW_INVALID_UNICODE) != 0;
+    bool newline = has_write_flag(NEWLINE_AT_END) != 0;
+    const usize end_len = 2; /* '\n' and '\0' */
 
-	switch (unsafe_yyjson_get_type(val)) {
-	case YYJSON_TYPE_RAW:
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len + 1);
-		cur = write_raw(cur, str_ptr, str_len);
-		break;
+    switch (unsafe_yyjson_get_type(val)) {
+        case YYJSON_TYPE_RAW:
+            str_len = unsafe_yyjson_get_len(val);
+            str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+            check_str_len(str_len);
+            incr_len(str_len + end_len);
+            cur = write_raw(cur, str_ptr, str_len);
+            break;
 
-	case YYJSON_TYPE_STR:
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len * 6 + 4);
-		cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-		if (unlikely(!cur))
-			goto fail_str;
-		break;
+        case YYJSON_TYPE_STR:
+            str_len = unsafe_yyjson_get_len(val);
+            str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+            check_str_len(str_len);
+            incr_len(str_len * 6 + 2 + end_len);
+            if (likely(cpy) && unsafe_yyjson_get_subtype(val)) {
+                cur = write_string_noesc(cur, str_ptr, str_len);
+            } else {
+                cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
+                if (unlikely(!cur)) goto fail_str;
+            }
+            break;
 
-	case YYJSON_TYPE_NUM:
-		incr_len(32);
-		cur = write_number(cur, val, flg);
-		if (unlikely(!cur))
-			goto fail_num;
-		break;
+        case YYJSON_TYPE_NUM:
+            incr_len(32 + end_len);
+            cur = write_number(cur, val, flg);
+            if (unlikely(!cur)) goto fail_num;
+            break;
 
-	case YYJSON_TYPE_BOOL:
-		incr_len(8);
-		cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-		break;
+        case YYJSON_TYPE_BOOL:
+            incr_len(8);
+            cur = write_bool(cur, unsafe_yyjson_get_bool(val));
+            break;
 
-	case YYJSON_TYPE_NULL:
-		incr_len(8);
-		cur = write_null(cur);
-		break;
+        case YYJSON_TYPE_NULL:
+            incr_len(8);
+            cur = write_null(cur);
+            break;
 
-	case YYJSON_TYPE_ARR:
-		incr_len(4);
-		byte_copy_2(cur, "[]");
-		cur += 2;
-		break;
+        case YYJSON_TYPE_ARR:
+            incr_len(2 + end_len);
+            byte_copy_2(cur, "[]");
+            cur += 2;
+            break;
 
-	case YYJSON_TYPE_OBJ:
-		incr_len(4);
-		byte_copy_2(cur, "{}");
-		cur += 2;
-		break;
+        case YYJSON_TYPE_OBJ:
+            incr_len(2 + end_len);
+            byte_copy_2(cur, "{}");
+            cur += 2;
+            break;
 
-	default:
-		goto fail_type;
-	}
+        default:
+            goto fail_type;
+    }
 
-	*cur = '\0';
-	*dat_len = (usize)(cur - hdr);
-	memset(err, 0, sizeof(yyjson_write_err));
-	return hdr;
+    if (newline) *cur++ = '\n';
+    *cur = '\0';
+    *dat_len = (usize)(cur - hdr);
+    memset(err, 0, sizeof(yyjson_write_err));
+    return hdr;
 
 fail_alloc:
-	return_err(MEMORY_ALLOCATION, "memory allocation failed");
+    return_err(MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-	return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-	return_err(NAN_OR_INF, "nan or inf number is not allowed");
+    return_err(NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-	return_err(INVALID_STRING, "invalid utf-8 encoding in string");
+    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
 
 #undef return_err
 #undef check_str_len
@@ -7149,177 +8389,182 @@ fail_str:
 
 /** Write JSON document minify.
     The root of this document should be a non-empty container. */
-static_inline u8 *yyjson_write_minify(const yyjson_val *root, const yyjson_write_flag flg, const yyjson_alc alc,
-                                      usize *dat_len, yyjson_write_err *err) {
+static_inline u8 *yyjson_write_minify(const yyjson_val *root,
+                                      const yyjson_write_flag flg,
+                                      const yyjson_alc alc,
+                                      usize *dat_len,
+                                      yyjson_write_err *err) {
 
-#define return_err(_code, _msg)                                                                                        \
-	do {                                                                                                               \
-		*dat_len = 0;                                                                                                  \
-		err->code = YYJSON_WRITE_ERROR_##_code;                                                                        \
-		err->msg = _msg;                                                                                               \
-		if (hdr)                                                                                                       \
-			alc.free(alc.ctx, hdr);                                                                                    \
-		return NULL;                                                                                                   \
-	} while (false)
+#define return_err(_code, _msg) do { \
+    *dat_len = 0; \
+    err->code = YYJSON_WRITE_ERROR_##_code; \
+    err->msg = _msg; \
+    if (hdr) alc.free(alc.ctx, hdr); \
+    return NULL; \
+} while (false)
 
-#define incr_len(_len)                                                                                                 \
-	do {                                                                                                               \
-		ext_len = (usize)(_len);                                                                                       \
-		if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) {                                                            \
-			alc_inc = yyjson_max(alc_len / 2, ext_len);                                                                \
-			alc_inc = size_align_up(alc_inc, sizeof(yyjson_write_ctx));                                                \
-			if (size_add_is_overflow(alc_len, alc_inc))                                                                \
-				goto fail_alloc;                                                                                       \
-			alc_len += alc_inc;                                                                                        \
-			tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len);                                         \
-			if (unlikely(!tmp))                                                                                        \
-				goto fail_alloc;                                                                                       \
-			ctx_len = (usize)(end - (u8 *)ctx);                                                                        \
-			ctx_tmp = (yyjson_write_ctx *)(void *)(tmp + (alc_len - ctx_len));                                         \
-			memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len);                                      \
-			ctx = ctx_tmp;                                                                                             \
-			cur = tmp + (cur - hdr);                                                                                   \
-			end = tmp + alc_len;                                                                                       \
-			hdr = tmp;                                                                                                 \
-		}                                                                                                              \
-	} while (false)
+#define incr_len(_len) do { \
+    ext_len = (usize)(_len); \
+    if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) { \
+        alc_inc = yyjson_max(alc_len / 2, ext_len); \
+        alc_inc = size_align_up(alc_inc, sizeof(yyjson_write_ctx)); \
+        if ((sizeof(usize) < 8) && size_add_is_overflow(alc_len, alc_inc)) \
+            goto fail_alloc; \
+        alc_len += alc_inc; \
+        tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len); \
+        if (unlikely(!tmp)) goto fail_alloc; \
+        ctx_len = (usize)(end - (u8 *)ctx); \
+        ctx_tmp = (yyjson_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
+        memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
+        ctx = ctx_tmp; \
+        cur = tmp + (cur - hdr); \
+        end = tmp + alc_len; \
+        hdr = tmp; \
+    } \
+} while (false)
 
-#define check_str_len(_len)                                                                                            \
-	do {                                                                                                               \
-		if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6))                                                   \
-			goto fail_alloc;                                                                                           \
-	} while (false)
+#define check_str_len(_len) do { \
+    if ((sizeof(usize) < 8) && (_len >= (USIZE_MAX - 16) / 6)) \
+        goto fail_alloc; \
+} while (false)
 
-	yyjson_val *val;
-	yyjson_type val_type;
-	usize ctn_len, ctn_len_tmp;
-	bool ctn_obj, ctn_obj_tmp, is_key;
-	u8 *hdr, *cur, *end, *tmp;
-	yyjson_write_ctx *ctx, *ctx_tmp;
-	usize alc_len, alc_inc, ctx_len, ext_len, str_len;
-	const u8 *str_ptr;
-	const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-	bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-	bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
+    yyjson_val *val;
+    yyjson_type val_type;
+    usize ctn_len, ctn_len_tmp;
+    bool ctn_obj, ctn_obj_tmp, is_key;
+    u8 *hdr, *cur, *end, *tmp;
+    yyjson_write_ctx *ctx, *ctx_tmp;
+    usize alc_len, alc_inc, ctx_len, ext_len, str_len;
+    const u8 *str_ptr;
+    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
+    bool cpy = (enc_table == enc_table_cpy);
+    bool esc = has_write_flag(ESCAPE_UNICODE) != 0;
+    bool inv = has_write_flag(ALLOW_INVALID_UNICODE) != 0;
+    bool newline = has_write_flag(NEWLINE_AT_END) != 0;
 
-	alc_len = root->uni.ofs / sizeof(yyjson_val);
-	alc_len = alc_len * YYJSON_WRITER_ESTIMATED_MINIFY_RATIO + 64;
-	alc_len = size_align_up(alc_len, sizeof(yyjson_write_ctx));
-	hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
-	if (!hdr)
-		goto fail_alloc;
-	cur = hdr;
-	end = hdr + alc_len;
-	ctx = (yyjson_write_ctx *)(void *)end;
+    alc_len = root->uni.ofs / sizeof(yyjson_val);
+    alc_len = alc_len * YYJSON_WRITER_ESTIMATED_MINIFY_RATIO + 64;
+    alc_len = size_align_up(alc_len, sizeof(yyjson_write_ctx));
+    hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
+    if (!hdr) goto fail_alloc;
+    cur = hdr;
+    end = hdr + alc_len;
+    ctx = (yyjson_write_ctx *)(void *)end;
 
 doc_begin:
-	val = (yyjson_val *)root;
-	val_type = unsafe_yyjson_get_type(val);
-	ctn_obj = (val_type == YYJSON_TYPE_OBJ);
-	ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
-	*cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-	val++;
+    val = constcast(yyjson_val *)root;
+    val_type = unsafe_yyjson_get_type(val);
+    ctn_obj = (val_type == YYJSON_TYPE_OBJ);
+    ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
+    *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+    val++;
 
 val_begin:
-	val_type = unsafe_yyjson_get_type(val);
-	if (val_type == YYJSON_TYPE_STR) {
-		is_key = ((u8)ctn_obj & (u8)~ctn_len);
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len * 6 + 16);
-		cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-		if (unlikely(!cur))
-			goto fail_str;
-		*cur++ = is_key ? ':' : ',';
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_NUM) {
-		incr_len(32);
-		cur = write_number(cur, val, flg);
-		if (unlikely(!cur))
-			goto fail_num;
-		*cur++ = ',';
-		goto val_end;
-	}
-	if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) == (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
-		ctn_len_tmp = unsafe_yyjson_get_len(val);
-		ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
-		incr_len(16);
-		if (unlikely(ctn_len_tmp == 0)) {
-			/* write empty container */
-			*cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
-			*cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
-			*cur++ = ',';
-			goto val_end;
-		} else {
-			/* push context, setup new container */
-			yyjson_write_ctx_set(--ctx, ctn_len, ctn_obj);
-			ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
-			ctn_obj = ctn_obj_tmp;
-			*cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-			val++;
-			goto val_begin;
-		}
-	}
-	if (val_type == YYJSON_TYPE_BOOL) {
-		incr_len(16);
-		cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-		cur++;
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_NULL) {
-		incr_len(16);
-		cur = write_null(cur);
-		cur++;
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_RAW) {
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len + 2);
-		cur = write_raw(cur, str_ptr, str_len);
-		*cur++ = ',';
-		goto val_end;
-	}
-	goto fail_type;
+    val_type = unsafe_yyjson_get_type(val);
+    if (val_type == YYJSON_TYPE_STR) {
+        is_key = ((u8)ctn_obj & (u8)~ctn_len);
+        str_len = unsafe_yyjson_get_len(val);
+        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+        check_str_len(str_len);
+        incr_len(str_len * 6 + 16);
+        if (likely(cpy) && unsafe_yyjson_get_subtype(val)) {
+            cur = write_string_noesc(cur, str_ptr, str_len);
+        } else {
+            cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
+            if (unlikely(!cur)) goto fail_str;
+        }
+        *cur++ = is_key ? ':' : ',';
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_NUM) {
+        incr_len(32);
+        cur = write_number(cur, val, flg);
+        if (unlikely(!cur)) goto fail_num;
+        *cur++ = ',';
+        goto val_end;
+    }
+    if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
+                    (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
+        ctn_len_tmp = unsafe_yyjson_get_len(val);
+        ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
+        incr_len(16);
+        if (unlikely(ctn_len_tmp == 0)) {
+            /* write empty container */
+            *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
+            *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
+            *cur++ = ',';
+            goto val_end;
+        } else {
+            /* push context, setup new container */
+            yyjson_write_ctx_set(--ctx, ctn_len, ctn_obj);
+            ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
+            ctn_obj = ctn_obj_tmp;
+            *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+            val++;
+            goto val_begin;
+        }
+    }
+    if (val_type == YYJSON_TYPE_BOOL) {
+        incr_len(16);
+        cur = write_bool(cur, unsafe_yyjson_get_bool(val));
+        cur++;
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_NULL) {
+        incr_len(16);
+        cur = write_null(cur);
+        cur++;
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_RAW) {
+        str_len = unsafe_yyjson_get_len(val);
+        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+        check_str_len(str_len);
+        incr_len(str_len + 2);
+        cur = write_raw(cur, str_ptr, str_len);
+        *cur++ = ',';
+        goto val_end;
+    }
+    goto fail_type;
 
 val_end:
-	val++;
-	ctn_len--;
-	if (unlikely(ctn_len == 0))
-		goto ctn_end;
-	goto val_begin;
+    val++;
+    ctn_len--;
+    if (unlikely(ctn_len == 0)) goto ctn_end;
+    goto val_begin;
 
 ctn_end:
-	cur--;
-	*cur++ = (u8)(']' | ((u8)ctn_obj << 5));
-	*cur++ = ',';
-	if (unlikely((u8 *)ctx >= end))
-		goto doc_end;
-	yyjson_write_ctx_get(ctx++, &ctn_len, &ctn_obj);
-	ctn_len--;
-	if (likely(ctn_len > 0)) {
-		goto val_begin;
-	} else {
-		goto ctn_end;
-	}
+    cur--;
+    *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+    *cur++ = ',';
+    if (unlikely((u8 *)ctx >= end)) goto doc_end;
+    yyjson_write_ctx_get(ctx++, &ctn_len, &ctn_obj);
+    ctn_len--;
+    if (likely(ctn_len > 0)) {
+        goto val_begin;
+    } else {
+        goto ctn_end;
+    }
 
 doc_end:
-	*--cur = '\0';
-	*dat_len = (usize)(cur - hdr);
-	memset(err, 0, sizeof(yyjson_write_err));
-	return hdr;
+    if (newline) {
+        incr_len(2);
+        *(cur - 1) = '\n';
+        cur++;
+    }
+    *--cur = '\0';
+    *dat_len = (usize)(cur - hdr);
+    memset(err, 0, sizeof(yyjson_write_err));
+    return hdr;
 
 fail_alloc:
-	return_err(MEMORY_ALLOCATION, "memory allocation failed");
+    return_err(MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-	return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-	return_err(NAN_OR_INF, "nan or inf number is not allowed");
+    return_err(NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-	return_err(INVALID_STRING, "invalid utf-8 encoding in string");
+    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
 
 #undef return_err
 #undef incr_len
@@ -7328,481 +8573,555 @@ fail_str:
 
 /** Write JSON document pretty.
     The root of this document should be a non-empty container. */
-static_inline u8 *yyjson_write_pretty(const yyjson_val *root, const yyjson_write_flag flg, const yyjson_alc alc,
-                                      usize *dat_len, yyjson_write_err *err) {
+static_inline u8 *yyjson_write_pretty(const yyjson_val *root,
+                                      const yyjson_write_flag flg,
+                                      const yyjson_alc alc,
+                                      usize *dat_len,
+                                      yyjson_write_err *err) {
 
-#define return_err(_code, _msg)                                                                                        \
-	do {                                                                                                               \
-		*dat_len = 0;                                                                                                  \
-		err->code = YYJSON_WRITE_ERROR_##_code;                                                                        \
-		err->msg = _msg;                                                                                               \
-		if (hdr)                                                                                                       \
-			alc.free(alc.ctx, hdr);                                                                                    \
-		return NULL;                                                                                                   \
-	} while (false)
+#define return_err(_code, _msg) do { \
+    *dat_len = 0; \
+    err->code = YYJSON_WRITE_ERROR_##_code; \
+    err->msg = _msg; \
+    if (hdr) alc.free(alc.ctx, hdr); \
+    return NULL; \
+} while (false)
 
-#define incr_len(_len)                                                                                                 \
-	do {                                                                                                               \
-		ext_len = (usize)(_len);                                                                                       \
-		if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) {                                                            \
-			alc_inc = yyjson_max(alc_len / 2, ext_len);                                                                \
-			alc_inc = size_align_up(alc_inc, sizeof(yyjson_write_ctx));                                                \
-			if (size_add_is_overflow(alc_len, alc_inc))                                                                \
-				goto fail_alloc;                                                                                       \
-			alc_len += alc_inc;                                                                                        \
-			tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len);                                         \
-			if (unlikely(!tmp))                                                                                        \
-				goto fail_alloc;                                                                                       \
-			ctx_len = (usize)(end - (u8 *)ctx);                                                                        \
-			ctx_tmp = (yyjson_write_ctx *)(void *)(tmp + (alc_len - ctx_len));                                         \
-			memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len);                                      \
-			ctx = ctx_tmp;                                                                                             \
-			cur = tmp + (cur - hdr);                                                                                   \
-			end = tmp + alc_len;                                                                                       \
-			hdr = tmp;                                                                                                 \
-		}                                                                                                              \
-	} while (false)
+#define incr_len(_len) do { \
+    ext_len = (usize)(_len); \
+    if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) { \
+        alc_inc = yyjson_max(alc_len / 2, ext_len); \
+        alc_inc = size_align_up(alc_inc, sizeof(yyjson_write_ctx)); \
+        if ((sizeof(usize) < 8) && size_add_is_overflow(alc_len, alc_inc)) \
+            goto fail_alloc; \
+        alc_len += alc_inc; \
+        tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len); \
+        if (unlikely(!tmp)) goto fail_alloc; \
+        ctx_len = (usize)(end - (u8 *)ctx); \
+        ctx_tmp = (yyjson_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
+        memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
+        ctx = ctx_tmp; \
+        cur = tmp + (cur - hdr); \
+        end = tmp + alc_len; \
+        hdr = tmp; \
+    } \
+} while (false)
 
-#define check_str_len(_len)                                                                                            \
-	do {                                                                                                               \
-		if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6))                                                   \
-			goto fail_alloc;                                                                                           \
-	} while (false)
+#define check_str_len(_len) do { \
+    if ((sizeof(usize) < 8) && (_len >= (USIZE_MAX - 16) / 6)) \
+        goto fail_alloc; \
+} while (false)
 
-	yyjson_val *val;
-	yyjson_type val_type;
-	usize ctn_len, ctn_len_tmp;
-	bool ctn_obj, ctn_obj_tmp, is_key, no_indent;
-	u8 *hdr, *cur, *end, *tmp;
-	yyjson_write_ctx *ctx, *ctx_tmp;
-	usize alc_len, alc_inc, ctx_len, ext_len, str_len, level;
-	const u8 *str_ptr;
-	const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-	bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-	bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
-	usize spaces = (flg & YYJSON_WRITE_PRETTY_TWO_SPACES) ? 2 : 4;
+    yyjson_val *val;
+    yyjson_type val_type;
+    usize ctn_len, ctn_len_tmp;
+    bool ctn_obj, ctn_obj_tmp, is_key, no_indent;
+    u8 *hdr, *cur, *end, *tmp;
+    yyjson_write_ctx *ctx, *ctx_tmp;
+    usize alc_len, alc_inc, ctx_len, ext_len, str_len, level;
+    const u8 *str_ptr;
+    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
+    bool cpy = (enc_table == enc_table_cpy);
+    bool esc = has_write_flag(ESCAPE_UNICODE) != 0;
+    bool inv = has_write_flag(ALLOW_INVALID_UNICODE) != 0;
+    usize spaces = has_write_flag(PRETTY_TWO_SPACES) ? 2 : 4;
+    bool newline = has_write_flag(NEWLINE_AT_END) != 0;
 
-	alc_len = root->uni.ofs / sizeof(yyjson_val);
-	alc_len = alc_len * YYJSON_WRITER_ESTIMATED_PRETTY_RATIO + 64;
-	alc_len = size_align_up(alc_len, sizeof(yyjson_write_ctx));
-	hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
-	if (!hdr)
-		goto fail_alloc;
-	cur = hdr;
-	end = hdr + alc_len;
-	ctx = (yyjson_write_ctx *)(void *)end;
+    alc_len = root->uni.ofs / sizeof(yyjson_val);
+    alc_len = alc_len * YYJSON_WRITER_ESTIMATED_PRETTY_RATIO + 64;
+    alc_len = size_align_up(alc_len, sizeof(yyjson_write_ctx));
+    hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
+    if (!hdr) goto fail_alloc;
+    cur = hdr;
+    end = hdr + alc_len;
+    ctx = (yyjson_write_ctx *)(void *)end;
 
 doc_begin:
-	val = (yyjson_val *)root;
-	val_type = unsafe_yyjson_get_type(val);
-	ctn_obj = (val_type == YYJSON_TYPE_OBJ);
-	ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
-	*cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-	*cur++ = '\n';
-	val++;
-	level = 1;
+    val = constcast(yyjson_val *)root;
+    val_type = unsafe_yyjson_get_type(val);
+    ctn_obj = (val_type == YYJSON_TYPE_OBJ);
+    ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
+    *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+    *cur++ = '\n';
+    val++;
+    level = 1;
 
 val_begin:
-	val_type = unsafe_yyjson_get_type(val);
-	if (val_type == YYJSON_TYPE_STR) {
-		is_key = (bool)((u8)ctn_obj & (u8)~ctn_len);
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len * 6 + 16 + (no_indent ? 0 : level * 4));
-		cur = write_indent(cur, no_indent ? 0 : level, spaces);
-		cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-		if (unlikely(!cur))
-			goto fail_str;
-		*cur++ = is_key ? ':' : ',';
-		*cur++ = is_key ? ' ' : '\n';
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_NUM) {
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		incr_len(32 + (no_indent ? 0 : level * 4));
-		cur = write_indent(cur, no_indent ? 0 : level, spaces);
-		cur = write_number(cur, val, flg);
-		if (unlikely(!cur))
-			goto fail_num;
-		*cur++ = ',';
-		*cur++ = '\n';
-		goto val_end;
-	}
-	if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) == (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		ctn_len_tmp = unsafe_yyjson_get_len(val);
-		ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
-		if (unlikely(ctn_len_tmp == 0)) {
-			/* write empty container */
-			incr_len(16 + (no_indent ? 0 : level * 4));
-			cur = write_indent(cur, no_indent ? 0 : level, spaces);
-			*cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
-			*cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
-			*cur++ = ',';
-			*cur++ = '\n';
-			goto val_end;
-		} else {
-			/* push context, setup new container */
-			incr_len(32 + (no_indent ? 0 : level * 4));
-			yyjson_write_ctx_set(--ctx, ctn_len, ctn_obj);
-			ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
-			ctn_obj = ctn_obj_tmp;
-			cur = write_indent(cur, no_indent ? 0 : level, spaces);
-			level++;
-			*cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-			*cur++ = '\n';
-			val++;
-			goto val_begin;
-		}
-	}
-	if (val_type == YYJSON_TYPE_BOOL) {
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		incr_len(16 + (no_indent ? 0 : level * 4));
-		cur = write_indent(cur, no_indent ? 0 : level, spaces);
-		cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-		cur += 2;
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_NULL) {
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		incr_len(16 + (no_indent ? 0 : level * 4));
-		cur = write_indent(cur, no_indent ? 0 : level, spaces);
-		cur = write_null(cur);
-		cur += 2;
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_RAW) {
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len + 3);
-		cur = write_raw(cur, str_ptr, str_len);
-		*cur++ = ',';
-		*cur++ = '\n';
-		goto val_end;
-	}
-	goto fail_type;
+    val_type = unsafe_yyjson_get_type(val);
+    if (val_type == YYJSON_TYPE_STR) {
+        is_key = (bool)((u8)ctn_obj & (u8)~ctn_len);
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        str_len = unsafe_yyjson_get_len(val);
+        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+        check_str_len(str_len);
+        incr_len(str_len * 6 + 16 + (no_indent ? 0 : level * 4));
+        cur = write_indent(cur, no_indent ? 0 : level, spaces);
+        if (likely(cpy) && unsafe_yyjson_get_subtype(val)) {
+            cur = write_string_noesc(cur, str_ptr, str_len);
+        } else {
+            cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
+            if (unlikely(!cur)) goto fail_str;
+        }
+        *cur++ = is_key ? ':' : ',';
+        *cur++ = is_key ? ' ' : '\n';
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_NUM) {
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        incr_len(32 + (no_indent ? 0 : level * 4));
+        cur = write_indent(cur, no_indent ? 0 : level, spaces);
+        cur = write_number(cur, val, flg);
+        if (unlikely(!cur)) goto fail_num;
+        *cur++ = ',';
+        *cur++ = '\n';
+        goto val_end;
+    }
+    if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
+                    (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        ctn_len_tmp = unsafe_yyjson_get_len(val);
+        ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
+        if (unlikely(ctn_len_tmp == 0)) {
+            /* write empty container */
+            incr_len(16 + (no_indent ? 0 : level * 4));
+            cur = write_indent(cur, no_indent ? 0 : level, spaces);
+            *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
+            *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
+            *cur++ = ',';
+            *cur++ = '\n';
+            goto val_end;
+        } else {
+            /* push context, setup new container */
+            incr_len(32 + (no_indent ? 0 : level * 4));
+            yyjson_write_ctx_set(--ctx, ctn_len, ctn_obj);
+            ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
+            ctn_obj = ctn_obj_tmp;
+            cur = write_indent(cur, no_indent ? 0 : level, spaces);
+            level++;
+            *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+            *cur++ = '\n';
+            val++;
+            goto val_begin;
+        }
+    }
+    if (val_type == YYJSON_TYPE_BOOL) {
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        incr_len(16 + (no_indent ? 0 : level * 4));
+        cur = write_indent(cur, no_indent ? 0 : level, spaces);
+        cur = write_bool(cur, unsafe_yyjson_get_bool(val));
+        cur += 2;
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_NULL) {
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        incr_len(16 + (no_indent ? 0 : level * 4));
+        cur = write_indent(cur, no_indent ? 0 : level, spaces);
+        cur = write_null(cur);
+        cur += 2;
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_RAW) {
+        str_len = unsafe_yyjson_get_len(val);
+        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+        check_str_len(str_len);
+        incr_len(str_len + 3);
+        cur = write_raw(cur, str_ptr, str_len);
+        *cur++ = ',';
+        *cur++ = '\n';
+        goto val_end;
+    }
+    goto fail_type;
 
 val_end:
-	val++;
-	ctn_len--;
-	if (unlikely(ctn_len == 0))
-		goto ctn_end;
-	goto val_begin;
+    val++;
+    ctn_len--;
+    if (unlikely(ctn_len == 0)) goto ctn_end;
+    goto val_begin;
 
 ctn_end:
-	cur -= 2;
-	*cur++ = '\n';
-	incr_len(level * 4);
-	cur = write_indent(cur, --level, spaces);
-	*cur++ = (u8)(']' | ((u8)ctn_obj << 5));
-	if (unlikely((u8 *)ctx >= end))
-		goto doc_end;
-	yyjson_write_ctx_get(ctx++, &ctn_len, &ctn_obj);
-	ctn_len--;
-	*cur++ = ',';
-	*cur++ = '\n';
-	if (likely(ctn_len > 0)) {
-		goto val_begin;
-	} else {
-		goto ctn_end;
-	}
+    cur -= 2;
+    *cur++ = '\n';
+    incr_len(level * 4);
+    cur = write_indent(cur, --level, spaces);
+    *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+    if (unlikely((u8 *)ctx >= end)) goto doc_end;
+    yyjson_write_ctx_get(ctx++, &ctn_len, &ctn_obj);
+    ctn_len--;
+    *cur++ = ',';
+    *cur++ = '\n';
+    if (likely(ctn_len > 0)) {
+        goto val_begin;
+    } else {
+        goto ctn_end;
+    }
 
 doc_end:
-	*cur = '\0';
-	*dat_len = (usize)(cur - hdr);
-	memset(err, 0, sizeof(yyjson_write_err));
-	return hdr;
+    if (newline) {
+        incr_len(2);
+        *cur++ = '\n';
+    }
+    *cur = '\0';
+    *dat_len = (usize)(cur - hdr);
+    memset(err, 0, sizeof(yyjson_write_err));
+    return hdr;
 
 fail_alloc:
-	return_err(MEMORY_ALLOCATION, "memory allocation failed");
+    return_err(MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-	return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-	return_err(NAN_OR_INF, "nan or inf number is not allowed");
+    return_err(NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-	return_err(INVALID_STRING, "invalid utf-8 encoding in string");
+    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
 
 #undef return_err
 #undef incr_len
 #undef check_str_len
 }
 
-char *yyjson_val_write_opts(const yyjson_val *val, yyjson_write_flag flg, const yyjson_alc *alc_ptr, usize *dat_len,
+char *yyjson_val_write_opts(const yyjson_val *val,
+                            yyjson_write_flag flg,
+                            const yyjson_alc *alc_ptr,
+                            usize *dat_len,
                             yyjson_write_err *err) {
-	yyjson_write_err dummy_err;
-	usize dummy_dat_len;
-	yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
-	yyjson_val *root = (yyjson_val *)val;
+    yyjson_write_err dummy_err;
+    usize dummy_dat_len;
+    yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
+    yyjson_val *root = constcast(yyjson_val *)val;
 
-	err = err ? err : &dummy_err;
-	dat_len = dat_len ? dat_len : &dummy_dat_len;
+    err = err ? err : &dummy_err;
+    dat_len = dat_len ? dat_len : &dummy_dat_len;
 
-#if YYJSON_DISABLE_NON_STANDARD
-	flg &= ~YYJSON_WRITE_ALLOW_INF_AND_NAN;
-	flg &= ~YYJSON_WRITE_ALLOW_INVALID_UNICODE;
-#endif
+    if (unlikely(!root)) {
+        *dat_len = 0;
+        err->msg = "input JSON is NULL";
+        err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
+        return NULL;
+    }
 
-	if (unlikely(!root)) {
-		*dat_len = 0;
-		err->msg = "input JSON is NULL";
-		err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
-		return NULL;
-	}
-
-	if (!unsafe_yyjson_is_ctn(root) || unsafe_yyjson_get_len(root) == 0) {
-		return (char *)yyjson_write_single(root, flg, alc, dat_len, err);
-	} else if (flg & (YYJSON_WRITE_PRETTY | YYJSON_WRITE_PRETTY_TWO_SPACES)) {
-		return (char *)yyjson_write_pretty(root, flg, alc, dat_len, err);
-	} else {
-		return (char *)yyjson_write_minify(root, flg, alc, dat_len, err);
-	}
+    if (!unsafe_yyjson_is_ctn(root) || unsafe_yyjson_get_len(root) == 0) {
+        return (char *)yyjson_write_single(root, flg, alc, dat_len, err);
+    } else if (flg & (YYJSON_WRITE_PRETTY | YYJSON_WRITE_PRETTY_TWO_SPACES)) {
+        return (char *)yyjson_write_pretty(root, flg, alc, dat_len, err);
+    } else {
+        return (char *)yyjson_write_minify(root, flg, alc, dat_len, err);
+    }
 }
 
-char *yyjson_write_opts(const yyjson_doc *doc, yyjson_write_flag flg, const yyjson_alc *alc_ptr, usize *dat_len,
+char *yyjson_write_opts(const yyjson_doc *doc,
+                        yyjson_write_flag flg,
+                        const yyjson_alc *alc_ptr,
+                        usize *dat_len,
                         yyjson_write_err *err) {
-	yyjson_val *root = doc ? doc->root : NULL;
-	return yyjson_val_write_opts(root, flg, alc_ptr, dat_len, err);
+    yyjson_val *root = doc ? doc->root : NULL;
+    return yyjson_val_write_opts(root, flg, alc_ptr, dat_len, err);
 }
 
-bool yyjson_val_write_file(const char *path, const yyjson_val *val, yyjson_write_flag flg, const yyjson_alc *alc_ptr,
+bool yyjson_val_write_file(const char *path,
+                           const yyjson_val *val,
+                           yyjson_write_flag flg,
+                           const yyjson_alc *alc_ptr,
                            yyjson_write_err *err) {
-	yyjson_write_err dummy_err;
-	u8 *dat;
-	usize dat_len = 0;
-	yyjson_val *root = (yyjson_val *)val;
-	bool suc;
+    yyjson_write_err dummy_err;
+    u8 *dat;
+    usize dat_len = 0;
+    yyjson_val *root = constcast(yyjson_val *)val;
+    bool suc;
 
-	alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
-	err = err ? err : &dummy_err;
-	if (unlikely(!path || !*path)) {
-		err->msg = "input path is invalid";
-		err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
-		return false;
-	}
+    alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
+    err = err ? err : &dummy_err;
+    if (unlikely(!path || !*path)) {
+        err->msg = "input path is invalid";
+        err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
+        return false;
+    }
 
-	dat = (u8 *)yyjson_val_write_opts(root, flg, alc_ptr, &dat_len, err);
-	if (unlikely(!dat))
-		return false;
-	suc = write_dat_to_file(path, dat, dat_len, err);
-	alc_ptr->free(alc_ptr->ctx, dat);
-	return suc;
+    dat = (u8 *)yyjson_val_write_opts(root, flg, alc_ptr, &dat_len, err);
+    if (unlikely(!dat)) return false;
+    suc = write_dat_to_file(path, dat, dat_len, err);
+    alc_ptr->free(alc_ptr->ctx, dat);
+    return suc;
 }
 
-bool yyjson_write_file(const char *path, const yyjson_doc *doc, yyjson_write_flag flg, const yyjson_alc *alc_ptr,
+bool yyjson_val_write_fp(FILE *fp,
+                         const yyjson_val *val,
+                         yyjson_write_flag flg,
+                         const yyjson_alc *alc_ptr,
+                         yyjson_write_err *err) {
+    yyjson_write_err dummy_err;
+    u8 *dat;
+    usize dat_len = 0;
+    yyjson_val *root = constcast(yyjson_val *)val;
+    bool suc;
+
+    alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
+    err = err ? err : &dummy_err;
+    if (unlikely(!fp)) {
+        err->msg = "input fp is invalid";
+        err->code = YYJSON_READ_ERROR_INVALID_PARAMETER;
+        return false;
+    }
+
+    dat = (u8 *)yyjson_val_write_opts(root, flg, alc_ptr, &dat_len, err);
+    if (unlikely(!dat)) return false;
+    suc = write_dat_to_fp(fp, dat, dat_len, err);
+    alc_ptr->free(alc_ptr->ctx, dat);
+    return suc;
+}
+
+bool yyjson_write_file(const char *path,
+                       const yyjson_doc *doc,
+                       yyjson_write_flag flg,
+                       const yyjson_alc *alc_ptr,
                        yyjson_write_err *err) {
-	yyjson_val *root = doc ? doc->root : NULL;
-	return yyjson_val_write_file(path, root, flg, alc_ptr, err);
+    yyjson_val *root = doc ? doc->root : NULL;
+    return yyjson_val_write_file(path, root, flg, alc_ptr, err);
 }
+
+bool yyjson_write_fp(FILE *fp,
+                    const yyjson_doc *doc,
+                    yyjson_write_flag flg,
+                     const yyjson_alc *alc_ptr,
+                    yyjson_write_err *err) {
+    yyjson_val *root = doc ? doc->root : NULL;
+    return yyjson_val_write_fp(fp, root, flg, alc_ptr, err);
+}
+
+
 
 /*==============================================================================
  * Mutable JSON Writer Implementation
  *============================================================================*/
 
 typedef struct yyjson_mut_write_ctx {
-	usize tag;
-	yyjson_mut_val *ctn;
+    usize tag;
+    yyjson_mut_val *ctn;
 } yyjson_mut_write_ctx;
 
-static_inline void yyjson_mut_write_ctx_set(yyjson_mut_write_ctx *ctx, yyjson_mut_val *ctn, usize size, bool is_obj) {
-	ctx->tag = (size << 1) | (usize)is_obj;
-	ctx->ctn = ctn;
+static_inline void yyjson_mut_write_ctx_set(yyjson_mut_write_ctx *ctx,
+                                            yyjson_mut_val *ctn,
+                                            usize size, bool is_obj) {
+    ctx->tag = (size << 1) | (usize)is_obj;
+    ctx->ctn = ctn;
 }
 
-static_inline void yyjson_mut_write_ctx_get(yyjson_mut_write_ctx *ctx, yyjson_mut_val **ctn, usize *size,
-                                            bool *is_obj) {
-	usize tag = ctx->tag;
-	*size = tag >> 1;
-	*is_obj = (bool)(tag & 1);
-	*ctn = ctx->ctn;
+static_inline void yyjson_mut_write_ctx_get(yyjson_mut_write_ctx *ctx,
+                                            yyjson_mut_val **ctn,
+                                            usize *size, bool *is_obj) {
+    usize tag = ctx->tag;
+    *size = tag >> 1;
+    *is_obj = (bool)(tag & 1);
+    *ctn = ctx->ctn;
+}
+
+/** Get the estimated number of values for the mutable JSON document. */
+static_inline usize yyjson_mut_doc_estimated_val_num(
+    const yyjson_mut_doc *doc) {
+    usize sum = 0;
+    yyjson_val_chunk *chunk = doc->val_pool.chunks;
+    while (chunk) {
+        sum += chunk->chunk_size / sizeof(yyjson_mut_val) - 1;
+        if (chunk == doc->val_pool.chunks) {
+            sum -= (usize)(doc->val_pool.end - doc->val_pool.cur);
+        }
+        chunk = chunk->next;
+    }
+    return sum;
 }
 
 /** Write single JSON value. */
-static_inline u8 *yyjson_mut_write_single(yyjson_mut_val *val, yyjson_write_flag flg, yyjson_alc alc, usize *dat_len,
+static_inline u8 *yyjson_mut_write_single(yyjson_mut_val *val,
+                                          yyjson_write_flag flg,
+                                          yyjson_alc alc,
+                                          usize *dat_len,
                                           yyjson_write_err *err) {
-	return yyjson_write_single((yyjson_val *)val, flg, alc, dat_len, err);
+    return yyjson_write_single((yyjson_val *)val, flg, alc, dat_len, err);
 }
 
 /** Write JSON document minify.
     The root of this document should be a non-empty container. */
-static_inline u8 *yyjson_mut_write_minify(const yyjson_mut_val *root, yyjson_write_flag flg, yyjson_alc alc,
-                                          usize *dat_len, yyjson_write_err *err) {
+static_inline u8 *yyjson_mut_write_minify(const yyjson_mut_val *root,
+                                          usize estimated_val_num,
+                                          yyjson_write_flag flg,
+                                          yyjson_alc alc,
+                                          usize *dat_len,
+                                          yyjson_write_err *err) {
 
-#define return_err(_code, _msg)                                                                                        \
-	do {                                                                                                               \
-		*dat_len = 0;                                                                                                  \
-		err->code = YYJSON_WRITE_ERROR_##_code;                                                                        \
-		err->msg = _msg;                                                                                               \
-		if (hdr)                                                                                                       \
-			alc.free(alc.ctx, hdr);                                                                                    \
-		return NULL;                                                                                                   \
-	} while (false)
+#define return_err(_code, _msg) do { \
+    *dat_len = 0; \
+    err->code = YYJSON_WRITE_ERROR_##_code; \
+    err->msg = _msg; \
+    if (hdr) alc.free(alc.ctx, hdr); \
+    return NULL; \
+} while (false)
 
-#define incr_len(_len)                                                                                                 \
-	do {                                                                                                               \
-		ext_len = (usize)(_len);                                                                                       \
-		if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) {                                                            \
-			alc_inc = yyjson_max(alc_len / 2, ext_len);                                                                \
-			alc_inc = size_align_up(alc_inc, sizeof(yyjson_mut_write_ctx));                                            \
-			if (size_add_is_overflow(alc_len, alc_inc))                                                                \
-				goto fail_alloc;                                                                                       \
-			alc_len += alc_inc;                                                                                        \
-			tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len);                                         \
-			if (unlikely(!tmp))                                                                                        \
-				goto fail_alloc;                                                                                       \
-			ctx_len = (usize)(end - (u8 *)ctx);                                                                        \
-			ctx_tmp = (yyjson_mut_write_ctx *)(void *)(tmp + (alc_len - ctx_len));                                     \
-			memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len);                                      \
-			ctx = ctx_tmp;                                                                                             \
-			cur = tmp + (cur - hdr);                                                                                   \
-			end = tmp + alc_len;                                                                                       \
-			hdr = tmp;                                                                                                 \
-		}                                                                                                              \
-	} while (false)
+#define incr_len(_len) do { \
+    ext_len = (usize)(_len); \
+    if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) { \
+        alc_inc = yyjson_max(alc_len / 2, ext_len); \
+        alc_inc = size_align_up(alc_inc, sizeof(yyjson_mut_write_ctx)); \
+        if ((sizeof(usize) < 8) && size_add_is_overflow(alc_len, alc_inc)) \
+            goto fail_alloc; \
+        alc_len += alc_inc; \
+        tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len); \
+        if (unlikely(!tmp)) goto fail_alloc; \
+        ctx_len = (usize)(end - (u8 *)ctx); \
+        ctx_tmp = (yyjson_mut_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
+        memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
+        ctx = ctx_tmp; \
+        cur = tmp + (cur - hdr); \
+        end = tmp + alc_len; \
+        hdr = tmp; \
+    } \
+} while (false)
 
-#define check_str_len(_len)                                                                                            \
-	do {                                                                                                               \
-		if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6))                                                   \
-			goto fail_alloc;                                                                                           \
-	} while (false)
+#define check_str_len(_len) do { \
+    if ((sizeof(usize) < 8) && (_len >= (USIZE_MAX - 16) / 6)) \
+        goto fail_alloc; \
+} while (false)
 
-	yyjson_mut_val *val, *ctn;
-	yyjson_type val_type;
-	usize ctn_len, ctn_len_tmp;
-	bool ctn_obj, ctn_obj_tmp, is_key;
-	u8 *hdr, *cur, *end, *tmp;
-	yyjson_mut_write_ctx *ctx, *ctx_tmp;
-	usize alc_len, alc_inc, ctx_len, ext_len, str_len;
-	const u8 *str_ptr;
-	const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-	bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-	bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
+    yyjson_mut_val *val, *ctn;
+    yyjson_type val_type;
+    usize ctn_len, ctn_len_tmp;
+    bool ctn_obj, ctn_obj_tmp, is_key;
+    u8 *hdr, *cur, *end, *tmp;
+    yyjson_mut_write_ctx *ctx, *ctx_tmp;
+    usize alc_len, alc_inc, ctx_len, ext_len, str_len;
+    const u8 *str_ptr;
+    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
+    bool cpy = (enc_table == enc_table_cpy);
+    bool esc = has_write_flag(ESCAPE_UNICODE) != 0;
+    bool inv = has_write_flag(ALLOW_INVALID_UNICODE) != 0;
+    bool newline = has_write_flag(NEWLINE_AT_END) != 0;
 
-	alc_len = 0 * YYJSON_WRITER_ESTIMATED_MINIFY_RATIO + 64;
-	alc_len = size_align_up(alc_len, sizeof(yyjson_mut_write_ctx));
-	hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
-	if (!hdr)
-		goto fail_alloc;
-	cur = hdr;
-	end = hdr + alc_len;
-	ctx = (yyjson_mut_write_ctx *)(void *)end;
+    alc_len = estimated_val_num * YYJSON_WRITER_ESTIMATED_MINIFY_RATIO + 64;
+    alc_len = size_align_up(alc_len, sizeof(yyjson_mut_write_ctx));
+    hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
+    if (!hdr) goto fail_alloc;
+    cur = hdr;
+    end = hdr + alc_len;
+    ctx = (yyjson_mut_write_ctx *)(void *)end;
 
 doc_begin:
-	val = (yyjson_mut_val *)root;
-	val_type = unsafe_yyjson_get_type(val);
-	ctn_obj = (val_type == YYJSON_TYPE_OBJ);
-	ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
-	*cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-	ctn = val;
-	val = (yyjson_mut_val *)val->uni.ptr; /* tail */
-	val = ctn_obj ? val->next->next : val->next;
+    val = constcast(yyjson_mut_val *)root;
+    val_type = unsafe_yyjson_get_type(val);
+    ctn_obj = (val_type == YYJSON_TYPE_OBJ);
+    ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
+    *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+    ctn = val;
+    val = (yyjson_mut_val *)val->uni.ptr; /* tail */
+    val = ctn_obj ? val->next->next : val->next;
 
 val_begin:
-	val_type = unsafe_yyjson_get_type(val);
-	if (val_type == YYJSON_TYPE_STR) {
-		is_key = ((u8)ctn_obj & (u8)~ctn_len);
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len * 6 + 16);
-		cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-		if (unlikely(!cur))
-			goto fail_str;
-		*cur++ = is_key ? ':' : ',';
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_NUM) {
-		incr_len(32);
-		cur = write_number(cur, (yyjson_val *)val, flg);
-		if (unlikely(!cur))
-			goto fail_num;
-		*cur++ = ',';
-		goto val_end;
-	}
-	if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) == (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
-		ctn_len_tmp = unsafe_yyjson_get_len(val);
-		ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
-		incr_len(16);
-		if (unlikely(ctn_len_tmp == 0)) {
-			/* write empty container */
-			*cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
-			*cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
-			*cur++ = ',';
-			goto val_end;
-		} else {
-			/* push context, setup new container */
-			yyjson_mut_write_ctx_set(--ctx, ctn, ctn_len, ctn_obj);
-			ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
-			ctn_obj = ctn_obj_tmp;
-			*cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-			ctn = val;
-			val = (yyjson_mut_val *)ctn->uni.ptr; /* tail */
-			val = ctn_obj ? val->next->next : val->next;
-			goto val_begin;
-		}
-	}
-	if (val_type == YYJSON_TYPE_BOOL) {
-		incr_len(16);
-		cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-		cur++;
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_NULL) {
-		incr_len(16);
-		cur = write_null(cur);
-		cur++;
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_RAW) {
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len + 2);
-		cur = write_raw(cur, str_ptr, str_len);
-		*cur++ = ',';
-		goto val_end;
-	}
-	goto fail_type;
+    val_type = unsafe_yyjson_get_type(val);
+    if (val_type == YYJSON_TYPE_STR) {
+        is_key = ((u8)ctn_obj & (u8)~ctn_len);
+        str_len = unsafe_yyjson_get_len(val);
+        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+        check_str_len(str_len);
+        incr_len(str_len * 6 + 16);
+        if (likely(cpy) && unsafe_yyjson_get_subtype(val)) {
+            cur = write_string_noesc(cur, str_ptr, str_len);
+        } else {
+            cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
+            if (unlikely(!cur)) goto fail_str;
+        }
+        *cur++ = is_key ? ':' : ',';
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_NUM) {
+        incr_len(32);
+        cur = write_number(cur, (yyjson_val *)val, flg);
+        if (unlikely(!cur)) goto fail_num;
+        *cur++ = ',';
+        goto val_end;
+    }
+    if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
+                    (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
+        ctn_len_tmp = unsafe_yyjson_get_len(val);
+        ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
+        incr_len(16);
+        if (unlikely(ctn_len_tmp == 0)) {
+            /* write empty container */
+            *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
+            *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
+            *cur++ = ',';
+            goto val_end;
+        } else {
+            /* push context, setup new container */
+            yyjson_mut_write_ctx_set(--ctx, ctn, ctn_len, ctn_obj);
+            ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
+            ctn_obj = ctn_obj_tmp;
+            *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+            ctn = val;
+            val = (yyjson_mut_val *)ctn->uni.ptr; /* tail */
+            val = ctn_obj ? val->next->next : val->next;
+            goto val_begin;
+        }
+    }
+    if (val_type == YYJSON_TYPE_BOOL) {
+        incr_len(16);
+        cur = write_bool(cur, unsafe_yyjson_get_bool(val));
+        cur++;
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_NULL) {
+        incr_len(16);
+        cur = write_null(cur);
+        cur++;
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_RAW) {
+        str_len = unsafe_yyjson_get_len(val);
+        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+        check_str_len(str_len);
+        incr_len(str_len + 2);
+        cur = write_raw(cur, str_ptr, str_len);
+        *cur++ = ',';
+        goto val_end;
+    }
+    goto fail_type;
 
 val_end:
-	ctn_len--;
-	if (unlikely(ctn_len == 0))
-		goto ctn_end;
-	val = val->next;
-	goto val_begin;
+    ctn_len--;
+    if (unlikely(ctn_len == 0)) goto ctn_end;
+    val = val->next;
+    goto val_begin;
 
 ctn_end:
-	cur--;
-	*cur++ = (u8)(']' | ((u8)ctn_obj << 5));
-	*cur++ = ',';
-	if (unlikely((u8 *)ctx >= end))
-		goto doc_end;
-	val = ctn->next;
-	yyjson_mut_write_ctx_get(ctx++, &ctn, &ctn_len, &ctn_obj);
-	ctn_len--;
-	if (likely(ctn_len > 0)) {
-		goto val_begin;
-	} else {
-		goto ctn_end;
-	}
+    cur--;
+    *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+    *cur++ = ',';
+    if (unlikely((u8 *)ctx >= end)) goto doc_end;
+    val = ctn->next;
+    yyjson_mut_write_ctx_get(ctx++, &ctn, &ctn_len, &ctn_obj);
+    ctn_len--;
+    if (likely(ctn_len > 0)) {
+        goto val_begin;
+    } else {
+        goto ctn_end;
+    }
 
 doc_end:
-	*--cur = '\0';
-	*dat_len = (usize)(cur - hdr);
-	err->code = YYJSON_WRITE_SUCCESS;
-	err->msg = "success";
-	return hdr;
+    if (newline) {
+        incr_len(2);
+        *(cur - 1) = '\n';
+        cur++;
+    }
+    *--cur = '\0';
+    *dat_len = (usize)(cur - hdr);
+    err->code = YYJSON_WRITE_SUCCESS;
+    err->msg = "success";
+    return hdr;
 
 fail_alloc:
-	return_err(MEMORY_ALLOCATION, "memory allocation failed");
+    return_err(MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-	return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-	return_err(NAN_OR_INF, "nan or inf number is not allowed");
+    return_err(NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-	return_err(INVALID_STRING, "invalid utf-8 encoding in string");
+    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
 
 #undef return_err
 #undef incr_len
@@ -7811,292 +9130,344 @@ fail_str:
 
 /** Write JSON document pretty.
     The root of this document should be a non-empty container. */
-static_inline u8 *yyjson_mut_write_pretty(const yyjson_mut_val *root, yyjson_write_flag flg, yyjson_alc alc,
-                                          usize *dat_len, yyjson_write_err *err) {
+static_inline u8 *yyjson_mut_write_pretty(const yyjson_mut_val *root,
+                                          usize estimated_val_num,
+                                          yyjson_write_flag flg,
+                                          yyjson_alc alc,
+                                          usize *dat_len,
+                                          yyjson_write_err *err) {
 
-#define return_err(_code, _msg)                                                                                        \
-	do {                                                                                                               \
-		*dat_len = 0;                                                                                                  \
-		err->code = YYJSON_WRITE_ERROR_##_code;                                                                        \
-		err->msg = _msg;                                                                                               \
-		if (hdr)                                                                                                       \
-			alc.free(alc.ctx, hdr);                                                                                    \
-		return NULL;                                                                                                   \
-	} while (false)
+#define return_err(_code, _msg) do { \
+    *dat_len = 0; \
+    err->code = YYJSON_WRITE_ERROR_##_code; \
+    err->msg = _msg; \
+    if (hdr) alc.free(alc.ctx, hdr); \
+    return NULL; \
+} while (false)
 
-#define incr_len(_len)                                                                                                 \
-	do {                                                                                                               \
-		ext_len = (usize)(_len);                                                                                       \
-		if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) {                                                            \
-			alc_inc = yyjson_max(alc_len / 2, ext_len);                                                                \
-			alc_inc = size_align_up(alc_inc, sizeof(yyjson_mut_write_ctx));                                            \
-			if (size_add_is_overflow(alc_len, alc_inc))                                                                \
-				goto fail_alloc;                                                                                       \
-			alc_len += alc_inc;                                                                                        \
-			tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len);                                         \
-			if (unlikely(!tmp))                                                                                        \
-				goto fail_alloc;                                                                                       \
-			ctx_len = (usize)(end - (u8 *)ctx);                                                                        \
-			ctx_tmp = (yyjson_mut_write_ctx *)(void *)(tmp + (alc_len - ctx_len));                                     \
-			memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len);                                      \
-			ctx = ctx_tmp;                                                                                             \
-			cur = tmp + (cur - hdr);                                                                                   \
-			end = tmp + alc_len;                                                                                       \
-			hdr = tmp;                                                                                                 \
-		}                                                                                                              \
-	} while (false)
+#define incr_len(_len) do { \
+    ext_len = (usize)(_len); \
+    if (unlikely((u8 *)(cur + ext_len) >= (u8 *)ctx)) { \
+        alc_inc = yyjson_max(alc_len / 2, ext_len); \
+        alc_inc = size_align_up(alc_inc, sizeof(yyjson_mut_write_ctx)); \
+        if ((sizeof(usize) < 8) && size_add_is_overflow(alc_len, alc_inc)) \
+            goto fail_alloc; \
+        alc_len += alc_inc; \
+        tmp = (u8 *)alc.realloc(alc.ctx, hdr, alc_len - alc_inc, alc_len); \
+        if (unlikely(!tmp)) goto fail_alloc; \
+        ctx_len = (usize)(end - (u8 *)ctx); \
+        ctx_tmp = (yyjson_mut_write_ctx *)(void *)(tmp + (alc_len - ctx_len)); \
+        memmove((void *)ctx_tmp, (void *)(tmp + ((u8 *)ctx - hdr)), ctx_len); \
+        ctx = ctx_tmp; \
+        cur = tmp + (cur - hdr); \
+        end = tmp + alc_len; \
+        hdr = tmp; \
+    } \
+} while (false)
 
-#define check_str_len(_len)                                                                                            \
-	do {                                                                                                               \
-		if ((USIZE_MAX < U64_MAX) && (_len >= (USIZE_MAX - 16) / 6))                                                   \
-			goto fail_alloc;                                                                                           \
-	} while (false)
+#define check_str_len(_len) do { \
+    if ((sizeof(usize) < 8) && (_len >= (USIZE_MAX - 16) / 6)) \
+        goto fail_alloc; \
+} while (false)
 
-	yyjson_mut_val *val, *ctn;
-	yyjson_type val_type;
-	usize ctn_len, ctn_len_tmp;
-	bool ctn_obj, ctn_obj_tmp, is_key, no_indent;
-	u8 *hdr, *cur, *end, *tmp;
-	yyjson_mut_write_ctx *ctx, *ctx_tmp;
-	usize alc_len, alc_inc, ctx_len, ext_len, str_len, level;
-	const u8 *str_ptr;
-	const char_enc_type *enc_table = get_enc_table_with_flag(flg);
-	bool esc = (flg & YYJSON_WRITE_ESCAPE_UNICODE) != 0;
-	bool inv = (flg & YYJSON_WRITE_ALLOW_INVALID_UNICODE) != 0;
-	usize spaces = (flg & YYJSON_WRITE_PRETTY_TWO_SPACES) ? 2 : 4;
+    yyjson_mut_val *val, *ctn;
+    yyjson_type val_type;
+    usize ctn_len, ctn_len_tmp;
+    bool ctn_obj, ctn_obj_tmp, is_key, no_indent;
+    u8 *hdr, *cur, *end, *tmp;
+    yyjson_mut_write_ctx *ctx, *ctx_tmp;
+    usize alc_len, alc_inc, ctx_len, ext_len, str_len, level;
+    const u8 *str_ptr;
+    const char_enc_type *enc_table = get_enc_table_with_flag(flg);
+    bool cpy = (enc_table == enc_table_cpy);
+    bool esc = has_write_flag(ESCAPE_UNICODE) != 0;
+    bool inv = has_write_flag(ALLOW_INVALID_UNICODE) != 0;
+    usize spaces = has_write_flag(PRETTY_TWO_SPACES) ? 2 : 4;
+    bool newline = has_write_flag(NEWLINE_AT_END) != 0;
 
-	alc_len = 0 * YYJSON_WRITER_ESTIMATED_PRETTY_RATIO + 64;
-	alc_len = size_align_up(alc_len, sizeof(yyjson_mut_write_ctx));
-	hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
-	if (!hdr)
-		goto fail_alloc;
-	cur = hdr;
-	end = hdr + alc_len;
-	ctx = (yyjson_mut_write_ctx *)(void *)end;
+    alc_len = estimated_val_num * YYJSON_WRITER_ESTIMATED_PRETTY_RATIO + 64;
+    alc_len = size_align_up(alc_len, sizeof(yyjson_mut_write_ctx));
+    hdr = (u8 *)alc.malloc(alc.ctx, alc_len);
+    if (!hdr) goto fail_alloc;
+    cur = hdr;
+    end = hdr + alc_len;
+    ctx = (yyjson_mut_write_ctx *)(void *)end;
 
 doc_begin:
-	val = (yyjson_mut_val *)root;
-	val_type = unsafe_yyjson_get_type(val);
-	ctn_obj = (val_type == YYJSON_TYPE_OBJ);
-	ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
-	*cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-	*cur++ = '\n';
-	ctn = val;
-	val = (yyjson_mut_val *)val->uni.ptr; /* tail */
-	val = ctn_obj ? val->next->next : val->next;
-	level = 1;
+    val = constcast(yyjson_mut_val *)root;
+    val_type = unsafe_yyjson_get_type(val);
+    ctn_obj = (val_type == YYJSON_TYPE_OBJ);
+    ctn_len = unsafe_yyjson_get_len(val) << (u8)ctn_obj;
+    *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+    *cur++ = '\n';
+    ctn = val;
+    val = (yyjson_mut_val *)val->uni.ptr; /* tail */
+    val = ctn_obj ? val->next->next : val->next;
+    level = 1;
 
 val_begin:
-	val_type = unsafe_yyjson_get_type(val);
-	if (val_type == YYJSON_TYPE_STR) {
-		is_key = (bool)((u8)ctn_obj & (u8)~ctn_len);
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len * 6 + 16 + (no_indent ? 0 : level * 4));
-		cur = write_indent(cur, no_indent ? 0 : level, spaces);
-		cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
-		if (unlikely(!cur))
-			goto fail_str;
-		*cur++ = is_key ? ':' : ',';
-		*cur++ = is_key ? ' ' : '\n';
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_NUM) {
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		incr_len(32 + (no_indent ? 0 : level * 4));
-		cur = write_indent(cur, no_indent ? 0 : level, spaces);
-		cur = write_number(cur, (yyjson_val *)val, flg);
-		if (unlikely(!cur))
-			goto fail_num;
-		*cur++ = ',';
-		*cur++ = '\n';
-		goto val_end;
-	}
-	if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) == (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		ctn_len_tmp = unsafe_yyjson_get_len(val);
-		ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
-		if (unlikely(ctn_len_tmp == 0)) {
-			/* write empty container */
-			incr_len(16 + (no_indent ? 0 : level * 4));
-			cur = write_indent(cur, no_indent ? 0 : level, spaces);
-			*cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
-			*cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
-			*cur++ = ',';
-			*cur++ = '\n';
-			goto val_end;
-		} else {
-			/* push context, setup new container */
-			incr_len(32 + (no_indent ? 0 : level * 4));
-			yyjson_mut_write_ctx_set(--ctx, ctn, ctn_len, ctn_obj);
-			ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
-			ctn_obj = ctn_obj_tmp;
-			cur = write_indent(cur, no_indent ? 0 : level, spaces);
-			level++;
-			*cur++ = (u8)('[' | ((u8)ctn_obj << 5));
-			*cur++ = '\n';
-			ctn = val;
-			val = (yyjson_mut_val *)ctn->uni.ptr; /* tail */
-			val = ctn_obj ? val->next->next : val->next;
-			goto val_begin;
-		}
-	}
-	if (val_type == YYJSON_TYPE_BOOL) {
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		incr_len(16 + (no_indent ? 0 : level * 4));
-		cur = write_indent(cur, no_indent ? 0 : level, spaces);
-		cur = write_bool(cur, unsafe_yyjson_get_bool(val));
-		cur += 2;
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_NULL) {
-		no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
-		incr_len(16 + (no_indent ? 0 : level * 4));
-		cur = write_indent(cur, no_indent ? 0 : level, spaces);
-		cur = write_null(cur);
-		cur += 2;
-		goto val_end;
-	}
-	if (val_type == YYJSON_TYPE_RAW) {
-		str_len = unsafe_yyjson_get_len(val);
-		str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
-		check_str_len(str_len);
-		incr_len(str_len + 3);
-		cur = write_raw(cur, str_ptr, str_len);
-		*cur++ = ',';
-		*cur++ = '\n';
-		goto val_end;
-	}
-	goto fail_type;
+    val_type = unsafe_yyjson_get_type(val);
+    if (val_type == YYJSON_TYPE_STR) {
+        is_key = (bool)((u8)ctn_obj & (u8)~ctn_len);
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        str_len = unsafe_yyjson_get_len(val);
+        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+        check_str_len(str_len);
+        incr_len(str_len * 6 + 16 + (no_indent ? 0 : level * 4));
+        cur = write_indent(cur, no_indent ? 0 : level, spaces);
+        if (likely(cpy) && unsafe_yyjson_get_subtype(val)) {
+            cur = write_string_noesc(cur, str_ptr, str_len);
+        } else {
+            cur = write_string(cur, esc, inv, str_ptr, str_len, enc_table);
+            if (unlikely(!cur)) goto fail_str;
+        }
+        *cur++ = is_key ? ':' : ',';
+        *cur++ = is_key ? ' ' : '\n';
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_NUM) {
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        incr_len(32 + (no_indent ? 0 : level * 4));
+        cur = write_indent(cur, no_indent ? 0 : level, spaces);
+        cur = write_number(cur, (yyjson_val *)val, flg);
+        if (unlikely(!cur)) goto fail_num;
+        *cur++ = ',';
+        *cur++ = '\n';
+        goto val_end;
+    }
+    if ((val_type & (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) ==
+                    (YYJSON_TYPE_ARR & YYJSON_TYPE_OBJ)) {
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        ctn_len_tmp = unsafe_yyjson_get_len(val);
+        ctn_obj_tmp = (val_type == YYJSON_TYPE_OBJ);
+        if (unlikely(ctn_len_tmp == 0)) {
+            /* write empty container */
+            incr_len(16 + (no_indent ? 0 : level * 4));
+            cur = write_indent(cur, no_indent ? 0 : level, spaces);
+            *cur++ = (u8)('[' | ((u8)ctn_obj_tmp << 5));
+            *cur++ = (u8)(']' | ((u8)ctn_obj_tmp << 5));
+            *cur++ = ',';
+            *cur++ = '\n';
+            goto val_end;
+        } else {
+            /* push context, setup new container */
+            incr_len(32 + (no_indent ? 0 : level * 4));
+            yyjson_mut_write_ctx_set(--ctx, ctn, ctn_len, ctn_obj);
+            ctn_len = ctn_len_tmp << (u8)ctn_obj_tmp;
+            ctn_obj = ctn_obj_tmp;
+            cur = write_indent(cur, no_indent ? 0 : level, spaces);
+            level++;
+            *cur++ = (u8)('[' | ((u8)ctn_obj << 5));
+            *cur++ = '\n';
+            ctn = val;
+            val = (yyjson_mut_val *)ctn->uni.ptr; /* tail */
+            val = ctn_obj ? val->next->next : val->next;
+            goto val_begin;
+        }
+    }
+    if (val_type == YYJSON_TYPE_BOOL) {
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        incr_len(16 + (no_indent ? 0 : level * 4));
+        cur = write_indent(cur, no_indent ? 0 : level, spaces);
+        cur = write_bool(cur, unsafe_yyjson_get_bool(val));
+        cur += 2;
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_NULL) {
+        no_indent = (bool)((u8)ctn_obj & (u8)ctn_len);
+        incr_len(16 + (no_indent ? 0 : level * 4));
+        cur = write_indent(cur, no_indent ? 0 : level, spaces);
+        cur = write_null(cur);
+        cur += 2;
+        goto val_end;
+    }
+    if (val_type == YYJSON_TYPE_RAW) {
+        str_len = unsafe_yyjson_get_len(val);
+        str_ptr = (const u8 *)unsafe_yyjson_get_str(val);
+        check_str_len(str_len);
+        incr_len(str_len + 3);
+        cur = write_raw(cur, str_ptr, str_len);
+        *cur++ = ',';
+        *cur++ = '\n';
+        goto val_end;
+    }
+    goto fail_type;
 
 val_end:
-	ctn_len--;
-	if (unlikely(ctn_len == 0))
-		goto ctn_end;
-	val = val->next;
-	goto val_begin;
+    ctn_len--;
+    if (unlikely(ctn_len == 0)) goto ctn_end;
+    val = val->next;
+    goto val_begin;
 
 ctn_end:
-	cur -= 2;
-	*cur++ = '\n';
-	incr_len(level * 4);
-	cur = write_indent(cur, --level, spaces);
-	*cur++ = (u8)(']' | ((u8)ctn_obj << 5));
-	if (unlikely((u8 *)ctx >= end))
-		goto doc_end;
-	val = ctn->next;
-	yyjson_mut_write_ctx_get(ctx++, &ctn, &ctn_len, &ctn_obj);
-	ctn_len--;
-	*cur++ = ',';
-	*cur++ = '\n';
-	if (likely(ctn_len > 0)) {
-		goto val_begin;
-	} else {
-		goto ctn_end;
-	}
+    cur -= 2;
+    *cur++ = '\n';
+    incr_len(level * 4);
+    cur = write_indent(cur, --level, spaces);
+    *cur++ = (u8)(']' | ((u8)ctn_obj << 5));
+    if (unlikely((u8 *)ctx >= end)) goto doc_end;
+    val = ctn->next;
+    yyjson_mut_write_ctx_get(ctx++, &ctn, &ctn_len, &ctn_obj);
+    ctn_len--;
+    *cur++ = ',';
+    *cur++ = '\n';
+    if (likely(ctn_len > 0)) {
+        goto val_begin;
+    } else {
+        goto ctn_end;
+    }
 
 doc_end:
-	*cur = '\0';
-	*dat_len = (usize)(cur - hdr);
-	err->code = YYJSON_WRITE_SUCCESS;
-	err->msg = "success";
-	return hdr;
+    if (newline) {
+        incr_len(2);
+        *cur++ = '\n';
+    }
+    *cur = '\0';
+    *dat_len = (usize)(cur - hdr);
+    err->code = YYJSON_WRITE_SUCCESS;
+    err->msg = "success";
+    return hdr;
 
 fail_alloc:
-	return_err(MEMORY_ALLOCATION, "memory allocation failed");
+    return_err(MEMORY_ALLOCATION, "memory allocation failed");
 fail_type:
-	return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
+    return_err(INVALID_VALUE_TYPE, "invalid JSON value type");
 fail_num:
-	return_err(NAN_OR_INF, "nan or inf number is not allowed");
+    return_err(NAN_OR_INF, "nan or inf number is not allowed");
 fail_str:
-	return_err(INVALID_STRING, "invalid utf-8 encoding in string");
+    return_err(INVALID_STRING, "invalid utf-8 encoding in string");
 
 #undef return_err
 #undef incr_len
 #undef check_str_len
 }
 
-char *yyjson_mut_val_write_opts(const yyjson_mut_val *val, yyjson_write_flag flg, const yyjson_alc *alc_ptr,
-                                usize *dat_len, yyjson_write_err *err) {
-	yyjson_write_err dummy_err;
-	usize dummy_dat_len;
-	yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
-	yyjson_mut_val *root = (yyjson_mut_val *)val;
+static char *yyjson_mut_write_opts_impl(const yyjson_mut_val *val,
+                                        usize estimated_val_num,
+                                        yyjson_write_flag flg,
+                                        const yyjson_alc *alc_ptr,
+                                        usize *dat_len,
+                                        yyjson_write_err *err) {
+    yyjson_write_err dummy_err;
+    usize dummy_dat_len;
+    yyjson_alc alc = alc_ptr ? *alc_ptr : YYJSON_DEFAULT_ALC;
+    yyjson_mut_val *root = constcast(yyjson_mut_val *)val;
 
-	err = err ? err : &dummy_err;
-	dat_len = dat_len ? dat_len : &dummy_dat_len;
+    err = err ? err : &dummy_err;
+    dat_len = dat_len ? dat_len : &dummy_dat_len;
 
-#if YYJSON_DISABLE_NON_STANDARD
-	flg &= ~YYJSON_WRITE_ALLOW_INF_AND_NAN;
-	flg &= ~YYJSON_WRITE_ALLOW_INVALID_UNICODE;
-#endif
+    if (unlikely(!root)) {
+        *dat_len = 0;
+        err->msg = "input JSON is NULL";
+        err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
+        return NULL;
+    }
 
-	if (unlikely(!root)) {
-		*dat_len = 0;
-		err->msg = "input JSON is NULL";
-		err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
-		return NULL;
-	}
-
-	if (!unsafe_yyjson_is_ctn(root) || unsafe_yyjson_get_len(root) == 0) {
-		return (char *)yyjson_mut_write_single(root, flg, alc, dat_len, err);
-	} else if (flg & (YYJSON_WRITE_PRETTY | YYJSON_WRITE_PRETTY_TWO_SPACES)) {
-		return (char *)yyjson_mut_write_pretty(root, flg, alc, dat_len, err);
-	} else {
-		return (char *)yyjson_mut_write_minify(root, flg, alc, dat_len, err);
-	}
+    if (!unsafe_yyjson_is_ctn(root) || unsafe_yyjson_get_len(root) == 0) {
+        return (char *)yyjson_mut_write_single(root, flg, alc, dat_len, err);
+    } else if (flg & (YYJSON_WRITE_PRETTY | YYJSON_WRITE_PRETTY_TWO_SPACES)) {
+        return (char *)yyjson_mut_write_pretty(root, estimated_val_num,
+                                               flg, alc, dat_len, err);
+    } else {
+        return (char *)yyjson_mut_write_minify(root, estimated_val_num,
+                                               flg, alc, dat_len, err);
+    }
 }
 
-char *yyjson_mut_write_opts(const yyjson_mut_doc *doc, yyjson_write_flag flg, const yyjson_alc *alc_ptr, usize *dat_len,
+char *yyjson_mut_val_write_opts(const yyjson_mut_val *val,
+                                yyjson_write_flag flg,
+                                const yyjson_alc *alc_ptr,
+                                usize *dat_len,
+                                yyjson_write_err *err) {
+    return yyjson_mut_write_opts_impl(val, 0, flg, alc_ptr, dat_len, err);
+}
+
+char *yyjson_mut_write_opts(const yyjson_mut_doc *doc,
+                            yyjson_write_flag flg,
+                            const yyjson_alc *alc_ptr,
+                            usize *dat_len,
                             yyjson_write_err *err) {
-	yyjson_mut_val *root = doc ? doc->root : NULL;
-	return yyjson_mut_val_write_opts(root, flg, alc_ptr, dat_len, err);
+    yyjson_mut_val *root;
+    usize estimated_val_num;
+    if (likely(doc)) {
+        root = doc->root;
+        estimated_val_num = yyjson_mut_doc_estimated_val_num(doc);
+    } else {
+        root = NULL;
+        estimated_val_num = 0;
+    }
+    return yyjson_mut_write_opts_impl(root, estimated_val_num,
+                                      flg, alc_ptr, dat_len, err);
 }
 
-bool yyjson_mut_val_write_file(const char *path, const yyjson_mut_val *val, yyjson_write_flag flg,
-                               const yyjson_alc *alc_ptr, yyjson_write_err *err) {
-	yyjson_write_err dummy_err;
-	u8 *dat;
-	usize dat_len = 0;
-	yyjson_mut_val *root = (yyjson_mut_val *)val;
-	bool suc;
+bool yyjson_mut_val_write_file(const char *path,
+                               const yyjson_mut_val *val,
+                               yyjson_write_flag flg,
+                               const yyjson_alc *alc_ptr,
+                               yyjson_write_err *err) {
+    yyjson_write_err dummy_err;
+    u8 *dat;
+    usize dat_len = 0;
+    yyjson_mut_val *root = constcast(yyjson_mut_val *)val;
+    bool suc;
 
-	alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
-	err = err ? err : &dummy_err;
-	if (unlikely(!path || !*path)) {
-		err->msg = "input path is invalid";
-		err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
-		return false;
-	}
+    alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
+    err = err ? err : &dummy_err;
+    if (unlikely(!path || !*path)) {
+        err->msg = "input path is invalid";
+        err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
+        return false;
+    }
 
-	dat = (u8 *)yyjson_mut_val_write_opts(root, flg, alc_ptr, &dat_len, err);
-	if (unlikely(!dat))
-		return false;
-	suc = write_dat_to_file(path, dat, dat_len, err);
-	alc_ptr->free(alc_ptr->ctx, dat);
-	return suc;
+    dat = (u8 *)yyjson_mut_val_write_opts(root, flg, alc_ptr, &dat_len, err);
+    if (unlikely(!dat)) return false;
+    suc = write_dat_to_file(path, dat, dat_len, err);
+    alc_ptr->free(alc_ptr->ctx, dat);
+    return suc;
 }
 
-bool yyjson_mut_write_file(const char *path, const yyjson_mut_doc *doc, yyjson_write_flag flg,
-                           const yyjson_alc *alc_ptr, yyjson_write_err *err) {
-	yyjson_mut_val *root = doc ? doc->root : NULL;
-	return yyjson_mut_val_write_file(path, root, flg, alc_ptr, err);
+bool yyjson_mut_val_write_fp(FILE *fp,
+                             const yyjson_mut_val *val,
+                             yyjson_write_flag flg,
+                             const yyjson_alc *alc_ptr,
+                             yyjson_write_err *err) {
+    yyjson_write_err dummy_err;
+    u8 *dat;
+    usize dat_len = 0;
+    yyjson_mut_val *root = constcast(yyjson_mut_val *)val;
+    bool suc;
+
+    alc_ptr = alc_ptr ? alc_ptr : &YYJSON_DEFAULT_ALC;
+    err = err ? err : &dummy_err;
+    if (unlikely(!fp)) {
+        err->msg = "input fp is invalid";
+        err->code = YYJSON_WRITE_ERROR_INVALID_PARAMETER;
+        return false;
+    }
+
+    dat = (u8 *)yyjson_mut_val_write_opts(root, flg, alc_ptr, &dat_len, err);
+    if (unlikely(!dat)) return false;
+    suc = write_dat_to_fp(fp, dat, dat_len, err);
+    alc_ptr->free(alc_ptr->ctx, dat);
+    return suc;
+}
+
+bool yyjson_mut_write_file(const char *path,
+                           const yyjson_mut_doc *doc,
+                           yyjson_write_flag flg,
+                           const yyjson_alc *alc_ptr,
+                           yyjson_write_err *err) {
+    yyjson_mut_val *root = doc ? doc->root : NULL;
+    return yyjson_mut_val_write_file(path, root, flg, alc_ptr, err);
+}
+
+bool yyjson_mut_write_fp(FILE *fp,
+                         const yyjson_mut_doc *doc,
+                         yyjson_write_flag flg,
+                         const yyjson_alc *alc_ptr,
+                         yyjson_write_err *err) {
+    yyjson_mut_val *root = doc ? doc->root : NULL;
+    return yyjson_mut_val_write_fp(fp, root, flg, alc_ptr, err);
 }
 
 #endif /* YYJSON_DISABLE_WRITER */
-
-/*==============================================================================
- * Compiler Hint End
- *============================================================================*/
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#pragma GCC diagnostic pop
-#endif
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif /* warning suppress end */

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,10 @@
 {
   "dependencies": [
     {
+      "name": "aws-sdk-cpp",
+      "features": ["glue"]
+    },
+    {
       "name": "avro-cpp",
       "features": ["snappy"]
     },


### PR DESCRIPTION
Add support for accessing tables stored at AWS Glue.

Example SQL call:

```sql
select * from iceberg_scan('{ "catalog_type": "glue", "region": "us-east-1", "database_name": "test_iceberg", "table_name": "users"}');
```

Added the framework for more additional external Iceberg catalog:

This JSON object should be of this format:

```json
{
  "catalog_type": "glue",
  "catalog": "1234567890",          // optional - the catalog to use
  "region": "us-east-1",            // required - change to the right region
  "database_name": "test_iceberg",  // required - change to your database
  "table_name": "table_name"        // required - change for each table.
}
```
