### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ based on pyspark 3.5, which you can install through pip.
 To build the extension with vcpkg, you can build this extension using:
 
 ```shell
-VCPKG_TOOLCHAIN_PATH='<path_to_your_vcpkg_toolchain_cmake_file>' make
+VCPKG_TOOLCHAIN_PATH='<path_to_your_vcpkg_repo>/scripts/buildsystems/vcpkg.cmake' make
 ```
 
 This will build both the separate loadable extension and a duckdb binary with the extension pre-loaded:


### PR DESCRIPTION
Improve the hint where the vcpkg toolchain path should be at in a default installation.